### PR TITLE
Change connection interface to event emitter

### DIFF
--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -1,7 +1,8 @@
 import logger from '../logger';
-import { Connection, InitConfig } from '../types';
+import { InitConfig } from '../types';
 import { encodeInvitationToUrl, decodeInvitationFromUrl } from '../helpers';
 import { IndyWallet } from '../wallet/IndyWallet';
+import { Connection } from '../protocols/connections/domain/Connection';
 import { ConnectionService } from '../protocols/connections/ConnectionService';
 import { MessageType as ConnectionsMessageType } from '../protocols/connections/messages';
 import { MessageType as BasicMessageMessageType } from '../protocols/basicmessage/messages';

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,4 @@
-import { InvitationDetails } from './types';
+import { InvitationDetails } from './protocols/connections/domain/InvitationDetails';
 
 export function decodeInvitationFromUrl(invitationUrl: string) {
   const [, encodedInvitation] = invitationUrl.split('c_i=');

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,3 +2,5 @@ export { Agent } from './agent/Agent';
 export { InboundTransporter } from './transport/InboundTransporter';
 export { OutboundTransporter } from './transport/OutboundTransporter';
 export { decodeInvitationFromUrl } from './helpers';
+
+export { Connection } from './protocols/connections/domain/Connection';

--- a/src/lib/protocols/basicmessage/BasicMessageService.ts
+++ b/src/lib/protocols/basicmessage/BasicMessageService.ts
@@ -1,6 +1,7 @@
-import { InboundMessage, Connection } from '../../types';
+import { InboundMessage } from '../../types';
 import { createOutboundMessage } from '../helpers';
 import { createAckMessage } from '../connections/messages';
+import { Connection } from '../connections/domain/Connection';
 import { createBasicMessage } from './messages';
 
 class BasicMessageService {

--- a/src/lib/protocols/connections/domain/Connection.ts
+++ b/src/lib/protocols/connections/domain/Connection.ts
@@ -1,0 +1,62 @@
+import EventEmitter from 'events';
+import { ConnectionState } from './ConnectionState';
+import { DidDoc } from './DidDoc';
+import { InvitationDetails } from './InvitationDetails';
+
+interface ConnectionProps {
+  did: Did;
+  didDoc: DidDoc;
+  verkey: Verkey;
+  theirDid?: Did;
+  theirKey?: Verkey;
+  theirDidDoc?: any;
+  invitation?: InvitationDetails;
+  state: ConnectionState;
+  endpoint?: string;
+  messages: any[];
+}
+
+export class Connection extends EventEmitter {
+  did: Did;
+  didDoc: DidDoc;
+  verkey: Verkey;
+  theirDid?: Did;
+  theirKey?: Verkey;
+  theirDidDoc?: any;
+  invitation?: InvitationDetails;
+  endpoint?: string;
+  messages: any[];
+
+  private state: ConnectionState;
+
+  constructor(props: ConnectionProps) {
+    super();
+    this.did = props.did;
+    this.didDoc = props.didDoc;
+    this.verkey = props.verkey;
+    this.state = props.state;
+    this.messages = props.messages;
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  updateState(newState: ConnectionState) {
+    this.state = newState;
+    this.emit('change', newState);
+  }
+
+  async isConnected() {
+    return new Promise(resolve => {
+      if (this.getState() == 4) {
+        resolve(true);
+      }
+      this.on('change', (newState: number) => {
+        if (newState === 4) {
+          resolve(true);
+        }
+      });
+    });
+  }
+}

--- a/src/lib/protocols/connections/domain/ConnectionState.ts
+++ b/src/lib/protocols/connections/domain/ConnectionState.ts
@@ -1,0 +1,7 @@
+export enum ConnectionState {
+  INIT,
+  INVITED,
+  REQUESTED,
+  RESPONDED,
+  COMPLETE,
+}

--- a/src/lib/protocols/connections/domain/DidDoc.ts
+++ b/src/lib/protocols/connections/domain/DidDoc.ts
@@ -1,0 +1,10 @@
+export interface DidDoc {
+  '@context': string;
+  service: Service[];
+}
+
+interface Service {
+  serviceEndpoint: string;
+  recipientKeys: Verkey[];
+  routingKeys: Verkey[];
+}

--- a/src/lib/protocols/connections/domain/InvitationDetails.ts
+++ b/src/lib/protocols/connections/domain/InvitationDetails.ts
@@ -1,0 +1,6 @@
+export interface InvitationDetails {
+  label: string;
+  recipientKeys: Verkey[];
+  serviceEndpoint: string;
+  routingKeys: Verkey[];
+}

--- a/src/lib/protocols/connections/messages.ts
+++ b/src/lib/protocols/connections/messages.ts
@@ -1,5 +1,6 @@
 import uuid from 'uuid/v4';
-import { InvitationDetails, Connection } from '../../types';
+import { Connection } from './domain/Connection';
+import { InvitationDetails } from './domain/InvitationDetails';
 
 export enum MessageType {
   ConnectionInvitation = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/invitation',

--- a/src/lib/protocols/helpers.ts
+++ b/src/lib/protocols/helpers.ts
@@ -1,4 +1,5 @@
-import { Connection, Message } from '../types';
+import { Message } from '../types';
+import { Connection } from './connections/domain/Connection';
 
 export function createOutboundMessage(connection: Connection, payload: Message, invitation?: any) {
   if (invitation) {

--- a/src/lib/protocols/routing/ProviderRoutingService.ts
+++ b/src/lib/protocols/routing/ProviderRoutingService.ts
@@ -1,5 +1,6 @@
-import { Connection, InboundMessage } from '../../types';
+import { InboundMessage } from '../../types';
 import { createOutboundMessage } from '../helpers';
+import { Connection } from '../connections/domain/Connection';
 
 interface RouteUpdate {
   action: 'add' | 'remove';

--- a/src/lib/testUtils.ts
+++ b/src/lib/testUtils.ts
@@ -1,4 +1,4 @@
-import { Connection } from './types';
+import { Connection } from './index';
 
 // Custom matchers which can be used to extend Jest matchers via extend, e. g. `expect.extend({ toBeConnectedWith })`.
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,5 @@
+import { Connection } from './protocols/connections/domain/Connection';
+
 type $FixMe = any;
 
 export type WireMessage = $FixMe;
@@ -11,45 +13,6 @@ export interface InitConfig {
   publicDid?: Did;
   publicDidSeed?: string;
   agencyUrl?: string;
-}
-
-export enum ConnectionState {
-  INIT,
-  INVITED,
-  REQUESTED,
-  RESPONDED,
-  COMPLETE,
-}
-
-export interface Connection {
-  did: Did;
-  didDoc: DidDoc;
-  verkey: Verkey;
-  theirDid?: Did;
-  theirKey?: Verkey;
-  theirDidDoc?: any;
-  invitation?: InvitationDetails;
-  state: ConnectionState;
-  endpoint?: string;
-  messages: any[];
-}
-
-export interface InvitationDetails {
-  label: string;
-  recipientKeys: Verkey[];
-  serviceEndpoint: string;
-  routingKeys: Verkey[];
-}
-
-export interface DidDoc {
-  '@context': string;
-  service: Service[];
-}
-
-interface Service {
-  serviceEndpoint: string;
-  recipientKeys: Verkey[];
-  routingKeys: Verkey[];
 }
 
 export interface Message {

--- a/types/indy-sdk/jest.d.ts
+++ b/types/indy-sdk/jest.d.ts
@@ -1,4 +1,4 @@
-import { Connection } from '../../src/lib/types';
+import { Connection } from '../../src/lib';
 
 declare global {
   namespace jest {


### PR DESCRIPTION
When I tried to use this library from UI client I realize it could be great to utilize the concept of JS and Node events emitting to listen on particular events and update UI accordingly. I start with the connection state update and we’ll see where it bring us. To be honest, I think of it partially as an experiment.  It’s still in question whether event emitter should be a connection, connection service, agent or something else.