### PR TITLE
Group hanlders by protocol

### DIFF
--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -17,17 +17,17 @@ import { Dispatcher } from './Dispatcher';
 import { MessageSender } from './MessageSender';
 import { InboundTransporter } from '../transport/InboundTransporter';
 import { OutboundTransporter } from '../transport/OutboundTransporter';
-import { InvitationHandler } from '../handlers/InvitationHandler';
-import { ConnectionRequestHandler } from '../handlers/ConnectionRequestHandler';
-import { ConnectionResponseHandler } from '../handlers/ConnectionResponseHandler';
-import { AckMessageHandler } from '../handlers/AckMessageHandler';
-import { BasicMessageHandler } from '../handlers/BasicMessageHandler';
-import { RouteUpdateHandler } from '../handlers/RouteUpdateHandler';
-import { ForwardHandler } from '../handlers/ForwardHandler';
+import { InvitationHandler } from '../handlers/connections/InvitationHandler';
+import { ConnectionRequestHandler } from '../handlers/connections/ConnectionRequestHandler';
+import { ConnectionResponseHandler } from '../handlers/connections/ConnectionResponseHandler';
+import { AckMessageHandler } from '../handlers/acks/AckMessageHandler';
+import { BasicMessageHandler } from '../handlers/basicmessage/BasicMessageHandler';
+import { RouteUpdateHandler } from '../handlers/routing/RouteUpdateHandler';
+import { ForwardHandler } from '../handlers/routing/ForwardHandler';
 import { Handler } from '../handlers/Handler';
 import { TrustPingService } from '../protocols/trustping/TrustPingService';
