### PR TITLE
replace inbound message with message context

### DIFF
--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -72,7 +72,6 @@ export class Agent {
     this.agentConfig = new AgentConfig(initialConfig);
     this.messageSender = new MessageSender(envelopeService, outboundTransporter);
     this.dispatcher = new Dispatcher(this.messageSender);
-    this.messageReceiver = new MessageReceiver(this.agentConfig, envelopeService, this.dispatcher);
     this.inboundTransporter = inboundTransporter;
 
     const storageService = new IndyStorageService(this.wallet);
@@ -87,6 +86,13 @@ export class Agent {
     this.consumerRoutingService = new ConsumerRoutingService(this.messageSender, this.agentConfig);
     this.trustPingService = new TrustPingService();
     this.messagePickupService = new MessagePickupService(messageRepository);
+
+    this.messageReceiver = new MessageReceiver(
+      this.agentConfig,
+      envelopeService,
+      this.connectionService,
+      this.dispatcher
+    );
 
     this.registerHandlers();
     this.registerModules();

--- a/src/lib/agent/Dispatcher.ts
+++ b/src/lib/agent/Dispatcher.ts
@@ -40,7 +40,7 @@ class Dispatcher {
     return outboundMessage || undefined;
   }
 
-  public getHandlerForType(messageType: string): Handler | undefined {
+  private getHandlerForType(messageType: string): Handler | undefined {
     for (const handler of this.handlers) {
       for (const MessageClass of handler.supportedMessages) {
         if (MessageClass.type === messageType) return handler;

--- a/src/lib/agent/Dispatcher.ts
+++ b/src/lib/agent/Dispatcher.ts
@@ -2,7 +2,7 @@ import { OutboundMessage, OutboundPackage } from '../types';
 import { Handler } from '../handlers/Handler';
 import { MessageSender } from './MessageSender';
 import { AgentMessage } from './AgentMessage';
-import { MessageContext } from './models/MessageContext';
+import { InboundMessageContext } from './models/InboundMessageContext';
 
 class Dispatcher {
   handlers: Handler[] = [];
@@ -16,7 +16,7 @@ class Dispatcher {
     this.handlers.push(handler);
   }
 
-  async dispatch(messageContext: MessageContext): Promise<OutboundMessage | OutboundPackage | undefined> {
+  async dispatch(messageContext: InboundMessageContext): Promise<OutboundMessage | OutboundPackage | undefined> {
     const message = messageContext.message;
     const handler = this.getHandlerForType(message.type);
 

--- a/src/lib/agent/MessageReceiver.ts
+++ b/src/lib/agent/MessageReceiver.ts
@@ -4,7 +4,7 @@ import { Dispatcher } from './Dispatcher';
 import { EnvelopeService } from './EnvelopeService';
 import { UnpackedMessage } from '../types';
 import { MessageType } from '../protocols/routing/messages';
-import { MessageContext } from './models/MessageContext';
+import { InboundMessageContext } from './models/InboundMessageContext';
 import { ConnectionService } from '../protocols/connections/ConnectionService';
 import { AgentMessage } from './AgentMessage';
 import { MessageTransformer } from './MessageTransformer';

--- a/src/lib/agent/MessageReceiver.ts
+++ b/src/lib/agent/MessageReceiver.ts
@@ -4,37 +4,90 @@ import { Dispatcher } from './Dispatcher';
 import { EnvelopeService } from './EnvelopeService';
 import { UnpackedMessage } from '../types';
 import { MessageType } from '../protocols/routing/messages';
+import { MessageContext } from './models/MessageContext';
+import { ConnectionService } from '../protocols/connections/ConnectionService';
+import { AgentMessage } from './AgentMessage';
+import { MessageTransformer } from './MessageTransformer';
 
 class MessageReceiver {
   config: AgentConfig;
   envelopeService: EnvelopeService;
+  connectionService: ConnectionService;
   dispatcher: Dispatcher;
 
-  constructor(config: AgentConfig, envelopeService: EnvelopeService, dispatcher: Dispatcher) {
+  constructor(
+    config: AgentConfig,
+    envelopeService: EnvelopeService,
+    connectionService: ConnectionService,
+    dispatcher: Dispatcher
+  ) {
     this.config = config;
     this.envelopeService = envelopeService;
+    this.connectionService = connectionService;
     this.dispatcher = dispatcher;
   }
 
-  async receiveMessage(inboundPackedMessage: any) {
+  /**
+   * Receive and handle an inbound DIDComm message. It will unpack the message, transform it
+   * to it's corresponding message class and finaly dispatch it to the dispatcher.
+   *
+   * @param inboundPackedMessage the message to receive and handle
+   */
+  public async receiveMessage(inboundPackedMessage: any) {
     logger.logJson(`Agent ${this.config.label} received message:`, inboundPackedMessage);
-    let inboundMessage;
 
+    const unpackedMessage = await this.unpackMessage(inboundPackedMessage);
+
+    logger.logJson('inboundMessage', unpackedMessage);
+
+    const message = await this.transformMessage(unpackedMessage);
+    let senderKey = unpackedMessage.sender_verkey;
+    let connection = undefined;
+    if (senderKey && unpackedMessage.recipient_verkey) {
+      connection = (await this.connectionService.findByVerkey(unpackedMessage.recipient_verkey)) || undefined;
+
+      // we validate the sender key if it is the one we have the connection with
+      // otherwise everyone could send message for our key, and we would just accept
+      // it as if it was send by the connection.
+      // TODO: does this correctly work for the connection process? Keys can be swapped during the protocol
+      if (connection && connection.theirKey != null && connection.theirKey != senderKey) {
+        throw new Error(
+          `Inbound message 'sender_key' ${senderKey} is different from connection.theirKey ${connection.theirKey}`
+        );
+      }
+    }
+
+    const messageContext = new MessageContext(message, {
+      connection,
+      senderVerkey: senderKey,
+      recipientVerkey: unpackedMessage.recipient_verkey,
+    });
+
+    return await this.dispatcher.dispatch(messageContext);
+  }
+
+  /**
+   * Unpack a message using the envelope service. Will perform extra unpacking steps for forward messages.
+   * If message is not packed, it will be returned as is, but in the unpacked message structure
+   *
+   * @param packedMessage the received, probably packed, message to unpack
+   */
+  private async unpackMessage(packedMessage: any): Promise<UnpackedMessage> {
     // If the inbound message has no @type field we assume
     // the message is packed and must be unpacked first
-    if (!inboundPackedMessage['@type']) {
+    if (!packedMessage['@type']) {
       // TODO: handle when the unpacking fails. At the moment this will throw a cryptic
       // indy-sdk error. Eventually we should create a problem report message
-      inboundMessage = await this.envelopeService.unpackMessage(inboundPackedMessage);
+      let unpackedMessage = await this.envelopeService.unpackMessage(packedMessage);
 
       // if the message is of type forward we should check whether the
       //  - forward message is intended for us (so unpack inner `msg` and pass that to dispatcher)
       //  - or that the message should be forwarded (pass unpacked forward message with packed `msg` to dispatcher)
-      if (inboundMessage.message['@type'] === MessageType.ForwardMessage) {
-        logger.logJson('Forwarded message', inboundMessage);
+      if (unpackedMessage.message['@type'] === MessageType.ForwardMessage) {
+        logger.logJson('Forwarded message', unpackedMessage);
 
         try {
-          inboundMessage = await this.envelopeService.unpackMessage(inboundMessage.message.msg);
+          unpackedMessage = await this.envelopeService.unpackMessage(unpackedMessage.message.msg);
         } catch {
           // To check whether the `to` field is a key belonging to us could be done in two ways.
           // We now just try to unpack, if it errors it means we don't have the key to unpack the message
@@ -44,19 +97,34 @@ class MessageReceiver {
           // It is thus okay to silently ignore this error
         }
       }
+
+      return unpackedMessage;
     }
     // If the message does have an @type field we assume
     // the message is already unpacked an use it directly
     else {
-      inboundMessage = { message: inboundPackedMessage };
+      const unpackedMessage: UnpackedMessage = { message: packedMessage };
+      return unpackedMessage;
+    }
+  }
+
+  /**
+   * Transform an unpacked DIDComm message into it's corresponding message class. Will look at all message types in the registered handlers.
+   *
+   * @param unpackedMessage the unpacked message for which to transform the message in to a class instance
+   */
+  private async transformMessage(unpackedMessage: UnpackedMessage): Promise<AgentMessage> {
+    const messageType = unpackedMessage.message['@type'];
+    const MessageClass = this.dispatcher.getMessageClassForType(messageType);
+
+    if (!MessageClass) {
+      throw new Error(`No message class for message type "${messageType}" found`);
     }
 
-    logger.logJson('inboundMessage', inboundMessage);
+    // Cast the plain JSON object to specific instance of Message extended from AgentMessage
+    const message = MessageTransformer.toMessageInstance(unpackedMessage.message, MessageClass);
 
-    // TODO: dispatcher expects UnpackedMessage type
-    // however the type can also be { message: inboundPackedMessage }
-    // when we receive an already unpacked message
-    return await this.dispatcher.dispatch(inboundMessage as UnpackedMessage);
+    return message;
   }
 }
 

--- a/src/lib/agent/MessageSender.ts
+++ b/src/lib/agent/MessageSender.ts
@@ -5,7 +5,7 @@ import { ReturnRouteTypes } from '../decorators/transport/TransportDecorator';
 import { MessageTransformer } from './MessageTransformer';
 import { AgentMessage } from './AgentMessage';
 import { Constructor } from '../utils/mixins';
-import { MessageContext } from './models/MessageContext';
+import { InboundMessageContext } from './models/InboundMessageContext';
 
 class MessageSender {
   envelopeService: EnvelopeService;
@@ -28,7 +28,7 @@ class MessageSender {
   async sendAndReceiveMessage<T extends AgentMessage>(
     outboundMessage: OutboundMessage,
     ReceivedMessageClass: Constructor<T>
-  ): Promise<MessageContext<T>> {
+  ): Promise<InboundMessageContext<T>> {
     outboundMessage.payload.setReturnRouting(ReturnRouteTypes.all);
 
     const outboundPackage = await this.envelopeService.packMessage(outboundMessage);
@@ -37,7 +37,7 @@ class MessageSender {
 
     const message = MessageTransformer.toMessageInstance(inboundUnpackedMessage.message, ReceivedMessageClass);
 
-    const messageContext = new MessageContext(message, {
+    const messageContext = new InboundMessageContext(message, {
       connection: outboundMessage.connection,
       recipientVerkey: inboundUnpackedMessage.recipient_verkey,
       senderVerkey: inboundUnpackedMessage.sender_verkey,

--- a/src/lib/agent/MessageSender.ts
+++ b/src/lib/agent/MessageSender.ts
@@ -1,10 +1,11 @@
-import { OutboundMessage, OutboundPackage, InboundMessage } from '../types';
+import { OutboundMessage, OutboundPackage } from '../types';
 import { OutboundTransporter } from '../transport/OutboundTransporter';
 import { EnvelopeService } from './EnvelopeService';
 import { ReturnRouteTypes } from '../decorators/transport/TransportDecorator';
 import { MessageTransformer } from './MessageTransformer';
 import { AgentMessage } from './AgentMessage';
 import { Constructor } from '../utils/mixins';
+import { MessageContext } from './models/MessageContext';
 
 class MessageSender {
   envelopeService: EnvelopeService;
@@ -27,7 +28,7 @@ class MessageSender {
   async sendAndReceiveMessage<T extends AgentMessage>(
     outboundMessage: OutboundMessage,
     ReceivedMessageClass: Constructor<T>
-  ): Promise<InboundMessage<T>> {
+  ): Promise<MessageContext<T>> {
     outboundMessage.payload.setReturnRouting(ReturnRouteTypes.all);
 
     const outboundPackage = await this.envelopeService.packMessage(outboundMessage);
@@ -35,7 +36,14 @@ class MessageSender {
     const inboundUnpackedMessage = await this.envelopeService.unpackMessage(inboundPackedMessage);
 
     const message = MessageTransformer.toMessageInstance(inboundUnpackedMessage.message, ReceivedMessageClass);
-    return { ...inboundUnpackedMessage, message };
+
+    const messageContext = new MessageContext(message, {
+      connection: outboundMessage.connection,
+      recipientVerkey: inboundUnpackedMessage.recipient_verkey,
+      senderVerkey: inboundUnpackedMessage.sender_verkey,
+    });
+
+    return messageContext;
   }
 }
 

--- a/src/lib/agent/models/InboundMessageContext.ts
+++ b/src/lib/agent/models/InboundMessageContext.ts
@@ -7,7 +7,7 @@ export interface MessageContextParams {
   recipientVerkey?: Verkey;
 }
 
-export class MessageContext<T extends AgentMessage = AgentMessage> {
+export class InboundMessageContext<T extends AgentMessage = AgentMessage> {
   message: T;
   connection?: ConnectionRecord;
   senderVerkey?: Verkey;

--- a/src/lib/agent/models/MessageContext.ts
+++ b/src/lib/agent/models/MessageContext.ts
@@ -1,0 +1,29 @@
+import { AgentMessage } from '../AgentMessage';
+import { ConnectionRecord } from '../../storage/ConnectionRecord';
+
+export interface MessageContextParams {
+  connection?: ConnectionRecord;
+  senderVerkey?: Verkey;
+  recipientVerkey?: Verkey;
+}
+
+export class MessageContext<T extends AgentMessage = AgentMessage> {
+  message: T;
+  connection?: ConnectionRecord;
+  senderVerkey?: Verkey;
+  recipientVerkey?: Verkey;
+
+  constructor(message: T, context: MessageContextParams = {}) {
+    this.message = message;
+    this.recipientVerkey = context.recipientVerkey;
+
+    if (context.connection) {
+      this.connection = context.connection;
+      // TODO: which senderkey should we prioritize
+      // Or should we throw an error when they don't match?
+      this.senderVerkey = context.connection.theirKey || context.senderVerkey || undefined;
+    } else if (context.senderVerkey) {
+      this.senderVerkey = context.senderVerkey;
+    }
+  }
+}

--- a/src/lib/handlers/Handler.ts
+++ b/src/lib/handlers/Handler.ts
@@ -1,17 +1,18 @@
-import { InboundMessage, OutboundMessage } from '../types';
+import { OutboundMessage } from '../types';
 import { AgentMessage } from '../agent/AgentMessage';
+import { MessageContext } from '../agent/models/MessageContext';
 
 export interface Handler<T extends typeof AgentMessage = typeof AgentMessage> {
   readonly supportedMessages: readonly T[];
 
-  handle(inboundMessage: InboundMessage): Promise<OutboundMessage | void>;
+  handle(messageContext: MessageContext): Promise<OutboundMessage | void>;
 }
 
 /**
- * Provides exact typing for the AgentMessage in the inbound message in the `handle` function
+ * Provides exact typing for the AgentMessage in the message context in the `handle` function
  * of a handler. It takes all possible types from `supportedMessageTypes`
  *
  * @example
- * async handle(inboundMessage: HandlerInboundMessage<BasicMessageHandler>) {}
+ * async handle(messageContext: HandlerInboundMessage<BasicMessageHandler>) {}
  */
-export type HandlerInboundMessage<H extends Handler> = InboundMessage<InstanceType<H['supportedMessages'][number]>>;
+export type HandlerInboundMessage<H extends Handler> = MessageContext<InstanceType<H['supportedMessages'][number]>>;

--- a/src/lib/handlers/Handler.ts
+++ b/src/lib/handlers/Handler.ts
@@ -1,11 +1,11 @@
 import { OutboundMessage } from '../types';
 import { AgentMessage } from '../agent/AgentMessage';
-import { MessageContext } from '../agent/models/MessageContext';
+import { InboundMessageContext } from '../agent/models/InboundMessageContext';
 
 export interface Handler<T extends typeof AgentMessage = typeof AgentMessage> {
   readonly supportedMessages: readonly T[];
 
-  handle(messageContext: MessageContext): Promise<OutboundMessage | void>;
+  handle(messageContext: InboundMessageContext): Promise<OutboundMessage | void>;
 }
 
 /**
@@ -15,4 +15,6 @@ export interface Handler<T extends typeof AgentMessage = typeof AgentMessage> {
  * @example
  * async handle(messageContext: HandlerInboundMessage<BasicMessageHandler>) {}
  */
-export type HandlerInboundMessage<H extends Handler> = MessageContext<InstanceType<H['supportedMessages'][number]>>;
+export type HandlerInboundMessage<H extends Handler> = InboundMessageContext<
+  InstanceType<H['supportedMessages'][number]>
+>;

--- a/src/lib/handlers/basicmessage/BasicMessageHandler.ts
+++ b/src/lib/handlers/basicmessage/BasicMessageHandler.ts
@@ -13,18 +13,17 @@ export class BasicMessageHandler implements Handler {
     this.basicMessageService = basicMessageService;
   }
 
-  async handle(inboundMessage: HandlerInboundMessage<BasicMessageHandler>) {
-    const { recipient_verkey } = inboundMessage;
-    const connection = await this.connectionService.findByVerkey(recipient_verkey);
+  async handle(messageContext: HandlerInboundMessage<BasicMessageHandler>) {
+    const connection = messageContext.connection;
 
     if (!connection) {
-      throw new Error(`Connection for verkey ${recipient_verkey} not found!`);
+      throw new Error(`Connection for verkey ${messageContext.recipientVerkey} not found!`);
     }
 
     if (!connection.theirKey) {
       throw new Error(`Connection with verkey ${connection.verkey} has no recipient keys.`);
     }
 
-    await this.basicMessageService.save(inboundMessage, connection);
+    await this.basicMessageService.save(messageContext, connection);
   }
 }

--- a/src/lib/handlers/connections/ConnectionRequestHandler.ts
+++ b/src/lib/handlers/connections/ConnectionRequestHandler.ts
@@ -10,8 +10,8 @@ export class ConnectionRequestHandler implements Handler {
     this.connectionService = connectionService;
   }
 
-  async handle(inboundMessage: HandlerInboundMessage<ConnectionRequestHandler>) {
-    const outboudMessage = await this.connectionService.acceptRequest(inboundMessage);
+  async handle(messageContext: HandlerInboundMessage<ConnectionRequestHandler>) {
+    const outboudMessage = await this.connectionService.acceptRequest(messageContext);
     return outboudMessage;
   }
 }

--- a/src/lib/handlers/coordinatemediation/KeylistUpdateHandler.ts
+++ b/src/lib/handlers/coordinatemediation/KeylistUpdateHandler.ts
@@ -13,14 +13,11 @@ export class KeylistUpdateHandler implements Handler {
     this.routingService = routingService;
   }
 
-  async handle(inboundMessage: HandlerInboundMessage<KeylistUpdateHandler>) {
-    const { recipient_verkey } = inboundMessage;
-    const connection = await this.connectionService.findByVerkey(recipient_verkey);
-
-    if (!connection) {
-      throw new Error(`Connection for verkey ${recipient_verkey} not found!`);
+  async handle(messageContext: HandlerInboundMessage<KeylistUpdateHandler>) {
+    if (!messageContext.connection) {
+      throw new Error(`Connection for verkey ${messageContext.recipientVerkey} not found!`);
     }
 
-    this.routingService.updateRoutes(inboundMessage, connection);
+    this.routingService.updateRoutes(messageContext, messageContext.connection);
   }
 }

--- a/src/lib/handlers/messagepickup/MessagePickupHandler.ts
+++ b/src/lib/handlers/messagepickup/MessagePickupHandler.ts
@@ -13,15 +13,11 @@ export class MessagePickupHandler implements Handler {
     this.messagePickupService = messagePickupService;
   }
 
-  async handle(inboundMessage: HandlerInboundMessage<MessagePickupHandler>) {
-    const { recipient_verkey } = inboundMessage;
-    const connection = await this.connectionService.findByVerkey(recipient_verkey);
-
-    if (!connection) {
-      throw new Error(`Connection for verkey ${recipient_verkey} not found!`);
+  async handle(messageContext: HandlerInboundMessage<MessagePickupHandler>) {
+    if (!messageContext.connection) {
+      throw new Error(`Connection for verkey ${messageContext.recipientVerkey} not found!`);
     }
 
-    const outboundMessage = this.messagePickupService.batch(connection);
-    return outboundMessage;
+    return this.messagePickupService.batch(messageContext.connection);
   }
 }

--- a/src/lib/handlers/routing/ForwardHandler.ts
+++ b/src/lib/handlers/routing/ForwardHandler.ts
@@ -10,8 +10,7 @@ export class ForwardHandler implements Handler {
     this.routingService = routingService;
   }
 
-  async handle(inboundMessage: HandlerInboundMessage<ForwardHandler>) {
-    const outboundMessage = this.routingService.forward(inboundMessage);
-    return outboundMessage;
+  async handle(messageContext: HandlerInboundMessage<ForwardHandler>) {
+    return this.routingService.forward(messageContext);
   }
 }

--- a/src/lib/handlers/trustping/TrustPingMessageHandler.ts
+++ b/src/lib/handlers/trustping/TrustPingMessageHandler.ts
@@ -14,18 +14,16 @@ export class TrustPingMessageHandler implements Handler {
     this.connectionService = connectionService;
   }
 
-  async handle(inboundMessage: HandlerInboundMessage<TrustPingMessageHandler>) {
-    const { recipient_verkey } = inboundMessage;
-    const connectionRecord = await this.connectionService.findByVerkey(recipient_verkey);
-
-    if (!connectionRecord) {
-      throw new Error(`Connection for recipient_verkey ${recipient_verkey} not found`);
+  async handle(messageContext: HandlerInboundMessage<TrustPingMessageHandler>) {
+    const { connection, recipientVerkey } = messageContext;
+    if (!connection) {
+      throw new Error(`Connection for verkey ${recipientVerkey} not found!`);
     }
 
-    if (connectionRecord.state != ConnectionState.COMPLETE) {
-      await this.connectionService.updateState(connectionRecord, ConnectionState.COMPLETE);
+    if (connection.state != ConnectionState.COMPLETE) {
+      await this.connectionService.updateState(connection, ConnectionState.COMPLETE);
     }
 
-    return this.trustPingService.processPing(inboundMessage, connectionRecord);
+    return this.trustPingService.processPing(messageContext, connection);
   }
 }

--- a/src/lib/modules/RoutingModule.ts
+++ b/src/lib/modules/RoutingModule.ts
@@ -85,10 +85,10 @@ export class RoutingModule {
     const inboundConnection = this.getInboundConnection();
     if (inboundConnection) {
       const outboundMessage = await this.messagePickupService.batchPickup(inboundConnection);
-      const batchMessage = await this.messageSender.sendAndReceiveMessage(outboundMessage, BatchMessage);
+      const batchResponse = await this.messageSender.sendAndReceiveMessage(outboundMessage, BatchMessage);
 
       // TODO: do something about the different types of message variable all having a different purpose
-      return batchMessage.message.messages.map(msg => msg.message);
+      return batchResponse.message.messages.map(msg => msg.message);
     }
     return [];
   }

--- a/src/lib/protocols/basicmessage/BasicMessageService.test.ts
+++ b/src/lib/protocols/basicmessage/BasicMessageService.test.ts
@@ -8,6 +8,7 @@ import { IndyStorageService } from '../../storage/IndyStorageService';
 import { BasicMessageService, EventType } from './BasicMessageService';
 import { BasicMessageRecord } from '../../storage/BasicMessageRecord';
 import { BasicMessage } from './BasicMessage';
+import { MessageContext } from '../../agent/models/MessageContext';
 
 describe('BasicMessageService', () => {
   const walletConfig = { id: 'test-wallet' + '-BasicMessageServiceTest' };
@@ -52,21 +53,20 @@ describe('BasicMessageService', () => {
         content: 'message',
       });
 
-      const message = {
-        message: basicMessage,
-        sender_verkey: 'senderKey',
-        recipient_verkey: 'recipientKey',
-      };
+      const messageContext = new MessageContext(basicMessage, {
+        senderVerkey: 'senderKey',
+        recipientVerkey: 'recipientKey',
+      });
 
       // TODO
       // Currently, it's not so easy to create instance of ConnectionRecord object.
       // We use simple `mockConnectionRecord` as any type
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await basicMessageService.save(message, mockConnectionRecord as any);
+      await basicMessageService.save(messageContext, mockConnectionRecord as any);
 
       expect(eventListenerMock).toHaveBeenCalledWith({
         verkey: mockConnectionRecord.verkey,
-        message: message.message,
+        message: messageContext.message,
       });
     });
   });

--- a/src/lib/protocols/basicmessage/BasicMessageService.test.ts
+++ b/src/lib/protocols/basicmessage/BasicMessageService.test.ts
@@ -8,7 +8,7 @@ import { IndyStorageService } from '../../storage/IndyStorageService';
 import { BasicMessageService, EventType } from './BasicMessageService';
 import { BasicMessageRecord } from '../../storage/BasicMessageRecord';
 import { BasicMessage } from './BasicMessage';
-import { MessageContext } from '../../agent/models/MessageContext';
+import { InboundMessageContext } from '../../agent/models/InboundMessageContext';
 
 describe('BasicMessageService', () => {
   const walletConfig = { id: 'test-wallet' + '-BasicMessageServiceTest' };
@@ -53,7 +53,7 @@ describe('BasicMessageService', () => {
         content: 'message',
       });
 
-      const messageContext = new MessageContext(basicMessage, {
+      const messageContext = new InboundMessageContext(basicMessage, {
         senderVerkey: 'senderKey',
         recipientVerkey: 'recipientKey',
       });

--- a/src/lib/protocols/basicmessage/BasicMessageService.ts
+++ b/src/lib/protocols/basicmessage/BasicMessageService.ts
@@ -5,7 +5,7 @@ import { Repository } from '../../storage/Repository';
 import { BasicMessageRecord } from '../../storage/BasicMessageRecord';
 import { ConnectionRecord } from '../../storage/ConnectionRecord';
 import { BasicMessage } from './BasicMessage';
-import { MessageContext } from '../../agent/models/MessageContext';
+import { InboundMessageContext } from '../../agent/models/InboundMessageContext';
 
 enum EventType {
   MessageReceived = 'messageReceived',
@@ -38,7 +38,7 @@ class BasicMessageService extends EventEmitter {
   /**
    * @todo use connection from message context
    */
-  async save({ message }: MessageContext<BasicMessage>, connection: ConnectionRecord) {
+  async save({ message }: InboundMessageContext<BasicMessage>, connection: ConnectionRecord) {
     const basicMessageRecord = new BasicMessageRecord({
       id: message.id,
       sent_time: message.sentTime.toISOString(),

--- a/src/lib/protocols/basicmessage/BasicMessageService.ts
+++ b/src/lib/protocols/basicmessage/BasicMessageService.ts
@@ -1,10 +1,11 @@
 import { EventEmitter } from 'events';
-import { InboundMessage, OutboundMessage } from '../../types';
+import { OutboundMessage } from '../../types';
 import { createOutboundMessage } from '../helpers';
 import { Repository } from '../../storage/Repository';
 import { BasicMessageRecord } from '../../storage/BasicMessageRecord';
 import { ConnectionRecord } from '../../storage/ConnectionRecord';
 import { BasicMessage } from './BasicMessage';
+import { MessageContext } from '../../agent/models/MessageContext';
 
 enum EventType {
   MessageReceived = 'messageReceived',
@@ -34,7 +35,10 @@ class BasicMessageService extends EventEmitter {
     return createOutboundMessage(connection, basicMessage);
   }
 
-  async save({ message }: InboundMessage<BasicMessage>, connection: ConnectionRecord) {
+  /**
+   * @todo use connection from message context
+   */
+  async save({ message }: MessageContext<BasicMessage>, connection: ConnectionRecord) {
     const basicMessageRecord = new BasicMessageRecord({
       id: message.id,
       sent_time: message.sentTime.toISOString(),

--- a/src/lib/protocols/connections/ConnectionService.ts
+++ b/src/lib/protocols/connections/ConnectionService.ts
@@ -1,6 +1,6 @@
 import uuid from 'uuid';
 import { EventEmitter } from 'events';
-import { InboundMessage, OutboundMessage } from '../../types';
+import { OutboundMessage } from '../../types';
 import { AgentConfig } from '../../agent/AgentConfig';
 import { createOutboundMessage } from '../helpers';
 import { ConnectionState } from './domain/ConnectionState';
@@ -17,6 +17,7 @@ import { Connection } from './domain/Connection';
 import { classToPlain, plainToClass } from 'class-transformer';
 import { validateOrReject } from 'class-validator';
 import { AckMessage } from './AckMessage';
+import { MessageContext } from '../../agent/models/MessageContext';
 
 enum EventType {
   StateChanged = 'stateChanged',
@@ -63,21 +64,20 @@ class ConnectionService extends EventEmitter {
   }
 
   async acceptRequest(
-    inboundMessage: InboundMessage<ConnectionRequestMessage>
+    messageContext: MessageContext<ConnectionRequestMessage>
   ): Promise<OutboundMessage<ConnectionResponseMessage>> {
-    const { message, recipient_verkey } = inboundMessage;
-    const connectionRecord = await this.findByVerkey(recipient_verkey);
+    const { message, connection: connectionRecord, recipientVerkey } = messageContext;
 
     if (!connectionRecord) {
-      throw new Error(`Connection for verkey ${recipient_verkey} not found!`);
+      throw new Error(`Connection for verkey ${recipientVerkey} not found!`);
     }
 
+    // TODO: validate using class-validator
     if (!message.connection) {
       throw new Error('Invalid message');
     }
 
-    const requestConnection = message.connection;
-    connectionRecord.updateDidExchangeConnection(requestConnection);
+    connectionRecord.updateDidExchangeConnection(message.connection);
 
     if (!connectionRecord.theirKey) {
       throw new Error(`Connection with verkey ${connectionRecord.verkey} has no recipient keys.`);
@@ -89,6 +89,8 @@ class ConnectionService extends EventEmitter {
       did: connectionRecord.did,
       didDoc: connectionRecord.didDoc,
     });
+
+    // TODO: find a better way that directly calling classToPlain here
     const plainConnection = classToPlain(connection);
 
     const connectionResponse = new ConnectionResponseMessage({
@@ -100,12 +102,11 @@ class ConnectionService extends EventEmitter {
     return createOutboundMessage(connectionRecord, connectionResponse);
   }
 
-  async acceptResponse(inboundMessage: InboundMessage<ConnectionResponseMessage>) {
-    const { message, recipient_verkey } = inboundMessage;
-    const connectionRecord = await this.findByVerkey(recipient_verkey);
+  async acceptResponse(messageContext: MessageContext<ConnectionResponseMessage>) {
+    const { message, connection: connectionRecord, recipientVerkey } = messageContext;
 
     if (!connectionRecord) {
-      throw new Error(`Connection for verkey ${recipient_verkey} not found!`);
+      throw new Error(`Connection for verkey ${recipientVerkey} not found!`);
     }
 
     const connectionJson = await unpackAndVerifySignatureDecorator(message.connectionSig, this.wallet);
@@ -128,18 +129,15 @@ class ConnectionService extends EventEmitter {
     return createOutboundMessage(connectionRecord, response);
   }
 
-  async acceptAck(inboundMessage: InboundMessage<AckMessage>) {
-    const { recipient_verkey, sender_verkey } = inboundMessage;
-    const connectionRecord = await this.findByVerkey(recipient_verkey);
+  async acceptAck(messageContext: MessageContext<AckMessage>) {
+    const connection = messageContext.connection;
 
-    if (!connectionRecord) {
-      throw new Error(`Connection for verkey ${recipient_verkey} not found!`);
+    if (!connection) {
+      throw new Error(`Connection for ${messageContext.recipientVerkey} not found!`);
     }
 
-    validateSenderKey(connectionRecord, sender_verkey);
-
-    if (connectionRecord.state !== ConnectionState.COMPLETE) {
-      await this.updateState(connectionRecord, ConnectionState.COMPLETE);
+    if (connection.state !== ConnectionState.COMPLETE) {
+      await this.updateState(connection, ConnectionState.COMPLETE);
     }
   }
 
@@ -182,12 +180,21 @@ class ConnectionService extends EventEmitter {
     return this.connectionRepository.findAll();
   }
 
-  async findByVerkey(verkey: Verkey) {
+  async findByVerkey(verkey: Verkey): Promise<ConnectionRecord | null> {
     const connectionRecords = await this.connectionRepository.findByQuery({ verkey });
-    return connectionRecords[0];
+
+    if (connectionRecords.length > 1) {
+      throw new Error(`There is more than one connection for given verkey ${verkey}`);
+    }
+
+    if (connectionRecords.length < 1) {
+      return null;
+    }
+
+    return connectionRecords.length > 0 ? connectionRecords[0] : null;
   }
 
-  async findByTheirKey(verkey: Verkey) {
+  async findByTheirKey(verkey: Verkey): Promise<ConnectionRecord | null> {
     const connectionRecords = await this.connectionRepository.findByQuery({ theirKey: verkey });
 
     if (connectionRecords.length > 1) {

--- a/src/lib/protocols/connections/ConnectionService.ts
+++ b/src/lib/protocols/connections/ConnectionService.ts
@@ -121,9 +121,6 @@ class ConnectionService extends EventEmitter {
 
     connectionRecord.tags = { ...connectionRecord.tags, theirKey: connectionRecord.theirKey };
 
-    // dotnet doesn't send senderVk here
-    // validateSenderKey(connection, sender_verkey);
-
     const response = new TrustPingMessage();
     await this.updateState(connectionRecord, ConnectionState.COMPLETE);
     return createOutboundMessage(connectionRecord, response);
@@ -216,22 +213,6 @@ class ConnectionService extends EventEmitter {
       serviceEndpoint: didDoc.service[0].serviceEndpoint,
       routingKeys: didDoc.service[0].routingKeys,
     };
-  }
-}
-
-function validateSenderKey(connection: ConnectionRecord, senderKey: Verkey) {
-  // TODO I have 2 questions
-
-  // 1. I don't know whether following check is necessary. I guess it is, but we should validate this condition
-  // for every other protocol. I also don't validate it `acceptRequest` because there is no `senderVk` in invitation
-  // (which could be also a bug and against protocol starndard)
-
-  // 2. I don't know whether to use `connection.theirKey` or `sender_verkey` for outbound message.
-
-  if (connection.theirKey !== senderKey) {
-    throw new Error(
-      `Inbound message 'sender_key' ${senderKey} is different from connection.theirKey ${connection.theirKey}`
-    );
   }
 }
 

--- a/src/lib/protocols/connections/ConnectionService.ts
+++ b/src/lib/protocols/connections/ConnectionService.ts
@@ -17,7 +17,7 @@ import { Connection } from './domain/Connection';
 import { classToPlain, plainToClass } from 'class-transformer';
 import { validateOrReject } from 'class-validator';
 import { AckMessage } from './AckMessage';
-import { MessageContext } from '../../agent/models/MessageContext';
+import { InboundMessageContext } from '../../agent/models/InboundMessageContext';
 
 enum EventType {
   StateChanged = 'stateChanged',
@@ -64,7 +64,7 @@ class ConnectionService extends EventEmitter {
   }
 
   async acceptRequest(
-    messageContext: MessageContext<ConnectionRequestMessage>
+    messageContext: InboundMessageContext<ConnectionRequestMessage>
   ): Promise<OutboundMessage<ConnectionResponseMessage>> {
     const { message, connection: connectionRecord, recipientVerkey } = messageContext;
 
@@ -102,7 +102,7 @@ class ConnectionService extends EventEmitter {
     return createOutboundMessage(connectionRecord, connectionResponse);
   }
 
-  async acceptResponse(messageContext: MessageContext<ConnectionResponseMessage>) {
+  async acceptResponse(messageContext: InboundMessageContext<ConnectionResponseMessage>) {
     const { message, connection: connectionRecord, recipientVerkey } = messageContext;
 
     if (!connectionRecord) {
@@ -129,7 +129,7 @@ class ConnectionService extends EventEmitter {
     return createOutboundMessage(connectionRecord, response);
   }
 
-  async acceptAck(messageContext: MessageContext<AckMessage>) {
+  async acceptAck(messageContext: InboundMessageContext<AckMessage>) {
     const connection = messageContext.connection;
 
     if (!connection) {

--- a/src/lib/protocols/messagepickup/MessagePickupService.ts
+++ b/src/lib/protocols/messagepickup/MessagePickupService.ts
@@ -29,7 +29,7 @@ export class MessagePickupService {
       throw new Error('Trying to find messages to connection without theirKey!');
     }
 
-    const messages = await this.messageRepository.findByVerkey(connection.theirKey);
+    const messages = this.messageRepository.findByVerkey(connection.theirKey);
     // TODO: each message should be stored with an id. to be able to conform to the id property
     // of batch message
     const batchMessages = messages.map(
@@ -43,7 +43,7 @@ export class MessagePickupService {
       messages: batchMessages,
     });
 
-    await this.messageRepository.deleteAllByVerkey(connection.theirKey); // TODO Maybe, don't delete, but just marked them as read
+    this.messageRepository.deleteAllByVerkey(connection.theirKey); // TODO Maybe, don't delete, but just marked them as read
     return createOutboundMessage(connection, batchMessage);
   }
 }

--- a/src/lib/protocols/messagepickup/MessagePickupService.ts
+++ b/src/lib/protocols/messagepickup/MessagePickupService.ts
@@ -43,7 +43,7 @@ export class MessagePickupService {
       messages: batchMessages,
     });
 
-    this.messageRepository.deleteAllByVerkey(connection.theirKey); // TODO Maybe, don't delete, but just marked them as read
+    await this.messageRepository.deleteAllByVerkey(connection.theirKey); // TODO Maybe, don't delete, but just marked them as read
     return createOutboundMessage(connection, batchMessage);
   }
 }

--- a/src/lib/protocols/routing/ProviderRoutingService.ts
+++ b/src/lib/protocols/routing/ProviderRoutingService.ts
@@ -1,14 +1,18 @@
-import { InboundMessage, OutboundMessage } from '../../types';
+import { OutboundMessage } from '../../types';
 import { createOutboundMessage } from '../helpers';
 import { ConnectionRecord } from '../../storage/ConnectionRecord';
 import { KeylistUpdateMessage, KeylistUpdateAction } from '../coordinatemediation/KeylistUpdateMessage';
 import { ForwardMessage } from './ForwardMessage';
+import { MessageContext } from '../../agent/models/MessageContext';
 
 class ProviderRoutingService {
   routingTable: { [recipientKey: string]: ConnectionRecord | undefined } = {};
 
-  updateRoutes(inboundMessage: InboundMessage<KeylistUpdateMessage>, connection: ConnectionRecord) {
-    const { message } = inboundMessage;
+  /**
+   * @todo use connection from message context
+   */
+  updateRoutes(messageContext: MessageContext<KeylistUpdateMessage>, connection: ConnectionRecord) {
+    const { message } = messageContext;
 
     for (const update of message.updates) {
       switch (update.action) {
@@ -22,8 +26,8 @@ class ProviderRoutingService {
     }
   }
 
-  forward(inboundMessage: InboundMessage<ForwardMessage>): OutboundMessage<ForwardMessage> {
-    const { message, recipient_verkey } = inboundMessage;
+  forward(messageContext: MessageContext<ForwardMessage>): OutboundMessage<ForwardMessage> {
+    const { message, recipientVerkey } = messageContext;
 
     // TODO: update to class-validator validation
     if (!message.to) {
@@ -33,7 +37,7 @@ class ProviderRoutingService {
     const connection = this.findRecipient(message.to);
 
     if (!connection) {
-      throw new Error(`Connection for verkey ${recipient_verkey} not found!`);
+      throw new Error(`Connection for verkey ${recipientVerkey} not found!`);
     }
 
     if (!connection.theirKey) {

--- a/src/lib/protocols/routing/ProviderRoutingService.ts
+++ b/src/lib/protocols/routing/ProviderRoutingService.ts
@@ -3,7 +3,7 @@ import { createOutboundMessage } from '../helpers';
 import { ConnectionRecord } from '../../storage/ConnectionRecord';
 import { KeylistUpdateMessage, KeylistUpdateAction } from '../coordinatemediation/KeylistUpdateMessage';
 import { ForwardMessage } from './ForwardMessage';
-import { MessageContext } from '../../agent/models/MessageContext';
+import { InboundMessageContext } from '../../agent/models/InboundMessageContext';
 
 class ProviderRoutingService {
   routingTable: { [recipientKey: string]: ConnectionRecord | undefined } = {};
@@ -11,7 +11,7 @@ class ProviderRoutingService {
   /**
    * @todo use connection from message context
    */
-  updateRoutes(messageContext: MessageContext<KeylistUpdateMessage>, connection: ConnectionRecord) {
+  updateRoutes(messageContext: InboundMessageContext<KeylistUpdateMessage>, connection: ConnectionRecord) {
     const { message } = messageContext;
 
     for (const update of message.updates) {
@@ -26,7 +26,7 @@ class ProviderRoutingService {
     }
   }
 
-  forward(messageContext: MessageContext<ForwardMessage>): OutboundMessage<ForwardMessage> {
+  forward(messageContext: InboundMessageContext<ForwardMessage>): OutboundMessage<ForwardMessage> {
     const { message, recipientVerkey } = messageContext;
 
     // TODO: update to class-validator validation

--- a/src/lib/protocols/trustping/TrustPingService.ts
+++ b/src/lib/protocols/trustping/TrustPingService.ts
@@ -2,13 +2,13 @@ import { createOutboundMessage } from '../helpers';
 import { ConnectionRecord } from '../../storage/ConnectionRecord';
 import { TrustPingMessage } from './TrustPingMessage';
 import { TrustPingResponseMessage } from './TrustPingResponseMessage';
-import { MessageContext } from '../../agent/models/MessageContext';
+import { InboundMessageContext } from '../../agent/models/InboundMessageContext';
 
 /**
  * @todo use connection from message context
  */
 export class TrustPingService {
-  processPing({ message }: MessageContext<TrustPingMessage>, connection: ConnectionRecord) {
+  processPing({ message }: InboundMessageContext<TrustPingMessage>, connection: ConnectionRecord) {
     if (message.responseRequested) {
       const response = new TrustPingResponseMessage({
         threadId: message.id,
@@ -19,5 +19,5 @@ export class TrustPingService {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  processPingResponse(messageContext: MessageContext<TrustPingResponseMessage>) {}
+  processPingResponse(messageContext: InboundMessageContext<TrustPingResponseMessage>) {}
 }

--- a/src/lib/protocols/trustping/TrustPingService.ts
+++ b/src/lib/protocols/trustping/TrustPingService.ts
@@ -1,11 +1,14 @@
-import { InboundMessage } from '../../types';
 import { createOutboundMessage } from '../helpers';
 import { ConnectionRecord } from '../../storage/ConnectionRecord';
 import { TrustPingMessage } from './TrustPingMessage';
 import { TrustPingResponseMessage } from './TrustPingResponseMessage';
+import { MessageContext } from '../../agent/models/MessageContext';
 
+/**
+ * @todo use connection from message context
+ */
 export class TrustPingService {
-  processPing({ message }: InboundMessage<TrustPingMessage>, connection: ConnectionRecord) {
+  processPing({ message }: MessageContext<TrustPingMessage>, connection: ConnectionRecord) {
     if (message.responseRequested) {
       const response = new TrustPingResponseMessage({
         threadId: message.id,
@@ -16,5 +19,5 @@ export class TrustPingService {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  processPingResponse(inboundMessage: InboundMessage<TrustPingResponseMessage>) {}
+  processPingResponse(messageContext: MessageContext<TrustPingResponseMessage>) {}
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -17,22 +17,13 @@ export interface InitConfig {
   walletCredentials: WalletCredentials;
 }
 
-export interface Message {
-  '@id': string;
-  '@type': string;
-  [key: string]: any;
-}
-
 export interface UnpackedMessage {
-  message: any;
-  sender_verkey: Verkey; // TODO make it optional
-  recipient_verkey: Verkey; // TODO make it optional
-}
-
-export interface InboundMessage<T extends AgentMessage = AgentMessage> {
-  message: T;
-  sender_verkey: Verkey; // TODO make it optional
-  recipient_verkey: Verkey; // TODO make it optional
+  message: {
+    '@type': string;
+    [key: string]: any;
+  };
+  sender_verkey?: Verkey;
+  recipient_verkey?: Verkey;
 }
 
 export interface OutboundMessage<T extends AgentMessage = AgentMessage> {


### PR DESCRIPTION
adds a message context class that is populated after a message is received. If found, it attaches the connection record associated with the message to the context.

I started to work on replacing the verkey with connection_id (which we apparently already have?, but is not used everywhere) but felt this could help avoid repetitive patterns of each handler retrieving the connection associated with the message.

Signed-off-by: Timo Glastra <timo@animo.id>