### PR TITLE
Extract methods from Agent to particular Module

### DIFF
--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -47,21 +47,25 @@ describe('agents', () => {
     bobAgent = new Agent(bobConfig, bobAgentInbound, bobAgentOutbound, indy);
     await bobAgent.init();
 
-    const aliceConnectionAtAliceBob = await aliceAgent.createConnection();
+    const aliceConnectionAtAliceBob = await aliceAgent.connections.createConnection();
     const { invitation } = aliceConnectionAtAliceBob;
 
     if (!invitation) {
       throw new Error('There is no invitation in newly created connection!');
     }
 
-    const bobConnectionAtBobAlice = await bobAgent.acceptInvitation(invitation);
+    const bobConnectionAtBobAlice = await bobAgent.connections.acceptInvitation(invitation);
 
-    const aliceConnectionRecordAtAliceBob = await aliceAgent.returnWhenIsConnected(aliceConnectionAtAliceBob.verkey);
+    const aliceConnectionRecordAtAliceBob = await aliceAgent.connections.returnWhenIsConnected(
+      aliceConnectionAtAliceBob.verkey
+    );
     if (!aliceConnectionRecordAtAliceBob) {
       throw new Error('Connection not found!');
     }
 
-    const bobConnectionRecordAtBobAlice = await bobAgent.returnWhenIsConnected(bobConnectionAtBobAlice.verkey);
+    const bobConnectionRecordAtBobAlice = await bobAgent.connections.returnWhenIsConnected(
+      bobConnectionAtBobAlice.verkey
+    );
     if (!bobConnectionRecordAtBobAlice) {
       throw new Error('Connection not found!');
     }
@@ -71,10 +75,10 @@ describe('agents', () => {
   });
 
   test('send a message to connection', async () => {
-    const aliceConnections = await aliceAgent.getConnections();
+    const aliceConnections = await aliceAgent.connections.getConnections();
     console.log('aliceConnections', aliceConnections);
 
-    const bobConnections = await bobAgent.getConnections();
+    const bobConnections = await bobAgent.connections.getConnections();
     console.log('bobConnections', bobConnections);
 
     // send message from Alice to Bob

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -75,10 +75,10 @@ describe('agents', () => {
   });
 
   test('send a message to connection', async () => {
-    const aliceConnections = await aliceAgent.connections.getConnections();
+    const aliceConnections = await aliceAgent.connections.getAll();
     console.log('aliceConnections', aliceConnections);
 
-    const bobConnections = await bobAgent.connections.getConnections();
+    const bobConnections = await bobAgent.connections.getAll();
     console.log('bobConnections', bobConnections);
 
     // send message from Alice to Bob
@@ -86,12 +86,12 @@ describe('agents', () => {
     console.log('lastAliceConnection\n', lastAliceConnection);
 
     const message = 'hello, world';
-    await aliceAgent.basicMessages.sendMessageToConnection(lastAliceConnection, message);
+    await aliceAgent.basicMessages.sendMessage(lastAliceConnection, message);
 
     const bobMessages = await poll(
       async () => {
         console.log(`Getting Bob's messages from Alice...`);
-        const messages = await bobAgent.basicMessageRepository.findByQuery({
+        const messages = await bobAgent.basicMessages.findAllByQuery({
           from: lastAliceConnection.did,
           to: lastAliceConnection.theirDid,
         });
@@ -99,8 +99,8 @@ describe('agents', () => {
       },
       (messages: WireMessage[]) => messages.length < 1
     );
-    console.log(bobMessages);
-    expect(bobMessages[0].content).toBe(message);
+    const lastMessage = bobMessages[bobMessages.length - 1];
+    expect(lastMessage.content).toBe(message);
   });
 });
 

--- a/src/lib/__tests__/agents.test.ts
+++ b/src/lib/__tests__/agents.test.ts
@@ -86,7 +86,7 @@ describe('agents', () => {
     console.log('lastAliceConnection\n', lastAliceConnection);
 
     const message = 'hello, world';
-    await aliceAgent.sendMessageToConnection(lastAliceConnection, message);
+    await aliceAgent.basicMessages.sendMessageToConnection(lastAliceConnection, message);
 
     const bobMessages = await poll(
       async () => {

--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'events';
 import logger from '../logger';
 import { InitConfig } from '../types';
 import { IndyWallet } from '../wallet/IndyWallet';
@@ -120,13 +119,6 @@ export class Agent {
   async closeAndDeleteWallet() {
     await this.wallet.close();
     await this.wallet.delete();
-  }
-
-  events(): { connections: EventEmitter; basicMessages: EventEmitter } {
-    return {
-      connections: this.connectionService,
-      basicMessages: this.basicMessageService,
-    };
   }
 
   private registerHandlers() {

--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -21,7 +21,6 @@ import { AckMessageHandler } from '../handlers/acks/AckMessageHandler';
 import { BasicMessageHandler } from '../handlers/basicmessage/BasicMessageHandler';
 import { RouteUpdateHandler } from '../handlers/routing/RouteUpdateHandler';
 import { ForwardHandler } from '../handlers/routing/ForwardHandler';
-import { Handler } from '../handlers/Handler';
 import { TrustPingMessageHandler } from '../handlers/trustping/TrustPingMessageHandler';
 import { TrustPingResponseMessageHandler } from '../handlers/trustping/TrustPingResponseMessageHandler';
 import { MessagePickupHandler } from '../handlers/messagepickup/MessagePickupHandler';
@@ -52,7 +51,6 @@ export class Agent {
   trustPingService: TrustPingService;
   messagePickupService: MessagePickupService;
   provisioningService: ProvisioninService;
-  handlers: Handler[] = [];
   basicMessageRepository: Repository<BasicMessageRecord>;
   connectionRepository: Repository<ConnectionRecord>;
   provisioningRepository: Repository<ProvisioningRecord>;

--- a/src/lib/agent/Dispatcher.ts
+++ b/src/lib/agent/Dispatcher.ts
@@ -3,12 +3,15 @@ import { Handler } from '../handlers/Handler';
 import { MessageSender } from './MessageSender';
 
 class Dispatcher {
-  handlers: Handler[];
+  handlers: Handler[] = [];
   messageSender: MessageSender;
 
-  constructor(handlers: Handler[], messageSender: MessageSender) {
-    this.handlers = handlers;
+  constructor(messageSender: MessageSender) {
     this.messageSender = messageSender;
+  }
+
+  registerHandler(handler: Handler) {
+    this.handlers.push(handler);
   }
 
   async dispatch(inboundMessage: any): Promise<OutboundMessage | OutboundPackage | null> {

--- a/src/lib/modules/BasicMessagesModule.ts
+++ b/src/lib/modules/BasicMessagesModule.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'events';
 import { BasicMessageService } from '../protocols/basicmessage/BasicMessageService';
 import { MessageSender } from '../agent/MessageSender';
 import { ConnectionRecord } from '../storage/ConnectionRecord';
@@ -18,5 +19,9 @@ export class BasicMessagesModule {
 
   async findAllByQuery(query: {}) {
     return this.basicMessageService.findAllByQuery(query);
+  }
+
+  events(): EventEmitter {
+    return this.basicMessageService;
   }
 }

--- a/src/lib/modules/BasicMessagesModule.ts
+++ b/src/lib/modules/BasicMessagesModule.ts
@@ -11,8 +11,12 @@ export class BasicMessagesModule {
     this.messageSender = messageSender;
   }
 
-  async sendMessageToConnection(connection: ConnectionRecord, message: string) {
+  async sendMessage(connection: ConnectionRecord, message: string) {
     const outboundMessage = await this.basicMessageService.send(message, connection);
     await this.messageSender.sendMessage(outboundMessage);
+  }
+
+  async findAllByQuery(query: {}) {
+    return this.basicMessageService.findAllByQuery(query);
   }
 }

--- a/src/lib/modules/BasicMessagesModule.ts
+++ b/src/lib/modules/BasicMessagesModule.ts
@@ -1,0 +1,18 @@
+import { BasicMessageService } from '../protocols/basicmessage/BasicMessageService';
+import { MessageSender } from '../agent/MessageSender';
+import { ConnectionRecord } from '../storage/ConnectionRecord';
+
+export class BasicMessagesModule {
+  basicMessageService: BasicMessageService;
+  messageSender: MessageSender;
+
+  constructor(basicMessageService: BasicMessageService, messageSender: MessageSender) {
+    this.basicMessageService = basicMessageService;
+    this.messageSender = messageSender;
+  }
+
+  async sendMessageToConnection(connection: ConnectionRecord, message: string) {
+    const outboundMessage = await this.basicMessageService.send(message, connection);
+    await this.messageSender.sendMessage(outboundMessage);
+  }
+}

--- a/src/lib/modules/ConnectionsModule.ts
+++ b/src/lib/modules/ConnectionsModule.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import { poll } from 'await-poll';
+import { EventEmitter } from 'events';
 import { AgentConfig } from '../agent/AgentConfig';
 import { ConnectionService } from '../protocols/connections/ConnectionService';
 import { ConsumerRoutingService } from '../protocols/routing/ConsumerRoutingService';
@@ -75,5 +76,9 @@ export class ConnectionsModule {
 
   async findConnectionByTheirKey(verkey: Verkey) {
     return this.connectionService.findByTheirKey(verkey);
+  }
+
+  events(): EventEmitter {
+    return this.connectionService;
   }
 }

--- a/src/lib/modules/ConnectionsModule.ts
+++ b/src/lib/modules/ConnectionsModule.ts
@@ -65,7 +65,7 @@ export class ConnectionsModule {
     return connectionRecord;
   }
 
-  async getConnections() {
+  async getAll() {
     return this.connectionService.getConnections();
   }
 

--- a/src/lib/modules/ConnectionsModule.ts
+++ b/src/lib/modules/ConnectionsModule.ts
@@ -1,0 +1,79 @@
+// @ts-ignore
+import { poll } from 'await-poll';
+import { AgentConfig } from '../agent/AgentConfig';
+import { ConnectionService } from '../protocols/connections/ConnectionService';
+import { ConsumerRoutingService } from '../protocols/routing/ConsumerRoutingService';
+import { MessageReceiver } from '../agent/MessageReceiver';
+import { ConnectionRecord } from '../storage/ConnectionRecord';
+import { ConnectionState } from '../protocols/connections/domain/ConnectionState';
+
+export class ConnectionsModule {
+  agentConfig: AgentConfig;
+  connectionService: ConnectionService;
+  consumerRoutingService: ConsumerRoutingService;
+  messageReceiver: MessageReceiver;
+
+  constructor(
+    agentConfig: AgentConfig,
+    connectionService: ConnectionService,
+    consumerRoutingService: ConsumerRoutingService,
+    messageReceiver: MessageReceiver
+  ) {
+    this.agentConfig = agentConfig;
+    this.connectionService = connectionService;
+    this.consumerRoutingService = consumerRoutingService;
+    this.messageReceiver = messageReceiver;
+  }
+
+  async createConnection() {
+    const connection = await this.connectionService.createConnectionWithInvitation();
+    const { invitation } = connection;
+
+    if (!invitation) {
+      throw new Error('Connection has no invitation assigned.');
+    }
+
+    // If agent has inbound connection, which means it's using agency, we need to create a route for newly created
+    // connection verkey at agency.
+    if (this.agentConfig.inboundConnection) {
+      this.consumerRoutingService.createRoute(connection.verkey);
+    }
+
+    return connection;
+  }
+
+  async acceptInvitation(invitation: any) {
+    const connection = (await this.messageReceiver.receiveMessage(invitation))?.connection;
+
+    if (!connection) {
+      throw new Error('No connection returned from receiveMessage');
+    }
+
+    if (!connection.verkey) {
+      throw new Error('No verkey in connection returned from receiveMessage');
+    }
+
+    return connection;
+  }
+
+  async returnWhenIsConnected(verkey: Verkey) {
+    const connectionRecord = await poll(
+      () => this.findConnectionByVerkey(verkey),
+      (c: ConnectionRecord) => c.state !== ConnectionState.COMPLETE,
+      100
+    );
+    return connectionRecord;
+  }
+
+  async getConnections() {
+    return this.connectionService.getConnections();
+  }
+
+  async findConnectionByVerkey(verkey: Verkey) {
+    return this.connectionService.findByVerkey(verkey);
+  }
+
+  async findConnectionByTheirKey(verkey: Verkey) {
+    return this.connectionService.findByTheirKey(verkey);
+  }
+}

--- a/src/lib/modules/RoutingModule.ts
+++ b/src/lib/modules/RoutingModule.ts
@@ -1,0 +1,101 @@
+import { AgentConfig } from '../agent/AgentConfig';
+import { ProvisioninService } from '../agent/ProvisioningService';
+import { ConnectionService } from '../protocols/connections/ConnectionService';
+import { MessagePickupService } from '../protocols/messagepickup/MessagePickupService';
+import { MessageSender } from '../agent/MessageSender';
+import { ConnectionState } from '../protocols/connections/domain/ConnectionState';
+import { decodeInvitationFromUrl } from '../helpers';
+import logger from '../logger';
+import { ProviderRoutingService } from '../protocols/routing/ProviderRoutingService';
+
+export class RoutingModule {
+  agentConfig: AgentConfig;
+  providerRoutingService: ProviderRoutingService;
+  provisioningService: ProvisioninService;
+  messagePickupService: MessagePickupService;
+  connectionService: ConnectionService;
+  messageSender: MessageSender;
+
+  constructor(
+    agentConfig: AgentConfig,
+    providerRoutingService: ProviderRoutingService,
+    provisioningService: ProvisioninService,
+    messagePickupService: MessagePickupService,
+    connectionService: ConnectionService,
+    messageSender: MessageSender
+  ) {
+    this.agentConfig = agentConfig;
+    this.providerRoutingService = providerRoutingService;
+    this.provisioningService = provisioningService;
+    this.messagePickupService = messagePickupService;
+    this.connectionService = connectionService;
+    this.messageSender = messageSender;
+  }
+
+  async provision(agencyConfiguration: AgencyConfiguration) {
+    let provisioningRecord = await this.provisioningService.find();
+
+    if (!provisioningRecord) {
+      logger.log('There is no provisioning. Creating connection with agency...');
+      const { verkey, invitationUrl } = agencyConfiguration;
+      const agencyInvitation = decodeInvitationFromUrl(invitationUrl);
+
+      const connectionRequest = await this.connectionService.acceptInvitation(agencyInvitation);
+      const connectionResponse = await this.messageSender.sendAndReceiveMessage(connectionRequest);
+      const ack = await this.connectionService.acceptResponse(connectionResponse);
+      await this.messageSender.sendMessage(ack);
+
+      const provisioningProps = {
+        agencyConnectionVerkey: connectionRequest.connection.verkey,
+        agencyPublicVerkey: verkey,
+      };
+      provisioningRecord = await this.provisioningService.create(provisioningProps);
+      logger.log('Provisioning record has been saved.');
+    }
+
+    logger.log('Provisioning record:', provisioningRecord);
+
+    const agentConnectionAtAgency = await this.connectionService.findByVerkey(
+      provisioningRecord.agencyConnectionVerkey
+    );
+
+    if (!agentConnectionAtAgency) {
+      throw new Error('Connection not found!');
+    }
+    logger.log('agentConnectionAtAgency', agentConnectionAtAgency);
+
+    if (agentConnectionAtAgency.state !== ConnectionState.COMPLETE) {
+      throw new Error('Connection has not been established.');
+    }
+
+    this.agentConfig.establishInbound({
+      verkey: provisioningRecord.agencyPublicVerkey,
+      connection: agentConnectionAtAgency,
+    });
+
+    return agentConnectionAtAgency;
+  }
+
+  async downloadMessages() {
+    const inboundConnection = this.getInboundConnection();
+    if (inboundConnection) {
+      const outboundMessage = await this.messagePickupService.batchPickup(inboundConnection);
+      const batchMessage = await this.messageSender.sendAndReceiveMessage(outboundMessage);
+      return batchMessage.message.messages;
+    }
+    return [];
+  }
+
+  getInboundConnection() {
+    return this.agentConfig.inboundConnection;
+  }
+
+  getRoutes() {
+    return this.providerRoutingService.getRoutes();
+  }
+}
+
+interface AgencyConfiguration {
+  verkey: Verkey;
+  invitationUrl: string;
+}

--- a/src/lib/modules/RoutingModule.ts
+++ b/src/lib/modules/RoutingModule.ts
@@ -90,7 +90,7 @@ export class RoutingModule {
     return this.agentConfig.inboundConnection;
   }
 
-  getRoutes() {
+  getRoutingTable() {
     return this.providerRoutingService.getRoutes();
   }
 }

--- a/src/lib/protocols/basicmessage/BasicMessageService.ts
+++ b/src/lib/protocols/basicmessage/BasicMessageService.ts
@@ -44,6 +44,10 @@ class BasicMessageService extends EventEmitter {
     this.emit(EventType.MessageReceived, { verkey: connection.verkey, message });
     return null;
   }
+
+  async findAllByQuery(query: {}) {
+    return this.basicMessageRepository.findByQuery(query);
+  }
 }
 
 export { BasicMessageService, EventType };

--- a/src/samples/__tests__/e2e.test.ts
+++ b/src/samples/__tests__/e2e.test.ts
@@ -53,12 +53,12 @@ describe('with agency', () => {
     bobAgent = new Agent(bobConfig, bobAgentReceiver, bobAgentSender, indy);
     await bobAgent.init();
 
-    const aliceInbound = aliceAgent.getInboundConnection();
+    const aliceInbound = aliceAgent.routing.getInboundConnection();
     const aliceInboundConnection = aliceInbound && aliceInbound.connection;
     const aliceKeyAtAliceAgency = aliceInboundConnection && aliceInboundConnection.verkey;
     console.log('aliceInboundConnection', aliceInboundConnection);
 
-    const bobInbound = bobAgent.getInboundConnection();
+    const bobInbound = bobAgent.routing.getInboundConnection();
     const bobInboundConnection = bobInbound && bobInbound.connection;
     const bobKeyAtBobAgency = bobInboundConnection && bobInboundConnection.verkey;
     console.log('bobInboundConnection', bobInboundConnection);
@@ -153,14 +153,14 @@ class PollingInboundTransporter implements InboundTransporter {
     const agencyUrl = agent.getAgencyUrl() || '';
     const agencyInvitationUrl = await get(`${agencyUrl}/invitation`);
     const { verkey: agencyVerkey } = JSON.parse(await get(`${agencyUrl}/`));
-    await agent.provision({ verkey: agencyVerkey, invitationUrl: agencyInvitationUrl });
+    await agent.routing.provision({ verkey: agencyVerkey, invitationUrl: agencyInvitationUrl });
     this.pollDownloadMessages(agent);
   }
 
   pollDownloadMessages(agent: Agent) {
     poll(
       async () => {
-        const downloadedMessages = await agent.downloadMessages();
+        const downloadedMessages = await agent.routing.downloadMessages();
         const messages = [...downloadedMessages];
         console.log('downloaded messges', messages);
         while (messages && messages.length > 0) {

--- a/src/samples/__tests__/e2e.test.ts
+++ b/src/samples/__tests__/e2e.test.ts
@@ -119,12 +119,12 @@ describe('with agency', () => {
     console.log('aliceConnectionAtAliceBob\n', aliceConnectionAtAliceBob);
 
     const message = 'hello, world';
-    await aliceAgent.basicMessages.sendMessageToConnection(aliceConnectionAtAliceBob, message);
+    await aliceAgent.basicMessages.sendMessage(aliceConnectionAtAliceBob, message);
 
     const bobMessages = await poll(
       async () => {
         console.log(`Getting Bob's messages from Alice...`);
-        const messages = await bobAgent.basicMessageRepository.findByQuery({
+        const messages = await bobAgent.basicMessages.findAllByQuery({
           from: aliceConnectionAtAliceBob.did,
           to: aliceConnectionAtAliceBob.theirDid,
         });
@@ -133,7 +133,6 @@ describe('with agency', () => {
       (messages: WireMessage[]) => messages.length < 1,
       1000
     );
-    console.log(bobMessages);
     const lastMessage = bobMessages[bobMessages.length - 1];
     expect(lastMessage.content).toBe(message);
   });

--- a/src/samples/__tests__/e2e.test.ts
+++ b/src/samples/__tests__/e2e.test.ts
@@ -119,7 +119,7 @@ describe('with agency', () => {
     console.log('aliceConnectionAtAliceBob\n', aliceConnectionAtAliceBob);
 
     const message = 'hello, world';
-    await aliceAgent.sendMessageToConnection(aliceConnectionAtAliceBob, message);
+    await aliceAgent.basicMessages.sendMessageToConnection(aliceConnectionAtAliceBob, message);
 
     const bobMessages = await poll(
       async () => {

--- a/src/samples/__tests__/e2e.test.ts
+++ b/src/samples/__tests__/e2e.test.ts
@@ -79,21 +79,25 @@ describe('with agency', () => {
   });
 
   test('Alice and Bob make a connection via agency', async () => {
-    const aliceConnectionAtAliceBob = await aliceAgent.createConnection();
+    const aliceConnectionAtAliceBob = await aliceAgent.connections.createConnection();
     const { invitation } = aliceConnectionAtAliceBob;
 
     if (!invitation) {
       throw new Error('There is no invitation in newly created connection!');
     }
 
-    const bobConnectionAtBobAlice = await bobAgent.acceptInvitation(invitation);
+    const bobConnectionAtBobAlice = await bobAgent.connections.acceptInvitation(invitation);
 
-    const aliceConnectionRecordAtAliceBob = await aliceAgent.returnWhenIsConnected(aliceConnectionAtAliceBob.verkey);
+    const aliceConnectionRecordAtAliceBob = await aliceAgent.connections.returnWhenIsConnected(
+      aliceConnectionAtAliceBob.verkey
+    );
     if (!aliceConnectionRecordAtAliceBob) {
       throw new Error('Connection not found!');
     }
 
-    const bobConnectionRecordAtBobAlice = await bobAgent.returnWhenIsConnected(bobConnectionAtBobAlice.verkey);
+    const bobConnectionRecordAtBobAlice = await bobAgent.connections.returnWhenIsConnected(
+      bobConnectionAtBobAlice.verkey
+    );
     if (!bobConnectionRecordAtBobAlice) {
       throw new Error('Connection not found!');
     }
@@ -107,7 +111,7 @@ describe('with agency', () => {
 
   test('Send a message from Alice to Bob via agency', async () => {
     // send message from Alice to Bob
-    const aliceConnectionAtAliceBob = await aliceAgent.findConnectionByVerkey(aliceAtAliceBobVerkey);
+    const aliceConnectionAtAliceBob = await aliceAgent.connections.findConnectionByVerkey(aliceAtAliceBobVerkey);
     if (!aliceConnectionAtAliceBob) {
       throw new Error(`There is no connection for verkey ${aliceAtAliceBobVerkey}`);
     }

--- a/src/samples/agency.ts
+++ b/src/samples/agency.ts
@@ -103,7 +103,7 @@ app.get('/api/connections', async (req, res) => {
 
 app.get('/api/routes', async (req, res) => {
   // TODO This endpoint is for testing purpose only. Return agency connection by their verkey.
-  const routes = agent.getRoutes();
+  const routes = agent.routing.getRoutes();
   res.send(routes);
 });
 

--- a/src/samples/agency.ts
+++ b/src/samples/agency.ts
@@ -77,7 +77,7 @@ app.get('/', async (req, res) => {
 
 // Create new invitation as inviter to invitee
 app.get('/invitation', async (req, res) => {
-  const connection = await agent.createConnection();
+  const connection = await agent.connections.createConnection();
   const { invitation } = connection;
 
   if (!invitation) {
@@ -91,13 +91,13 @@ app.get('/invitation', async (req, res) => {
 app.get('/api/connections/:verkey', async (req, res) => {
   // TODO This endpoint is for testing purpose only. Return agency connection by their verkey.
   const verkey = req.params.verkey;
-  const connection = await agent.findConnectionByTheirKey(verkey);
+  const connection = await agent.connections.findConnectionByTheirKey(verkey);
   res.send(connection);
 });
 
 app.get('/api/connections', async (req, res) => {
   // TODO This endpoint is for testing purpose only. Return agency connection by their verkey.
-  const connections = await agent.getConnections();
+  const connections = await agent.connections.getConnections();
   res.json(connections);
 });
 

--- a/src/samples/agency.ts
+++ b/src/samples/agency.ts
@@ -97,13 +97,13 @@ app.get('/api/connections/:verkey', async (req, res) => {
 
 app.get('/api/connections', async (req, res) => {
   // TODO This endpoint is for testing purpose only. Return agency connection by their verkey.
-  const connections = await agent.connections.getConnections();
+  const connections = await agent.connections.getAll();
   res.json(connections);
 });
 
 app.get('/api/routes', async (req, res) => {
   // TODO This endpoint is for testing purpose only. Return agency connection by their verkey.
-  const routes = agent.routing.getRoutes();
+  const routes = agent.routing.getRoutingTable();
   res.send(routes);
 });
 


### PR DESCRIPTION
I'm extracting some methods from the Agent class to particular modules. These modules are currently more like Facade but could eventually evolve to standalone modules, consuming services, encapsulate handlers, providing services. I don't see it as necessary to go this direction right now. 

Modules also work as a public framework API, available via Agent object properties:
- `connections`
- `routing`
- `basicMessages`

