### PR TITLE
Return connection object instead of just invitation URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-config-prettier": "^6.0.0",
     "eslint-plugin-prettier": "^3.1.0",
     "husky": "^3.1.0",
-    "indy-sdk": "^1.10.1",
+    "indy-sdk": "^1.14.0",
     "jest": "^24.8.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.18.2",

--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -98,7 +98,7 @@ export class Agent {
     return this.context.wallet.getPublicDid();
   }
 
-  async createInvitationUrl() {
+  async createConnection() {
     const connection = await this.connectionService.createConnectionWithInvitation();
     const { invitation } = connection;
 
@@ -112,18 +112,21 @@ export class Agent {
       this.consumerRoutingService.createRoute(connection.verkey);
     }
 
-    return encodeInvitationToUrl(invitation);
+    return connection;
   }
 
-  async acceptInvitationUrl(invitationUrl: string) {
-    const invitation = decodeInvitationFromUrl(invitationUrl);
-    const verkey = (await this.messageReceiver.receiveMessage(invitation))?.connection.verkey;
+  async acceptInvitation(invitation: any) {
+    const connection = (await this.messageReceiver.receiveMessage(invitation))?.connection;
 
-    if (!verkey) {
-      throw new Error('No verkey has been return');
+    if (!connection) {
+      throw new Error('No connection returned from receiveMessage');
     }
 
-    return verkey;
+    if (!connection.verkey) {
+      throw new Error('No verkey in connection returned from receiveMessage');
+    }
+
+    return connection;
   }
 
   async receiveMessage(inboundPackedMessage: any) {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,6 +1,6 @@
 export { Agent } from './agent/Agent';
 export { InboundTransporter } from './transport/InboundTransporter';
 export { OutboundTransporter } from './transport/OutboundTransporter';
-export { decodeInvitationFromUrl } from './helpers';
+export { encodeInvitationToUrl, decodeInvitationFromUrl } from './helpers';
 
 export { Connection } from './protocols/connections/domain/Connection';

--- a/src/samples/agency.ts
+++ b/src/samples/agency.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import bodyParser from 'body-parser';
 import config from './config';
 import logger from '../lib/logger';
-import { Agent, InboundTransporter, OutboundTransporter } from '../lib';
+import { Agent, InboundTransporter, OutboundTransporter, encodeInvitationToUrl } from '../lib';
 import { OutboundPackage } from '../lib/types';
 import indy from 'indy-sdk';
 
@@ -73,7 +73,14 @@ app.get('/', async (req, res) => {
 
 // Create new invitation as inviter to invitee
 app.get('/invitation', async (req, res) => {
-  const invitationUrl = await agent.createInvitationUrl();
+  const connection = await agent.createConnection();
+  const { invitation } = connection;
+
+  if (!invitation) {
+    throw new Error('There is no invitation in newly created connection!');
+  }
+
+  const invitationUrl = encodeInvitationToUrl(invitation);
   res.send(invitationUrl);
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,9 +1890,10 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indy-sdk@^1.10.1:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/indy-sdk/-/indy-sdk-1.12.0.tgz#ecfe0cda5719b619b9832c04bf586af2d0714875"
+indy-sdk@^1.14.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/indy-sdk/-/indy-sdk-1.15.0.tgz#1729a62771044da7eb1ded2b8ee2481fbf5b2b6d"
+  integrity sha512-NwOMl/hZzBdGNoeK/4dqbHMXEGVnI/Az/GyClDiAQZRcNWP9k0YAavSP0AHYjNp/rejY80vQrxP4NNALoa4MOw==
   dependencies:
     bindings "^1.3.1"
     nan "^2.11.1"


### PR DESCRIPTION
As a Developer, I want to get `connection` object when I generate or accept invitation to work with this instance right away and don't have to call `getConnections()` and search in all connections in agent instance. 

There are also more deletions than additions so it seems like a good approach.

We can also add some identifier (`id`) attribute, perhaps generated uuid, for every connection object as a next step.