### PR TITLE
ConnectionService: Use Connection Protocol

### DIFF
--- a/src/lib/decorators.test.ts
+++ b/src/lib/decorators.test.ts
@@ -36,10 +36,10 @@ describe('decorators', () => {
     '~thread': { thid: 'thread1' },
     'connection~sig': {
       '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
-      signature: 'FnVvO/NJqmDM9OiIdg3zN4yCZ7dowDjARymMSpO1ngX0f4ehPQzkweNdHwvInm9QfMhNoWgXz4esHpayuhVbDQ==',
+      signature: 'zOSmKNCHKqOJGDJ6OlfUXTPJiirEAXrFn1kPiFDZfvG5hNTBKhsSzqAvlg44apgWBu7O57vGWZsXBF2BWZ5JAw==',
       sig_data:
         'AAAAAAAAAAB7ImRpZCI6ImRpZCIsImRpZF9kb2MiOnsiQGNvbnRleHQiOiJodHRwczovL3czaWQub3JnL2RpZC92MSIsInNlcnZpY2UiOlt7ImlkIjoiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2RpZC1jb21tdW5pY2F0aW9uIiwidHlwZSI6ImRpZC1jb21tdW5pY2F0aW9uIiwicHJpb3JpdHkiOjAsInJlY2lwaWVudEtleXMiOlsic29tZVZlcmtleSJdLCJyb3V0aW5nS2V5cyI6W10sInNlcnZpY2VFbmRwb2ludCI6Imh0dHBzOi8vYWdlbnQuZXhhbXBsZS5jb20vIn1dfX0=',
-      signers: 'GjZWsBLgZCR18aL468JAT7w9CZRiBnpxUPPgyQxh4voa',
+      signer: 'GjZWsBLgZCR18aL468JAT7w9CZRiBnpxUPPgyQxh4voa',
     },
   };
 

--- a/src/lib/decorators.test.ts
+++ b/src/lib/decorators.test.ts
@@ -38,7 +38,7 @@ describe('decorators', () => {
       '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
       signature: 'FnVvO/NJqmDM9OiIdg3zN4yCZ7dowDjARymMSpO1ngX0f4ehPQzkweNdHwvInm9QfMhNoWgXz4esHpayuhVbDQ==',
       sig_data:
-        'eyJkaWQiOiJkaWQiLCJkaWRfZG9jIjp7IkBjb250ZXh0IjoiaHR0cHM6Ly93M2lkLm9yZy9kaWQvdjEiLCJzZXJ2aWNlIjpbeyJpZCI6ImRpZDpleGFtcGxlOjEyMzQ1Njc4OWFiY2RlZmdoaSNkaWQtY29tbXVuaWNhdGlvbiIsInR5cGUiOiJkaWQtY29tbXVuaWNhdGlvbiIsInByaW9yaXR5IjowLCJyZWNpcGllbnRLZXlzIjpbInNvbWVWZXJrZXkiXSwicm91dGluZ0tleXMiOltdLCJzZXJ2aWNlRW5kcG9pbnQiOiJodHRwczovL2FnZW50LmV4YW1wbGUuY29tLyJ9XX19',
+        'AAAAAAAAAAB7ImRpZCI6ImRpZCIsImRpZF9kb2MiOnsiQGNvbnRleHQiOiJodHRwczovL3czaWQub3JnL2RpZC92MSIsInNlcnZpY2UiOlt7ImlkIjoiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2RpZC1jb21tdW5pY2F0aW9uIiwidHlwZSI6ImRpZC1jb21tdW5pY2F0aW9uIiwicHJpb3JpdHkiOjAsInJlY2lwaWVudEtleXMiOlsic29tZVZlcmtleSJdLCJyb3V0aW5nS2V5cyI6W10sInNlcnZpY2VFbmRwb2ludCI6Imh0dHBzOi8vYWdlbnQuZXhhbXBsZS5jb20vIn1dfX0=',
       signers: 'GjZWsBLgZCR18aL468JAT7w9CZRiBnpxUPPgyQxh4voa',
     },
   };
@@ -59,7 +59,7 @@ describe('decorators', () => {
     const seed1 = '00000000000000000000000000000My1';
     const verkey = await indy.createKey(wh, { seed: seed1 });
 
-    const result = await sign(wh, message, 'connection', verkey);
+    const result = await sign(wh, message, 'connection', verkey, true);
     expect(result).toEqual(signedMessage);
   });
 

--- a/src/lib/decorators.test.ts
+++ b/src/lib/decorators.test.ts
@@ -1,5 +1,13 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 import indy from 'indy-sdk';
+
+jest.mock('./timestamp', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(() => Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 0)),
+  };
+});
+
 import { sign, verify } from './decorators';
 
 describe('decorators', () => {
@@ -58,8 +66,7 @@ describe('decorators', () => {
   test('sign decorator signs data in a given field of message', async () => {
     const seed1 = '00000000000000000000000000000My1';
     const verkey = await indy.createKey(wh, { seed: seed1 });
-
-    const result = await sign(wh, message, 'connection', verkey, true);
+    const result = await sign(wh, message, 'connection', verkey);
     expect(result).toEqual(signedMessage);
   });
 

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -1,7 +1,8 @@
 import indy from 'indy-sdk';
 import { Message } from './types';
 
-// Question: Spec isn't clear about the endianness. Assumes little-endian here
+// Question: Spec isn't clear about the endianness. Assumes big-endian here
+// since ACA-Py uses big-endian
 function timestamp(isTest: boolean): Uint8Array {
   if (isTest) {
     return Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 0);
@@ -14,7 +15,7 @@ function timestamp(isTest: boolean): Uint8Array {
     bytes.push(byte);
     time = (time - byte) / 256; // Javascript right shift (>>>) only works on 32 bit integers
   }
-  return Uint8Array.from(bytes);
+  return Uint8Array.from(bytes).reverse();
 }
 
 export async function sign(
@@ -26,9 +27,8 @@ export async function sign(
 ): Promise<Message> {
   const { [field]: data, ...originalMessage } = message;
 
-  const dataBuffer = Buffer.from(JSON.stringify(data), 'utf8');
+  const dataBuffer = Buffer.concat([timestamp(isTest), Buffer.from(JSON.stringify(data), 'utf8')]);
   const signatureBuffer = await indy.cryptoSign(wh, signer, dataBuffer);
-  const sigdataBuffer = Buffer.concat([timestamp(isTest), dataBuffer]);
 
   const signedMessage = {
     // TypeScript is not able to infer mandatory type and id attribute, so we have to write it specifically.
@@ -38,8 +38,8 @@ export async function sign(
     [`${field}~sig`]: {
       '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
       signature: signatureBuffer.toString('base64'),
-      sig_data: sigdataBuffer.toString('base64'),
-      signers: signer,
+      sig_data: dataBuffer.toString('base64'),
+      signer: signer,
     },
   };
 
@@ -49,9 +49,9 @@ export async function sign(
 export async function verify(message: Message, field: string) {
   const { [`${field}~sig`]: data, ...signedMessage } = message;
 
-  const signerVerkey = data.signers;
+  const signerVerkey = data.signer;
   // first 8 bytes are for 64 bit integer from unix epoch
-  const signedData = Buffer.from(data.sig_data, 'base64').slice(8);
+  const signedData = Buffer.from(data.sig_data, 'base64');
   const signature = Buffer.from(data.signature, 'base64');
 
   // check signature
@@ -66,7 +66,7 @@ export async function verify(message: Message, field: string) {
     '@type': message['@type'],
     '@id': message['@id'],
     ...signedMessage,
-    [`${field}`]: JSON.parse(signedData.toString('utf-8')),
+    [`${field}`]: JSON.parse(signedData.slice(8).toString('utf-8')),
   };
 
   return originalMessage;

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -2,7 +2,11 @@ import indy from 'indy-sdk';
 import { Message } from './types';
 
 // Question: Spec isn't clear about the endianness. Assumes little-endian here
-function timestamp(): Uint8Array {
+function timestamp(isTest: boolean): Uint8Array {
+  if (isTest) {
+    return Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 0);
+  }
+
   let time = Date.now();
   const bytes = [];
   for (let i = 0; i < 8; i++) {
@@ -13,12 +17,18 @@ function timestamp(): Uint8Array {
   return Uint8Array.from(bytes);
 }
 
-export async function sign(wh: WalletHandle, message: Message, field: string, signer: Verkey): Promise<Message> {
+export async function sign(
+  wh: WalletHandle,
+  message: Message,
+  field: string,
+  signer: Verkey,
+  isTest: boolean = false
+): Promise<Message> {
   const { [field]: data, ...originalMessage } = message;
 
   const dataBuffer = Buffer.from(JSON.stringify(data), 'utf8');
   const signatureBuffer = await indy.cryptoSign(wh, signer, dataBuffer);
-  const sigdataBuffer = Buffer.concat([timestamp(), dataBuffer]);
+  const sigdataBuffer = Buffer.concat([timestamp(isTest), dataBuffer]);
 
   const signedMessage = {
     // TypeScript is not able to infer mandatory type and id attribute, so we have to write it specifically.

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -1,11 +1,24 @@
 import indy from 'indy-sdk';
 import { Message } from './types';
 
+// Question: Spec isn't clear about the endianness. Assumes little-endian here
+function timestamp(): Uint8Array {
+  let time = Date.now();
+  const bytes = [];
+  for (let i = 0; i < 8; i++) {
+    const byte = time & 0xff;
+    bytes.push(byte);
+    time = (time - byte) / 256; // Javascript right shift (>>>) only works on 32 bit integers
+  }
+  return Uint8Array.from(bytes);
+}
+
 export async function sign(wh: WalletHandle, message: Message, field: string, signer: Verkey): Promise<Message> {
   const { [field]: data, ...originalMessage } = message;
 
   const dataBuffer = Buffer.from(JSON.stringify(data), 'utf8');
   const signatureBuffer = await indy.cryptoSign(wh, signer, dataBuffer);
+  const sigdataBuffer = Buffer.concat([timestamp(), dataBuffer]);
 
   const signedMessage = {
     // TypeScript is not able to infer mandatory type and id attribute, so we have to write it specifically.
@@ -15,7 +28,7 @@ export async function sign(wh: WalletHandle, message: Message, field: string, si
     [`${field}~sig`]: {
       '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
       signature: signatureBuffer.toString('base64'),
-      sig_data: dataBuffer.toString('base64'),
+      sig_data: sigdataBuffer.toString('base64'),
       signers: signer,
     },
   };
@@ -27,7 +40,8 @@ export async function verify(message: Message, field: string) {
   const { [`${field}~sig`]: data, ...signedMessage } = message;
 
   const signerVerkey = data.signers;
-  const signedData = Buffer.from(data.sig_data, 'base64');
+  // first 8 bytes are for 64 bit integer from unix epoch
+  const signedData = Buffer.from(data.sig_data, 'base64').slice(8);
   const signature = Buffer.from(data.signature, 'base64');
 
   // check signature
@@ -42,8 +56,7 @@ export async function verify(message: Message, field: string) {
     '@type': message['@type'],
     '@id': message['@id'],
     ...signedMessage,
-    // first 8 bytes are for 64 bit integer from unix epoch
-    [`${field}`]: JSON.parse(signedData.slice(8).toString('utf-8')),
+    [`${field}`]: JSON.parse(signedData.toString('utf-8')),
   };
 
   return originalMessage;

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -1,22 +1,6 @@
 import indy from 'indy-sdk';
 import { Message } from './types';
-
-// Question: Spec isn't clear about the endianness. Assumes big-endian here
-// since ACA-Py uses big-endian
-function timestamp(isTest: boolean): Uint8Array {
-  if (isTest) {
-    return Uint8Array.of(0, 0, 0, 0, 0, 0, 0, 0);
-  }
-
-  let time = Date.now();
-  const bytes = [];
-  for (let i = 0; i < 8; i++) {
-    const byte = time & 0xff;
-    bytes.push(byte);
-    time = (time - byte) / 256; // Javascript right shift (>>>) only works on 32 bit integers
-  }
-  return Uint8Array.from(bytes).reverse();
-}
+import timestamp from './timestamp';
 
 export async function sign(
   wh: WalletHandle,
@@ -27,7 +11,7 @@ export async function sign(
 ): Promise<Message> {
   const { [field]: data, ...originalMessage } = message;
 
-  const dataBuffer = Buffer.concat([timestamp(isTest), Buffer.from(JSON.stringify(data), 'utf8')]);
+  const dataBuffer = Buffer.concat([timestamp(), Buffer.from(JSON.stringify(data), 'utf8')]);
   const signatureBuffer = await indy.cryptoSign(wh, signer, dataBuffer);
 
   const signedMessage = {

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -2,13 +2,7 @@ import indy from 'indy-sdk';
 import { Message } from './types';
 import timestamp from './timestamp';
 
-export async function sign(
-  wh: WalletHandle,
-  message: Message,
-  field: string,
-  signer: Verkey,
-  isTest: boolean = false
-): Promise<Message> {
+export async function sign(wh: WalletHandle, message: Message, field: string, signer: Verkey): Promise<Message> {
   const { [field]: data, ...originalMessage } = message;
 
   const dataBuffer = Buffer.concat([timestamp(), Buffer.from(JSON.stringify(data), 'utf8')]);

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -42,7 +42,8 @@ export async function verify(message: Message, field: string) {
     '@type': message['@type'],
     '@id': message['@id'],
     ...signedMessage,
-    [`${field}`]: JSON.parse(signedData.toString('utf-8')),
+    // first 8 bytes are for 64 bit integer from unix epoch
+    [`${field}`]: JSON.parse(signedData.slice(8).toString('utf-8')),
   };
 
   return originalMessage;

--- a/src/lib/protocols/connections/ConnectionService.ts
+++ b/src/lib/protocols/connections/ConnectionService.ts
@@ -75,12 +75,12 @@ class ConnectionService {
 
     const originalMessage = await wallet.verify(message, 'connection');
     connection.updateDidExchangeConnection(originalMessage.connection);
-
     if (!connection.theirKey) {
       throw new Error(`Connection with verkey ${connection.verkey} has no recipient keys.`);
     }
 
-    validateSenderKey(connection, sender_verkey);
+    // dotnet doesn't send senderVk here
+    // validateSenderKey(connection, sender_verkey);
 
     const response = createAckMessage(message['@id']);
     connection.updateState(ConnectionState.COMPLETE);

--- a/src/lib/protocols/connections/domain/Connection.ts
+++ b/src/lib/protocols/connections/domain/Connection.ts
@@ -74,8 +74,8 @@ export class Connection extends EventEmitter {
         if (newState == state) {
           resolve(true);
         }
-      })
-    })
+      });
+    });
   }
 
   async isConnected() {

--- a/src/lib/protocols/connections/domain/Connection.ts
+++ b/src/lib/protocols/connections/domain/Connection.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 import { ConnectionState } from './ConnectionState';
 import { DidDoc } from './DidDoc';
 import { InvitationDetails } from './InvitationDetails';
@@ -65,16 +65,20 @@ export class Connection extends EventEmitter {
     this.emit('change', newState);
   }
 
-  async isConnected() {
+  async hasState(state: ConnectionState) {
     return new Promise(resolve => {
-      if (this.getState() == 4) {
+      if (this.getState() == state) {
         resolve(true);
       }
       this.on('change', (newState: number) => {
-        if (newState === 4) {
+        if (newState == state) {
           resolve(true);
         }
-      });
-    });
+      })
+    })
+  }
+
+  async isConnected() {
+    return this.hasState(ConnectionState.COMPLETE);
   }
 }

--- a/src/lib/protocols/connections/domain/Connection.ts
+++ b/src/lib/protocols/connections/domain/Connection.ts
@@ -16,8 +16,8 @@ interface ConnectionProps {
 }
 
 interface DidExchangeConnection {
-  did: Did;
-  did_doc: DidDoc;
+  DID: Did;
+  DIDDoc: DidDoc;
 }
 
 export class Connection extends EventEmitter {
@@ -56,8 +56,8 @@ export class Connection extends EventEmitter {
   }
 
   updateDidExchangeConnection(didExchangeConnection: DidExchangeConnection) {
-    this.theirDid = didExchangeConnection.did;
-    this.theirDidDoc = didExchangeConnection.did_doc;
+    this.theirDid = didExchangeConnection.DID;
+    this.theirDidDoc = didExchangeConnection.DIDDoc;
   }
 
   updateState(newState: ConnectionState) {

--- a/src/lib/protocols/connections/messages.ts
+++ b/src/lib/protocols/connections/messages.ts
@@ -3,9 +3,9 @@ import { Connection } from './domain/Connection';
 import { InvitationDetails } from './domain/InvitationDetails';
 
 export enum MessageType {
-  ConnectionInvitation = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/invitation',
-  ConnectionRequest = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/request',
-  ConnectionResposne = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/didexchange/1.0/response',
+  ConnectionInvitation = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation',
+  ConnectionRequest = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/request',
+  ConnectionResposne = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response',
   Ack = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/notification/1.0/ack',
 }
 
@@ -31,8 +31,8 @@ export function createConnectionRequestMessage(connection: Connection, label: st
     '@id': uuid(),
     label: label,
     connection: {
-      did: connection.did,
-      did_doc: connection.didDoc,
+      DID: connection.did,
+      DIDDoc: connection.didDoc,
     },
   };
 }
@@ -45,8 +45,8 @@ export function createConnectionResponseMessage(connection: Connection, thid: st
       thid,
     },
     connection: {
-      did: connection.did,
-      did_doc: connection.didDoc,
+      DID: connection.did,
+      DIDDoc: connection.didDoc,
     },
   };
 }

--- a/src/lib/protocols/helpers.ts
+++ b/src/lib/protocols/helpers.ts
@@ -8,7 +8,7 @@ export function createOutboundMessage(connection: Connection, payload: Message, 
       endpoint: invitation.serviceEndpoint,
       payload,
       recipientKeys: invitation.recipientKeys,
-      routingKeys: invitation.routingKeys,
+      routingKeys: invitation.routingKeys || [],
       senderVk: connection.verkey,
     };
   }

--- a/src/lib/protocols/helpers.ts
+++ b/src/lib/protocols/helpers.ts
@@ -9,7 +9,7 @@ export function createOutboundMessage(connection: Connection, payload: Message, 
       payload,
       recipientKeys: invitation.recipientKeys,
       routingKeys: invitation.routingKeys,
-      senderVk: null,
+      senderVk: connection.verkey,
     };
   }
 

--- a/src/lib/timestamp.ts
+++ b/src/lib/timestamp.ts
@@ -1,0 +1,12 @@
+// Question: Spec isn't clear about the endianness. Assumes big-endian here
+// since ACA-Py uses big-endian.
+export default function timestamp(): Uint8Array {
+  let time = Date.now();
+  const bytes = [];
+  for (let i = 0; i < 8; i++) {
+    const byte = time & 0xff;
+    bytes.push(byte);
+    time = (time - byte) / 256; // Javascript right shift (>>>) only works on 32 bit integers
+  }
+  return Uint8Array.from(bytes).reverse();
+}


### PR DESCRIPTION
Switches to the [Aries Connection Protocol](https://github.com/hyperledger/aries-rfcs/tree/04ce2e2b0f956f2b3dcdad8298c6c039b31b57bc/features/0160-connection-protocol).

P.S. I'm aware of message type prefixes [being changed](https://github.com/hyperledger/aries-rfcs/blob/1d676fa8630a4b659ed5d175ea3b0043c6e83016/features/0348-transition-msg-type-to-https/README.md) but that can be accommodated in a future PR. Deadline for that is end of February.