### PR TITLE
add supported message types to handlers

### DIFF
--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -1,14 +1,9 @@
 import logger from '../logger';
 import { InitConfig } from '../types';
-import { encodeInvitationToUrl, decodeInvitationFromUrl } from '../helpers';
+import { decodeInvitationFromUrl } from '../helpers';
 import { IndyWallet } from '../wallet/IndyWallet';
 import { Connection } from '../protocols/connections/domain/Connection';
 import { ConnectionService } from '../protocols/connections/ConnectionService';
-import { MessageType as ConnectionsMessageType } from '../protocols/connections/messages';
-import { MessageType as BasicMessageMessageType } from '../protocols/basicmessage/messages';
-import { MessageType as RoutingMessageType } from '../protocols/routing/messages';
-import { MessageType as TrustPingMessageType } from '../protocols/trustping/messages';
-import { MessageType as MessagePickupType } from '../protocols/messagepickup/messages';
 import { ProviderRoutingService } from '../protocols/routing/ProviderRoutingService';
 import { BasicMessageService } from '../protocols/basicmessage/BasicMessageService';
 import { ConsumerRoutingService } from '../protocols/routing/ConsumerRoutingService';
@@ -49,7 +44,7 @@ export class Agent {
   consumerRoutingService: ConsumerRoutingService;
   trustPingService: TrustPingService;
   messagePickupService: MessagePickupService;
-  handlers: { [key: string]: Handler } = {};
+  handlers: Handler[] = [];
   basicMessageRepository: Repository<BasicMessageRecord>;
   connectionRepository: Repository<ConnectionRecord>;
 
@@ -205,27 +200,18 @@ export class Agent {
   }
 
   private registerHandlers() {
-    const handlers = {
-      [ConnectionsMessageType.ConnectionInvitation]: new InvitationHandler(
-        this.connectionService,
-        this.consumerRoutingService
-      ),
-      [ConnectionsMessageType.ConnectionRequest]: new ConnectionRequestHandler(this.connectionService),
-      [ConnectionsMessageType.ConnectionResposne]: new ConnectionResponseHandler(this.connectionService),
-      [ConnectionsMessageType.Ack]: new AckMessageHandler(this.connectionService),
-      [BasicMessageMessageType.BasicMessage]: new BasicMessageHandler(this.connectionService, this.basicMessageService),
-      [RoutingMessageType.RouteUpdateMessage]: new RouteUpdateHandler(
-        this.connectionService,
-        this.providerRoutingService
-      ),
-      [RoutingMessageType.ForwardMessage]: new ForwardHandler(this.providerRoutingService),
-      [TrustPingMessageType.TrustPingMessage]: new TrustPingMessageHandler(
-        this.trustPingService,
-        this.connectionService
-      ),
-      [TrustPingMessageType.TrustPingResponseMessage]: new TrustPingResponseMessageHandler(this.trustPingService),
-      [MessagePickupType.BatchPickup]: new MessagePickupHandler(this.connectionService, this.messagePickupService),
-    };
+    const handlers = [
+      new InvitationHandler(this.connectionService, this.consumerRoutingService),
+      new ConnectionRequestHandler(this.connectionService),
+      new ConnectionResponseHandler(this.connectionService),
+      new AckMessageHandler(this.connectionService),
+      new BasicMessageHandler(this.connectionService, this.basicMessageService),
+      new RouteUpdateHandler(this.connectionService, this.providerRoutingService),
+      new ForwardHandler(this.providerRoutingService),
+      new TrustPingMessageHandler(this.trustPingService, this.connectionService),
+      new TrustPingResponseMessageHandler(this.trustPingService),
+      new MessagePickupHandler(this.connectionService, this.messagePickupService),
+    ];
 
     this.handlers = handlers;
   }

--- a/src/lib/agent/Dispatcher.ts
+++ b/src/lib/agent/Dispatcher.ts
@@ -3,17 +3,17 @@ import { Handler } from '../handlers/Handler';
 import { MessageSender } from './MessageSender';
 
 class Dispatcher {
-  handlers: { [key: string]: Handler } = {};
+  handlers: Handler[];
   messageSender: MessageSender;
 
-  constructor(handlers: { [key: string]: Handler } = {}, messageSender: MessageSender) {
+  constructor(handlers: Handler[], messageSender: MessageSender) {
     this.handlers = handlers;
     this.messageSender = messageSender;
   }
 
   async dispatch(inboundMessage: any): Promise<OutboundMessage | OutboundPackage | null> {
     const messageType: string = inboundMessage.message['@type'];
-    const handler = this.handlers[messageType];
+    const handler = this.getHandlerForType(messageType);
 
     if (!handler) {
       throw new Error(`No handler for message type "${messageType}" found`);
@@ -27,6 +27,10 @@ class Dispatcher {
       await this.messageSender.sendMessage(outboundMessage);
     }
     return outboundMessage;
+  }
+
+  private getHandlerForType(messageType: string): Handler | undefined {
+    return this.handlers.find(handler => handler.supportedMessageTypes.includes(messageType));
   }
 }
 

--- a/src/lib/handlers/Handler.ts
+++ b/src/lib/handlers/Handler.ts
@@ -1,5 +1,7 @@
 import { InboundMessage, OutboundMessage } from '../types';
 
 export interface Handler {
-  handle(inboudMessage: InboundMessage): Promise<OutboundMessage | null>;
+  readonly supportedMessageTypes: string[];
+
+  handle(inboundMessage: InboundMessage): Promise<OutboundMessage | null>;
 }

--- a/src/lib/handlers/acks/AckMessageHandler.ts
+++ b/src/lib/handlers/acks/AckMessageHandler.ts
@@ -1,12 +1,17 @@
 import { InboundMessage } from '../../types';
 import { Handler } from '../Handler';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
+import { MessageType } from '../../protocols/connections/messages';
 
 export class AckMessageHandler implements Handler {
   connectionService: ConnectionService;
 
   constructor(connectionService: ConnectionService) {
     this.connectionService = connectionService;
+  }
+
+  get supportedMessageTypes(): [MessageType.Ack] {
+    return [MessageType.Ack];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/handlers/basicmessage/BasicMessageHandler.ts
+++ b/src/lib/handlers/basicmessage/BasicMessageHandler.ts
@@ -2,6 +2,7 @@ import { InboundMessage } from '../../types';
 import { Handler } from '../Handler';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
 import { BasicMessageService } from '../../protocols/basicmessage/BasicMessageService';
+import { MessageType } from '../../protocols/basicmessage/messages';
 
 export class BasicMessageHandler implements Handler {
   connectionService: ConnectionService;
@@ -10,6 +11,10 @@ export class BasicMessageHandler implements Handler {
   constructor(connectionService: ConnectionService, basicMessageService: BasicMessageService) {
     this.connectionService = connectionService;
     this.basicMessageService = basicMessageService;
+  }
+
+  get supportedMessageTypes(): [MessageType.BasicMessage] {
+    return [MessageType.BasicMessage];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/handlers/connections/ConnectionRequestHandler.ts
+++ b/src/lib/handlers/connections/ConnectionRequestHandler.ts
@@ -1,12 +1,17 @@
 import { InboundMessage } from '../../types';
 import { Handler } from '../Handler';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
+import { MessageType } from '../../protocols/connections/messages';
 
 export class ConnectionRequestHandler implements Handler {
   connectionService: ConnectionService;
 
   constructor(connectionService: ConnectionService) {
     this.connectionService = connectionService;
+  }
+
+  get supportedMessageTypes(): [MessageType.ConnectionRequest] {
+    return [MessageType.ConnectionRequest];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/handlers/connections/ConnectionResponseHandler.ts
+++ b/src/lib/handlers/connections/ConnectionResponseHandler.ts
@@ -1,12 +1,17 @@
 import { InboundMessage } from '../../types';
 import { Handler } from '../Handler';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
+import { MessageType } from '../../protocols/connections/messages';
 
 export class ConnectionResponseHandler implements Handler {
   connectionService: ConnectionService;
 
   constructor(connectionService: ConnectionService) {
     this.connectionService = connectionService;
+  }
+
+  get supportedMessageTypes(): [MessageType.ConnectionResponse] {
+    return [MessageType.ConnectionResponse];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/handlers/connections/InvitationHandler.ts
+++ b/src/lib/handlers/connections/InvitationHandler.ts
@@ -2,6 +2,7 @@ import { InboundMessage } from '../../types';
 import { Handler } from '../Handler';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
 import { ConsumerRoutingService } from '../../protocols/routing/ConsumerRoutingService';
+import { MessageType } from '../../protocols/connections/messages';
 
 export class InvitationHandler implements Handler {
   connectionService: ConnectionService;
@@ -10,6 +11,10 @@ export class InvitationHandler implements Handler {
   constructor(connectionService: ConnectionService, routingService: ConsumerRoutingService) {
     this.connectionService = connectionService;
     this.routingService = routingService;
+  }
+
+  get supportedMessageTypes(): [MessageType.ConnectionInvitation] {
+    return [MessageType.ConnectionInvitation];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/handlers/messagepickup/MessagePickupHandler.ts
+++ b/src/lib/handlers/messagepickup/MessagePickupHandler.ts
@@ -2,6 +2,7 @@ import { InboundMessage } from '../../types';
 import { Handler } from '../Handler';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
 import { MessagePickupService } from '../../protocols/messagepickup/MessagePickupService';
+import { MessageType } from '../../protocols/messagepickup/messages';
 
 export class MessagePickupHandler implements Handler {
   connectionService: ConnectionService;
@@ -10,6 +11,10 @@ export class MessagePickupHandler implements Handler {
   constructor(connectionService: ConnectionService, messagePickupService: MessagePickupService) {
     this.connectionService = connectionService;
     this.messagePickupService = messagePickupService;
+  }
+
+  get supportedMessageTypes(): [MessageType.BatchPickup] {
+    return [MessageType.BatchPickup];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/handlers/routing/ForwardHandler.ts
+++ b/src/lib/handlers/routing/ForwardHandler.ts
@@ -1,12 +1,17 @@
 import { InboundMessage } from '../../types';
 import { Handler } from '../Handler';
 import { ProviderRoutingService } from '../../protocols/routing/ProviderRoutingService';
+import { MessageType } from '../../protocols/routing/messages';
 
 export class ForwardHandler implements Handler {
   routingService: ProviderRoutingService;
 
   constructor(routingService: ProviderRoutingService) {
     this.routingService = routingService;
+  }
+
+  get supportedMessageTypes(): [MessageType.ForwardMessage] {
+    return [MessageType.ForwardMessage];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/handlers/routing/RouteUpdateHandler.ts
+++ b/src/lib/handlers/routing/RouteUpdateHandler.ts
@@ -2,6 +2,7 @@ import { InboundMessage } from '../../types';
 import { Handler } from '../Handler';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
 import { ProviderRoutingService } from '../../protocols/routing/ProviderRoutingService';
+import { MessageType } from '../../protocols/routing/messages';
 
 export class RouteUpdateHandler implements Handler {
   connectionService: ConnectionService;
@@ -10,6 +11,10 @@ export class RouteUpdateHandler implements Handler {
   constructor(connectionService: ConnectionService, routingService: ProviderRoutingService) {
     this.connectionService = connectionService;
     this.routingService = routingService;
+  }
+
+  get supportedMessageTypes(): [MessageType.RouteUpdateMessage] {
+    return [MessageType.RouteUpdateMessage];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/handlers/trustping/TrustPingMessageHandler.ts
+++ b/src/lib/handlers/trustping/TrustPingMessageHandler.ts
@@ -2,6 +2,7 @@ import { Handler } from '../Handler';
 import { InboundMessage } from '../../types';
 import { TrustPingService } from '../../protocols/trustping/TrustPingService';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
+import { MessageType } from '../../protocols/trustping/messages';
 
 export class TrustPingMessageHandler implements Handler {
   trustPingService: TrustPingService;
@@ -12,11 +13,15 @@ export class TrustPingMessageHandler implements Handler {
     this.connectionService = connectionService;
   }
 
+  get supportedMessageTypes(): [MessageType.TrustPingMessage] {
+    return [MessageType.TrustPingMessage];
+  }
+
   async handle(inboundMessage: InboundMessage) {
     const { recipient_verkey } = inboundMessage;
     const connection = await this.connectionService.findByVerkey(recipient_verkey);
     if (!connection) {
-      throw new Error(`Connection for receipient_verkey ${recipient_verkey} not found`);
+      throw new Error(`Connection for recipient_verkey ${recipient_verkey} not found`);
     }
     return this.trustPingService.processPing(inboundMessage, connection);
   }

--- a/src/lib/handlers/trustping/TrustPingResponseMessageHandler.ts
+++ b/src/lib/handlers/trustping/TrustPingResponseMessageHandler.ts
@@ -1,12 +1,17 @@
 import { Handler } from '../Handler';
 import { InboundMessage } from '../../types';
 import { TrustPingService } from '../../protocols/trustping/TrustPingService';
+import { MessageType } from '../../protocols/trustping/messages';
 
 export class TrustPingResponseMessageHandler implements Handler {
   trustPingService: TrustPingService;
 
   constructor(trustPingService: TrustPingService) {
     this.trustPingService = trustPingService;
+  }
+
+  get supportedMessageTypes(): [MessageType.TrustPingResponseMessage] {
+    return [MessageType.TrustPingResponseMessage];
   }
 
   async handle(inboundMessage: InboundMessage) {

--- a/src/lib/protocols/connections/messages.ts
+++ b/src/lib/protocols/connections/messages.ts
@@ -5,7 +5,7 @@ import { InvitationDetails } from './domain/InvitationDetails';
 export enum MessageType {
   ConnectionInvitation = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation',
   ConnectionRequest = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/request',
-  ConnectionResposne = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response',
+  ConnectionResponse = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response',
   Ack = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/notification/1.0/ack',
 }
 
@@ -39,7 +39,7 @@ export function createConnectionRequestMessage(connection: Connection, label: st
 
 export function createConnectionResponseMessage(connection: Connection, thid: string) {
   return {
-    '@type': MessageType.ConnectionResposne,
+    '@type': MessageType.ConnectionResponse,
     '@id': uuid(),
     '~thread': {
       thid,


### PR DESCRIPTION
This PR adds a `supportedMessageTypes` to the `Handler` interface that every handler must implement. Inspired by the .NET implementation.

Now the handler defines which message types it supports instead of declaring this in the agent. I think it fits better in the handler as the handler is coupled to which message types it support.

This also makes the agent class a bit smaller, and will help in the future with pluggable protocol handlers.