-import { TrustPingMessageHandler } from '../handlers/TrustPingMessageHandler';
-import { TrustPingResponseMessageHandler } from '../handlers/TrustPingResponseMessageHandler';
+import { TrustPingMessageHandler } from '../handlers/trustping/TrustPingMessageHandler';
+import { TrustPingResponseMessageHandler } from '../handlers/trustping/TrustPingResponseMessageHandler';
 
 export class Agent {
   inboundTransporter: InboundTransporter;

--- a/src/lib/handlers/acks/AckMessageHandler.ts
+++ b/src/lib/handlers/acks/AckMessageHandler.ts
@@ -1,6 +1,6 @@
-import { InboundMessage } from '../types';
-import { Handler } from './Handler';
-import { ConnectionService } from '../protocols/connections/ConnectionService';
+import { InboundMessage } from '../../types';
+import { Handler } from '../Handler';
+import { ConnectionService } from '../../protocols/connections/ConnectionService';
 
 export class AckMessageHandler implements Handler {
   connectionService: ConnectionService;

--- a/src/lib/handlers/basicmessage/BasicMessageHandler.ts
+++ b/src/lib/handlers/basicmessage/BasicMessageHandler.ts
@@ -1,7 +1,7 @@
-import { InboundMessage } from '../types';
-import { Handler } from './Handler';
-import { ConnectionService } from '../protocols/connections/ConnectionService';
-import { BasicMessageService } from '../protocols/basicmessage/BasicMessageService';
+import { InboundMessage } from '../../types';
+import { Handler } from '../Handler';
+import { ConnectionService } from '../../protocols/connections/ConnectionService';
+import { BasicMessageService } from '../../protocols/basicmessage/BasicMessageService';
 
 export class BasicMessageHandler implements Handler {
   connectionService: ConnectionService;

--- a/src/lib/handlers/connections/ConnectionRequestHandler.ts
+++ b/src/lib/handlers/connections/ConnectionRequestHandler.ts
@@ -1,6 +1,6 @@
-import { InboundMessage } from '../types';
-import { Handler } from './Handler';
-import { ConnectionService } from '../protocols/connections/ConnectionService';
+import { InboundMessage } from '../../types';
+import { Handler } from '../Handler';
+import { ConnectionService } from '../../protocols/connections/ConnectionService';
 
 export class ConnectionRequestHandler implements Handler {
   connectionService: ConnectionService;

--- a/src/lib/handlers/connections/ConnectionResponseHandler.ts
+++ b/src/lib/handlers/connections/ConnectionResponseHandler.ts
@@ -1,6 +1,6 @@
-import { InboundMessage } from '../types';
-import { Handler } from './Handler';
-import { ConnectionService } from '../protocols/connections/ConnectionService';
+import { InboundMessage } from '../../types';
+import { Handler } from '../Handler';
+import { ConnectionService } from '../../protocols/connections/ConnectionService';
 
 export class ConnectionResponseHandler implements Handler {
   connectionService: ConnectionService;

--- a/src/lib/handlers/connections/InvitationHandler.ts
+++ b/src/lib/handlers/connections/InvitationHandler.ts
@@ -1,7 +1,7 @@
-import { InboundMessage } from '../types';
-import { Handler } from './Handler';
-import { ConnectionService } from '../protocols/connections/ConnectionService';
-import { ConsumerRoutingService } from '../protocols/routing/ConsumerRoutingService';
+import { InboundMessage } from '../../types';
+import { Handler } from '../Handler';
+import { ConnectionService } from '../../protocols/connections/ConnectionService';
+import { ConsumerRoutingService } from '../../protocols/routing/ConsumerRoutingService';
 
 export class InvitationHandler implements Handler {
   connectionService: ConnectionService;

--- a/src/lib/handlers/routing/ForwardHandler.ts
+++ b/src/lib/handlers/routing/ForwardHandler.ts
@@ -1,6 +1,6 @@
-import { InboundMessage } from '../types';
-import { Handler } from './Handler';
-import { ProviderRoutingService } from '../protocols/routing/ProviderRoutingService';
+import { InboundMessage } from '../../types';
+import { Handler } from '../Handler';
+import { ProviderRoutingService } from '../../protocols/routing/ProviderRoutingService';
 
 export class ForwardHandler implements Handler {
   routingService: ProviderRoutingService;

--- a/src/lib/handlers/routing/RouteUpdateHandler.ts
+++ b/src/lib/handlers/routing/RouteUpdateHandler.ts
@@ -1,7 +1,7 @@
-import { InboundMessage } from '../types';
-import { Handler } from './Handler';
-import { ConnectionService } from '../protocols/connections/ConnectionService';
-import { ProviderRoutingService } from '../protocols/routing/ProviderRoutingService';
+import { InboundMessage } from '../../types';
+import { Handler } from '../Handler';
+import { ConnectionService } from '../../protocols/connections/ConnectionService';
+import { ProviderRoutingService } from '../../protocols/routing/ProviderRoutingService';
 
 export class RouteUpdateHandler implements Handler {
   connectionService: ConnectionService;

--- a/src/lib/handlers/trustping/TrustPingMessageHandler.ts
+++ b/src/lib/handlers/trustping/TrustPingMessageHandler.ts
@@ -1,8 +1,7 @@
-import { Handler } from './Handler';
-import { InboundMessage } from '../types';
-import { TrustPingService } from '../protocols/trustping/TrustPingService';
-import { ConnectionService } from '../protocols/connections/ConnectionService';
-import { MessageType } from '../protocols/trustping/messages';
+import { Handler } from '../Handler';
+import { InboundMessage } from '../../types';
+import { TrustPingService } from '../../protocols/trustping/TrustPingService';
+import { ConnectionService } from '../../protocols/connections/ConnectionService';
 
 export class TrustPingMessageHandler implements Handler {
   trustPingService: TrustPingService;

--- a/src/lib/handlers/trustping/TrustPingResponseMessageHandler.ts
+++ b/src/lib/handlers/trustping/TrustPingResponseMessageHandler.ts
@@ -1,6 +1,6 @@
-import { Handler } from './Handler';
-import { InboundMessage } from '../types';
-import { TrustPingService } from '../protocols/trustping/TrustPingService';
+import { Handler } from '../Handler';
+import { InboundMessage } from '../../types';
+import { TrustPingService } from '../../protocols/trustping/TrustPingService';
 
 export class TrustPingResponseMessageHandler implements Handler {
   trustPingService: TrustPingService;

--- a/src/lib/protocols/trustping/TrustPingService.ts
+++ b/src/lib/protocols/trustping/TrustPingService.ts
@@ -1,6 +1,6 @@
 import { InboundMessage } from '../../types';
 import { createOutboundMessage } from '../helpers';
-import { createTrustPingResponseMessage, MessageType } from './messages';
+import { createTrustPingResponseMessage } from './messages';
 import { Connection } from '../..';
 import { ConnectionState } from '../connections/domain/ConnectionState';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,6 +309,10 @@
   dependencies:
     "@types/express" "*"
 
+"@types/debug@^4.1.5":
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
+
 "@types/dotenv@^6.1.1":
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/@types/dotenv/-/dotenv-6.1.1.tgz#f7ce1cc4fe34f0a4373ba99fefa437b0bec54b46"


### PR DESCRIPTION
Solves #22 

I would like to keep it in `handlers` folder and not in `protocols`, at least for now, because I want to preserve fewer dependencies between protocols. I would like to make protocols independent of each other, not sure whether it's even achievable, I feel it's a good direction to go.

Signed-off-by: jakubkoci <jakub.koci@gmail.com>