### PR TITLE
Refactoring of connection service

### DIFF
--- a/src/lib/decorators.test.ts
+++ b/src/lib/decorators.test.ts
@@ -1,10 +1,48 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import indy from 'indy-sdk';
-import { sign } from './decorators';
+import { sign, verify } from './decorators';
 
 describe('decorators', () => {
   const walletConfig = { id: 'wallet-1' + 'test1' };
   const walletCredentials = { key: 'key' };
+
+  const message = {
+    '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/response',
+    '@id': '12345678900987654321',
+    '~thread': {
+      thid: 'thread1',
+    },
+    connection: {
+      did: 'did',
+      did_doc: {
+        '@context': 'https://w3id.org/did/v1',
+        service: [
+          {
+            id: 'did:example:123456789abcdefghi#did-communication',
+            type: 'did-communication',
+            priority: 0,
+            recipientKeys: ['someVerkey'],
+            routingKeys: [],
+            serviceEndpoint: 'https://agent.example.com/',
+          },
+        ],
+      },
+    },
+  };
+
+  const signedMessage = {
+    '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/response',
+    '@id': '12345678900987654321',
+    '~thread': { thid: 'thread1' },
+    'connection~sig': {
+      '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
+      signature: 'FnVvO/NJqmDM9OiIdg3zN4yCZ7dowDjARymMSpO1ngX0f4ehPQzkweNdHwvInm9QfMhNoWgXz4esHpayuhVbDQ==',
+      sig_data:
+        'eyJkaWQiOiJkaWQiLCJkaWRfZG9jIjp7IkBjb250ZXh0IjoiaHR0cHM6Ly93M2lkLm9yZy9kaWQvdjEiLCJzZXJ2aWNlIjpbeyJpZCI6ImRpZDpleGFtcGxlOjEyMzQ1Njc4OWFiY2RlZmdoaSNkaWQtY29tbXVuaWNhdGlvbiIsInR5cGUiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbInNvbWVWZXJrZXkiXSwicm91dGluZ0tleXMiOltdLCJzZXJ2aWNlRW5kcG9pbnQiOiJodHRwczovL2FnZW50LmV4YW1wbGUuY29tLyJ9XX19',
+      signers: 'GjZWsBLgZCR18aL468JAT7w9CZRiBnpxUPPgyQxh4voa',
+    },
+  };
+
   let wh: WalletHandle;
 
   beforeAll(async () => {
@@ -17,49 +55,34 @@ describe('decorators', () => {
     await indy.deleteWallet(walletConfig, walletCredentials);
   });
 
-  test('sign decorator signs data in given field', async () => {
+  test('sign decorator signs data in a given field of message', async () => {
     const seed1 = '00000000000000000000000000000My1';
     const verkey = await indy.createKey(wh, { seed: seed1 });
 
-    const message = {
-      '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/response',
-      '@id': '12345678900987654321',
-      '~thread': {
-        thid: 'thread1',
-      },
-      connection: {
-        did: 'did',
-        did_doc: {
-          '@context': 'https://w3id.org/did/v1',
-          service: [
-            {
-              id: 'did:example:123456789abcdefghi#did-communication',
-              type: 'did-communication',
-              priority: 0,
-              recipientKeys: [verkey],
-              routingKeys: [],
-              serviceEndpoint: 'https://agent.example.com/',
-            },
-          ],
-        },
-      },
-    };
+    const result = await sign(wh, message, 'connection', verkey);
+    expect(result).toEqual(signedMessage);
+  });
 
-    const signedMessage = await sign(wh, message, 'connection', verkey);
+  test('verify decorator verifies data in a given field of message', async () => {
+    const result = await verify(signedMessage, 'connection');
+    expect(result).toEqual(message);
+  });
 
-    const expectedMessage = {
-      '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/response',
-      '@id': '12345678900987654321',
-      '~thread': { thid: 'thread1' },
+  test('verify decorator throws when signature is not valid', async () => {
+    const wrongSignature = '6sblL1+OMlTFB3KhIQ8HKKZga8te7NAJAmBVPg2WzNYjMHVjfm+LJP6ZS1GUc2FRtfczRyLEfXrXb86SnzBmBA==';
+    const wronglySignedMessage = {
+      ...signedMessage,
       'connection~sig': {
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
-        signature: '6sblL1+OMlTFB3KhIQ8HKKZga8te7NAJAmBVPg2WzNYjMHVjfm+LJP6ZS1GUc2FRtfczRyLEfXrXb86SnzBmBA==',
-        sig_data:
-          'eyJkaWQiOiJkaWQiLCJkaWRfZG9jIjp7IkBjb250ZXh0IjoiaHR0cHM6Ly93M2lkLm9yZy9kaWQvdjEiLCJzZXJ2aWNlIjpbeyJpZCI6ImRpZDpleGFtcGxlOjEyMzQ1Njc4OWFiY2RlZmdoaSNkaWQtY29tbXVuaWNhdGlvbiIsInR5cGUiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbIkdqWldzQkxnWkNSMThhTDQ2OEpBVDd3OUNaUmlCbnB4VVBQZ3lReGg0dm9hIl0sInJvdXRpbmdLZXlzIjpbXSwic2VydmljZUVuZHBvaW50IjoiaHR0cHM6Ly9hZ2VudC5leGFtcGxlLmNvbS8ifV19fQ==',
-        signers: 'GjZWsBLgZCR18aL468JAT7w9CZRiBnpxUPPgyQxh4voa',
+        ...signedMessage['connection~sig'],
+        signature: wrongSignature,
       },
     };
 
-    expect(signedMessage).toEqual(expectedMessage);
+    expect.assertions(1);
+    try {
+      await verify(wronglySignedMessage, 'connection');
+    } catch (error) {
+      expect(error.message).toEqual('Signature is not valid!');
+    }
   });
 });

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -22,3 +22,28 @@ export async function sign(wh: WalletHandle, message: Message, field: string, si
 
   return signedMessage;
 }
+
+export async function verify(message: Message, field: string) {
+  const { [`${field}~sig`]: data, ...signedMessage } = message;
+
+  const signerVerkey = data.signers;
+  const signedData = Buffer.from(data.sig_data, 'base64');
+  const signature = Buffer.from(data.signature, 'base64');
+
+  // check signature
+  const valid = await indy.cryptoVerify(signerVerkey, signedData, signature);
+
+  if (!valid) {
+    throw new Error('Signature is not valid!');
+  }
+
+  const originalMessage = {
+    // TypeScript is not able to infer mandatory type and id attribute, so we have to write it specifically.
+    '@type': message['@type'],
+    '@id': message['@id'],
+    ...signedMessage,
+    [`${field}`]: JSON.parse(signedData.toString('utf-8')),
+  };
+
+  return originalMessage;
+}

--- a/src/lib/protocols/connections/domain/Connection.ts
+++ b/src/lib/protocols/connections/domain/Connection.ts
@@ -8,12 +8,16 @@ interface ConnectionProps {
   didDoc: DidDoc;
   verkey: Verkey;
   theirDid?: Did;
-  theirKey?: Verkey;
   theirDidDoc?: DidDoc;
   invitation?: InvitationDetails;
   state: ConnectionState;
   endpoint?: string;
   messages: any[];
+}
+
+interface DidExchangeConnection {
+  did: Did;
+  did_doc: DidDoc;
 }
 
 export class Connection extends EventEmitter {
@@ -33,6 +37,9 @@ export class Connection extends EventEmitter {
     this.did = props.did;
     this.didDoc = props.didDoc;
     this.verkey = props.verkey;
+    this.theirDid = props.theirDid;
+    this.theirDidDoc = props.theirDidDoc;
+    this.invitation = props.invitation;
     this.state = props.state;
     this.messages = props.messages;
   }
@@ -46,6 +53,11 @@ export class Connection extends EventEmitter {
 
   getState() {
     return this.state;
+  }
+
+  updateDidExchangeConnection(didExchangeConnection: DidExchangeConnection) {
+    this.theirDid = didExchangeConnection.did;
+    this.theirDidDoc = didExchangeConnection.did_doc;
   }
 
   updateState(newState: ConnectionState) {

--- a/src/lib/protocols/connections/domain/Connection.ts
+++ b/src/lib/protocols/connections/domain/Connection.ts
@@ -9,7 +9,7 @@ interface ConnectionProps {
   verkey: Verkey;
   theirDid?: Did;
   theirKey?: Verkey;
-  theirDidDoc?: any;
+  theirDidDoc?: DidDoc;
   invitation?: InvitationDetails;
   state: ConnectionState;
   endpoint?: string;
@@ -21,8 +21,7 @@ export class Connection extends EventEmitter {
   didDoc: DidDoc;
   verkey: Verkey;
   theirDid?: Did;
-  theirKey?: Verkey;
-  theirDidDoc?: any;
+  theirDidDoc?: DidDoc;
   invitation?: InvitationDetails;
   endpoint?: string;
   messages: any[];
@@ -36,6 +35,13 @@ export class Connection extends EventEmitter {
     this.verkey = props.verkey;
     this.state = props.state;
     this.messages = props.messages;
+  }
+
+  get theirKey() {
+    if (!this.theirDidDoc) {
+      return null;
+    }
+    return this.theirDidDoc.service[0].recipientKeys[0];
   }
 
   getState() {

--- a/src/lib/testUtils.ts
+++ b/src/lib/testUtils.ts
@@ -6,12 +6,14 @@ export function toBeConnectedWith(received: Connection, connection: Connection) 
   const pass = received.did === connection.theirDid && received.verkey === connection.theirKey;
   if (pass) {
     return {
-      message: () => `expected connection ${received.did} not to be connected to with ${connection.theirDid}`,
+      message: () =>
+        `expected connection ${received.did}, ${received.verkey} not to be connected to with ${connection.theirDid}, ${connection.theirKey}`,
       pass: true,
     };
   } else {
     return {
-      message: () => `expected connection ${received.did} to be connected to with ${connection.theirDid}`,
+      message: () =>
+        `expected connection ${received.did}, ${received.verkey} to be connected to with ${connection.theirDid}, ${connection.theirKey}`,
       pass: false,
     };
   }

--- a/src/lib/wallet/IndyWallet.ts
+++ b/src/lib/wallet/IndyWallet.ts
@@ -1,7 +1,7 @@
 import indy from 'indy-sdk';
 import logger from '../logger';
 import { InboundMessage, Message } from '../types';
-import { sign } from '../decorators';
+import { sign, verify } from '../decorators';
 import { Wallet, WalletConfig, WalletCredentials, DidInfo, DidConfig } from './Wallet';
 
 export class IndyWallet implements Wallet {
@@ -102,8 +102,8 @@ export class IndyWallet implements Wallet {
     return sign(this.wh, message, attribute, verkey);
   }
 
-  async verify(signerVerkey: Verkey, data: Buffer, signature: Buffer) {
-    return indy.cryptoVerify(signerVerkey, data, signature);
+  async verify(message: Message, attribute: string) {
+    return verify(message, attribute);
   }
 
   async close() {

--- a/src/lib/wallet/Wallet.ts
+++ b/src/lib/wallet/Wallet.ts
@@ -10,7 +10,7 @@ export interface Wallet {
   pack(payload: {}, recipientKeys: Verkey[], senderVk: Verkey | null): Promise<JsonWebKey>;
   unpack(messagePackage: JsonWebKey): Promise<InboundMessage>;
   sign(message: Message, attribute: string, verkey: Verkey): Promise<Message>;
-  verify(signerVerkey: Verkey, data: Buffer, signature: Buffer): Promise<boolean>;
+  verify(message: Message, attribute: string): Promise<Message>;
 }
 
 export interface DidInfo {

--- a/src/samples/__tests__/e2e.test.ts
+++ b/src/samples/__tests__/e2e.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 // @ts-ignore
 import { poll } from 'await-poll';
-import { Agent, decodeInvitationFromUrl, InboundTransporter, OutboundTransporter } from '../../lib';
+import { Agent, decodeInvitationFromUrl, InboundTransporter, OutboundTransporter, Connection } from '../../lib';
 import { WireMessage, OutboundPackage } from '../../lib/types';
 import { get, post } from '../http';
 import { toBeConnectedWith } from '../../lib/testUtils';
@@ -60,8 +60,11 @@ describe('with agency', () => {
       await get(`${bobAgent.getAgencyUrl()}/api/connections/${bobKeyAtBobAgency}`)
     );
 
-    expect(aliceInboundConnection).toBeConnectedWith(agencyConnectionAtAliceAgency);
-    expect(bobInboundConnection).toBeConnectedWith(agencyConnectionAtBobAgency);
+    // Here I'm creating instance based on JSON response to be able to call methods on connection. Matcher calls
+    // `theirKey` which is getter method to access verkey in DidDoc If this will become a problem we can consider to add
+    // some (de)serialization mechanism.
+    expect(aliceInboundConnection).toBeConnectedWith(new Connection(agencyConnectionAtAliceAgency));
+    expect(bobInboundConnection).toBeConnectedWith(new Connection(agencyConnectionAtBobAgency));
   });
 
   test('make a connection via agency', async () => {

--- a/types/indy-sdk/index.d.ts
+++ b/types/indy-sdk/index.d.ts
@@ -7,7 +7,7 @@ declare module 'indy-sdk' {
   function keyForLocalDid(wh: WalletHandle, did: Did): Promise<Verkey>;
   function cryptoAnonCrypt(recipientVk: Verkey, messageRaw: Buffer): Promise<Buffer>;
   function cryptoSign(wh: WalletHandle, signerVk: Verkey, messageRaw: Buffer): Promise<Buffer>;
-  function cryptoVerify(signerVk: Verkey, messageRaw: Buffer, signatureRaw: Buffer): boolean;
+  function cryptoVerify(signerVk: Verkey, messageRaw: Buffer, signatureRaw: Buffer): Promise<boolean>;
   function createKey(wh: WalletHandle, key: KeyConfig): Promise<Verkey>;
   function packMessage(
     wh: WalletHandle,


### PR DESCRIPTION
The most amount of code is related to the extraction and generalization signature verification of connection response message, now it should work for all and not only connection related messages. 

Overall, it's more changes than I originally expected, but you can see smaller bits of changes looking into separate commits if you want:
* Encapsulate theirKey attribute, remove unsed code and update types
* Encapsulate did exchange connection object
* Extract connection response signature verification into decorators