### PR TITLE
decorators: use base64url

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@types/express": "^4.17.0",
     "await-poll": "^1.0.2",
+    "base64url": "^3.0.1",
     "body-parser": "^1.19.0",
     "debug": "^4.1.1",
     "dotenv": "^8.0.0",

--- a/src/lib/decorators.test.ts
+++ b/src/lib/decorators.test.ts
@@ -44,9 +44,9 @@ describe('decorators', () => {
     '~thread': { thid: 'thread1' },
     'connection~sig': {
       '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
-      signature: 'zOSmKNCHKqOJGDJ6OlfUXTPJiirEAXrFn1kPiFDZfvG5hNTBKhsSzqAvlg44apgWBu7O57vGWZsXBF2BWZ5JAw==',
+      signature: 'zOSmKNCHKqOJGDJ6OlfUXTPJiirEAXrFn1kPiFDZfvG5hNTBKhsSzqAvlg44apgWBu7O57vGWZsXBF2BWZ5JAw',
       sig_data:
-        'AAAAAAAAAAB7ImRpZCI6ImRpZCIsImRpZF9kb2MiOnsiQGNvbnRleHQiOiJodHRwczovL3czaWQub3JnL2RpZC92MSIsInNlcnZpY2UiOlt7ImlkIjoiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2RpZC1jb21tdW5pY2F0aW9uIiwidHlwZSI6ImRpZC1jb21tdW5pY2F0aW9uIiwicHJpb3JpdHkiOjAsInJlY2lwaWVudEtleXMiOlsic29tZVZlcmtleSJdLCJyb3V0aW5nS2V5cyI6W10sInNlcnZpY2VFbmRwb2ludCI6Imh0dHBzOi8vYWdlbnQuZXhhbXBsZS5jb20vIn1dfX0=',
+        'AAAAAAAAAAB7ImRpZCI6ImRpZCIsImRpZF9kb2MiOnsiQGNvbnRleHQiOiJodHRwczovL3czaWQub3JnL2RpZC92MSIsInNlcnZpY2UiOlt7ImlkIjoiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2RpZC1jb21tdW5pY2F0aW9uIiwidHlwZSI6ImRpZC1jb21tdW5pY2F0aW9uIiwicHJpb3JpdHkiOjAsInJlY2lwaWVudEtleXMiOlsic29tZVZlcmtleSJdLCJyb3V0aW5nS2V5cyI6W10sInNlcnZpY2VFbmRwb2ludCI6Imh0dHBzOi8vYWdlbnQuZXhhbXBsZS5jb20vIn1dfX0',
       signer: 'GjZWsBLgZCR18aL468JAT7w9CZRiBnpxUPPgyQxh4voa',
     },
   };

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -1,4 +1,5 @@
 import indy from 'indy-sdk';
+import base64url from 'base64url';
 import { Message } from './types';
 import timestamp from './timestamp';
 
@@ -15,9 +16,9 @@ export async function sign(wh: WalletHandle, message: Message, field: string, si
     ...originalMessage,
     [`${field}~sig`]: {
       '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
-      signature: signatureBuffer.toString('base64'),
-      sig_data: dataBuffer.toString('base64'),
-      signer: signer,
+      signature: base64url.encode(signatureBuffer),
+      sig_data: base64url.encode(dataBuffer),
+      signer: base64url.encode(signer),
     },
   };
 
@@ -27,10 +28,10 @@ export async function sign(wh: WalletHandle, message: Message, field: string, si
 export async function verify(message: Message, field: string) {
   const { [`${field}~sig`]: data, ...signedMessage } = message;
 
-  const signerVerkey = data.signer;
+  const signerVerkey = base64url.decode(data.signer);
   // first 8 bytes are for 64 bit integer from unix epoch
-  const signedData = Buffer.from(data.sig_data, 'base64');
-  const signature = Buffer.from(data.signature, 'base64');
+  const signedData = base64url.toBuffer(data.sig_data);
+  const signature = base64url.toBuffer(data.signature);
 
   // check signature
   const valid = await indy.cryptoVerify(signerVerkey, signedData, signature);

--- a/src/lib/decorators.ts
+++ b/src/lib/decorators.ts
@@ -18,7 +18,7 @@ export async function sign(wh: WalletHandle, message: Message, field: string, si
       '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
       signature: base64url.encode(signatureBuffer),
       sig_data: base64url.encode(dataBuffer),
-      signer: base64url.encode(signer),
+      signer: signer,
     },
   };
 
@@ -28,7 +28,7 @@ export async function sign(wh: WalletHandle, message: Message, field: string, si
 export async function verify(message: Message, field: string) {
   const { [`${field}~sig`]: data, ...signedMessage } = message;
 
-  const signerVerkey = base64url.decode(data.signer);
+  const signerVerkey = data.signer;
   // first 8 bytes are for 64 bit integer from unix epoch
   const signedData = base64url.toBuffer(data.sig_data);
   const signature = base64url.toBuffer(data.signature);


### PR DESCRIPTION
Aries RFC 0234 requires signature decorators to encode fields
using base64url instead of base64

Refer https://github.com/hyperledger/aries-rfcs/blob/master/features/0234-signature-decorator/README.md

Signed-off-by: Gaurav Narula <gnarula94@gmail.com>