### PR TITLE
Add connections persistence

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prettier": "prettier --ignore-path .gitignore '**/*.+(js|json|ts)'",
     "format": "yarn prettier --write",
     "check-format": "yarn prettier --list-different",
-    "test": "jest",
+    "test": "jest --verbose",
     "dev": "ts-node-dev --respawn --transpileOnly ./src/samples/agency.ts",
     "prod": "rm -rf build && yarn compile && DEBUG=aries-framework-javascript node ./build/samples/agency.js",
     "validate": "npm-run-all --parallel lint compile",

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -60,7 +60,7 @@ describe('agents', () => {
     }
 
     await bobConnectionAtBobAlice.isConnected();
-    console.log('bobConnectionAtAliceBob\n', bobConnectionAtBobAlice);
+    console.log('bobConnectionAtBobAlice\n', bobConnectionAtBobAlice);
 
     expect(aliceConnectionAtAliceBob).toBeConnectedWith(bobConnectionAtBobAlice);
     expect(bobConnectionAtBobAlice).toBeConnectedWith(aliceConnectionAtAliceBob);
@@ -74,15 +74,18 @@ describe('agents', () => {
     console.log('bobConnections', bobConnections);
 
     // send message from Alice to Bob
+    const lastAliceConnection = aliceConnections[aliceConnections.length - 1];
+    console.log('lastAliceConnection\n', lastAliceConnection);
+
     const message = 'hello, world';
-    await aliceAgent.sendMessageToConnection(aliceConnections[0], message);
+    await aliceAgent.sendMessageToConnection(lastAliceConnection, message);
 
     const bobMessages = await poll(
       async () => {
         console.log(`Getting Bob's messages from Alice...`);
         const messages = await bobAgent.basicMessageRepository.findByQuery({
-          from: aliceConnections[0].did,
-          to: aliceConnections[0].theirDid,
+          from: lastAliceConnection.did,
+          to: lastAliceConnection.theirDid,
         });
         return messages;
       },

--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -70,7 +70,7 @@ export class Agent {
     this.basicMessageRepository = new Repository<BasicMessageRecord>(BasicMessageRecord, storageService);
     this.connectionRepository = new Repository<ConnectionRecord>(ConnectionRecord, storageService);
 
-    this.connectionService = new ConnectionService(this.context);
+    this.connectionService = new ConnectionService(this.context, this.connectionRepository);
     this.basicMessageService = new BasicMessageService(this.basicMessageRepository);
     this.providerRoutingService = new ProviderRoutingService();
     this.consumerRoutingService = new ConsumerRoutingService(this.context);
@@ -133,12 +133,8 @@ export class Agent {
     return await this.messageReceiver.receiveMessage(inboundPackedMessage);
   }
 
-  getConnections() {
+  async getConnections() {
     return this.connectionService.getConnections();
-  }
-
-  findConnectionByMyKey(verkey: Verkey) {
-    return this.connectionService.findByVerkey(verkey);
   }
 
   findConnectionByTheirKey(verkey: Verkey) {

--- a/src/lib/handlers/basicmessage/BasicMessageHandler.ts
+++ b/src/lib/handlers/basicmessage/BasicMessageHandler.ts
@@ -14,7 +14,7 @@ export class BasicMessageHandler implements Handler {
 
   async handle(inboundMessage: InboundMessage) {
     const { recipient_verkey } = inboundMessage;
-    const connection = this.connectionService.findByVerkey(recipient_verkey);
+    const connection = await this.connectionService.findByVerkey(recipient_verkey);
 
     if (!connection) {
       throw new Error(`Connection for verkey ${recipient_verkey} not found!`);

--- a/src/lib/handlers/routing/RouteUpdateHandler.ts
+++ b/src/lib/handlers/routing/RouteUpdateHandler.ts
@@ -14,7 +14,7 @@ export class RouteUpdateHandler implements Handler {
 
   async handle(inboundMessage: InboundMessage) {
     const { recipient_verkey } = inboundMessage;
-    const connection = this.connectionService.findByVerkey(recipient_verkey);
+    const connection = await this.connectionService.findByVerkey(recipient_verkey);
 
     if (!connection) {
       throw new Error(`Connection for verkey ${recipient_verkey} not found!`);

--- a/src/lib/handlers/trustping/TrustPingMessageHandler.ts
+++ b/src/lib/handlers/trustping/TrustPingMessageHandler.ts
@@ -14,7 +14,7 @@ export class TrustPingMessageHandler implements Handler {
 
   async handle(inboundMessage: InboundMessage) {
     const { recipient_verkey } = inboundMessage;
-    const connection = this.connectionService.findByVerkey(recipient_verkey);
+    const connection = await this.connectionService.findByVerkey(recipient_verkey);
     if (!connection) {
       throw new Error(`Connection for receipient_verkey ${recipient_verkey} not found`);
     }

--- a/src/lib/protocols/connections/domain/Connection.ts
+++ b/src/lib/protocols/connections/domain/Connection.ts
@@ -1,9 +1,12 @@
+// @ts-ignore
+import { wait } from 'await-poll';
 import { EventEmitter } from 'events';
 import { ConnectionState } from './ConnectionState';
 import { DidDoc } from './DidDoc';
 import { InvitationDetails } from './InvitationDetails';
 
 export interface ConnectionProps {
+  id: string;
   did: Did;
   didDoc: DidDoc;
   verkey: Verkey;
@@ -20,6 +23,7 @@ interface DidExchangeConnection {
 }
 
 export class Connection extends EventEmitter {
+  id: string;
   did: Did;
   didDoc: DidDoc;
   verkey: Verkey;
@@ -32,6 +36,7 @@ export class Connection extends EventEmitter {
 
   constructor(props: ConnectionProps) {
     super();
+    this.id = props.id;
     this.did = props.did;
     this.didDoc = props.didDoc;
     this.verkey = props.verkey;
@@ -62,20 +67,10 @@ export class Connection extends EventEmitter {
     this.emit('change', newState);
   }
 
-  async hasState(state: ConnectionState) {
-    return new Promise(resolve => {
-      if (this.getState() == state) {
-        resolve(true);
-      }
-      this.on('change', (newState: number) => {
-        if (newState == state) {
-          resolve(true);
-        }
-      });
-    });
-  }
-
   async isConnected() {
-    return this.hasState(ConnectionState.COMPLETE);
+    while (this.state !== ConnectionState.COMPLETE) {
+      await wait(1000);
+    }
+    return true;
   }
 }

--- a/src/lib/storage/ConnectionRecord.ts
+++ b/src/lib/storage/ConnectionRecord.ts
@@ -3,10 +3,9 @@ import { ConnectionProps } from '../protocols/connections/domain/Connection';
 import { DidDoc } from '../protocols/connections/domain/DidDoc';
 import { InvitationDetails } from '../protocols/connections/domain/InvitationDetails';
 import { ConnectionState } from '../protocols/connections/domain/ConnectionState';
-import uuid from 'uuid/v4';
 
 export interface ConnectionStorageProps extends ConnectionProps {
-  id?: string;
+  id: string;
   tags: { [keys: string]: string };
 }
 
@@ -24,7 +23,7 @@ export class ConnectionRecord extends BaseRecord implements ConnectionStoragePro
   static type: RecordType = RecordType.ConnectionRecord;
 
   constructor(props: ConnectionStorageProps) {
-    super(props.id ? props.id : uuid());
+    super(props.id);
     this.did = props.did;
     this.didDoc = props.didDoc;
     this.verkey = props.verkey;


### PR DESCRIPTION
I'm adding persistence to connections. I don't see it as a final solution for 2 reasons, but let's put it there for the reference at least. These reasons are:

1. It still preserves the in-memory connections array. The reason is that we use connection object as emitter and when retrieving a connection from the database we're creating a new object and then a new instance of an event emitter, therefore there could be two instances of same connection with different listeners. So, I load all connections into an array (memory) and use only in-memory instances, but updating the database for every change. 

2. I feel there is to much duplication between `Connection`, `ConnectionRecord`,  `ConnectionProps` and `ConnectionStorageProps` objects. We won't probably have only one class, interface, but it would be good to minimize it.