### PR TITLE
Add env to run agency with debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,7 @@ You have to start agencies first, because it runs all tests togheter.
 ```
 yarn test
 ```
+
+## Logs
+
+If you don't want agency to be logging you just remove `DEBUG=aries-framework-javascript` from `yarn prod` command in `package.json`

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check-format": "yarn prettier --list-different",
     "test": "jest",
     "dev": "ts-node-dev --respawn --transpileOnly ./src/samples/agency.ts",
-    "prod": "rm -rf build && yarn compile && node ./build/samples/agency.js",
+    "prod": "rm -rf build && yarn compile && DEBUG=aries-framework-javascript node ./build/samples/agency.js",
     "validate": "npm-run-all --parallel lint compile",
     "prepack": "rm -rf build && yarn compile"
   },


### PR DESCRIPTION
@gnarula I was confused because the agency didn't log anything and didn't know what was the reason :) So I'm just adding debug logs as default and mentioning the option to turn-off logs in docs.

Signed-off-by: jakubkoci <jakub.koci@gmail.com>