### PR TITLE
improve docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,37 +1,16 @@
-# Note that the indy-sdk requires ubuntu 16 and some custom dependencies so we can't use node:carbon-apline like the others
-FROM ubuntu:18.04 as base
+FROM animosolutions/indy-nodejs:1.15.0 as base
 
-# Grab dependencies via apt-get
-RUN apt-get update && \
-      apt-get install -y \
-      software-properties-common \
-      apt-transport-https \
-      curl \
-      build-essential \
-      python2.7 \
-      python-pip
+WORKDIR /www
+ENV RUN_MODE="docker"
 
-# Setup nodejs
-RUN curl -sL https://deb.nodesource.com/setup_8.x | bash && \
-    apt-get install nodejs -y
+COPY package.json package.json
+COPY yarn.lock yarn.lock
 
-ARG libindy_ver=1.14.0
-# Recommended way to get setup with libindy: https://github.com/hyperledger/indy-sdk#ubuntu-based-distributions-ubuntu-1604
-ARG indy_stream=stable
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 68DB5E88 && \
-    add-apt-repository "deb https://repo.sovrin.org/sdk/deb xenial $indy_stream" && \
-    apt-get update && \
-    apt-get install -y libindy=${libindy_ver}
+# Run install after copying only depdendency file
+# to make use of docker layer caching
+RUN yarn install
 
-# Setup our server
-RUN mkdir www/
-WORKDIR www/
-ADD package.json ./
-ADD . .
+# Copy other depdencies
+COPY . . 
 
-# setup yarn
-RUN curl -o- -L https://yarnpkg.com/install.sh | bash
-RUN cp -R $HOME/.yarn/bin .
-RUN PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH" yarn install
-# start it up, would like to get the server working but needs indy node etc.
-CMD ["bash"]
+RUN yarn compile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,36 @@
-FROM animosolutions/indy-nodejs:1.15.0 as base
+FROM ubuntu:18.04 as base
 
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -y && apt-get install -y \
+    software-properties-common \
+    apt-transport-https \
+    curl \
+    # Only needed to build indy-sdk
+    build-essential 
+
+# libindy
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88
+RUN add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable"
+
+# nodejs
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
+
+# yarn
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+
+# install depdencies
+RUN apt-get update -y && apt-get install -y --allow-unauthenticated \
+    libindy \
+    nodejs
+
+# Install yarn seperately due to `no-install-recommends` to skip nodejs install 
+RUN apt-get install -y --no-install-recommends yarn
+
+FROM base as final
+
+# AFJ specifc setup
 WORKDIR /www
 ENV RUN_MODE="docker"
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ You have to start agencies first, because it runs all tests together.
 yarn test
 ```
 
-## Logs
+# Docker
 
-If you don't want agency to be logging you just remove `DEBUG=aries-framework-javascript` from `yarn prod` command in `package.json`
+If you don't want to install the libindy dependencies yourself, or want a clean environment when running the framework or tests you can use docker.
+
+```sh
+# This build the docker image with all dependencies installed
+docker build -t aries-framework-javascript .
+
+# Run tests without network
+docker run -it --rm aries-framework-javascript  yarn test -t "agents"
+
+# Run test with network and agencies
+docker-compose up # Run alice-agency and bob-agency
+docker run -it --rm --network host aries-framework-javascript yarn test
+```
+
+# Logs
+
+If you don't want agency to be logging you just remove `DEBUG=aries-framework-javascript` from `yarn prod:start` command in `package.json`

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ yarn test
 If you don't want to install the libindy dependencies yourself, or want a clean environment when running the framework or tests you can use docker.
 
 ```sh
-# This build the docker image with all dependencies installed
+# This builds the docker image with all dependencies installed
 docker build -t aries-framework-javascript .
 
 # Run tests without network
@@ -107,4 +107,4 @@ docker run -it --rm --network host aries-framework-javascript yarn test
 
 # Logs
 
-If you don't want agency to be logging you just remove `DEBUG=aries-framework-javascript` from `yarn prod:start` command in `package.json`
+If you want the agency to show the logs, you can run the `prod:debug` command instead of `prod:debug`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,22 @@
-#
-#
 version: '3'
 
-networks:
-  hyperledger-network:
-    driver: bridge
-    ipam:
-      driver: default
-      config:
-        - subnet: 10.0.0.0/24
-
 services:
-  aries-javascript-alice:
-    env_file:
-      - ./.env
-    build: ./
-    image: aries-javascript
-    container_name: aries-javascript-alice
-    working_dir: /www
-    command: ./run.sh alice server
-    volumes:
-     - ./:/www
-     - node_modules:/www/node_modules
+  alice-agency:
+    build: .
+    image: aries-framework-javascript
+    command: ./run.sh alice
     networks:
-      - hyperledger-network
-    tty: true
-  aries-javascript-bob:
-    env_file:
-      - ./.env
-    build: ./
-    image: aries-javascript
-    container_name: aries-javascript-bob
-    working_dir: /www
-    command: ./run.sh bob server
-    volumes:
-      - ./:/www
-      - node_modules:/www/node_modules
+      - hyperledger
+    ports:
+      - 3001:3001
+  bob-agency:
+    build: .
+    image: aries-framework-javascript
+    command: ./run.sh bob
     networks:
-      - hyperledger-network
-    tty: true
-volumes:
-  node_modules:
-  db_data: {}
+      - hyperledger
+    ports:
+      - 3002:3002
+
+networks:
+  hyperledger:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "check-format": "yarn prettier --list-different",
     "test": "jest --verbose",
     "dev": "ts-node-dev --respawn --transpileOnly ./src/samples/agency.ts",
-    "prod": "rm -rf build && yarn compile && DEBUG=aries-framework-javascript node ./build/samples/agency.js",
+    "prod:start": "DEBUG=aries-framework-javascript node ./build/samples/agency.js",
+    "prod": "rm -rf build && yarn compile && yarn prod:start",
     "validate": "npm-run-all --parallel lint compile",
     "prepack": "rm -rf build && yarn compile"
   },

--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "check-format": "yarn prettier --list-different",
     "test": "jest --verbose",
     "dev": "ts-node-dev --respawn --transpileOnly ./src/samples/agency.ts",
-    "prod:start": "DEBUG=aries-framework-javascript node ./build/samples/agency.js",
-    "prod": "rm -rf build && yarn compile && yarn prod:start",
+    "prod:start": "node ./build/samples/agency.js",
+    "prod:debug": "DEBUG=aries-framework-javascript && yarn prod:start",
+    "prod:build": "rm -rf build && yarn compile",
     "validate": "npm-run-all --parallel lint compile",
     "prepack": "rm -rf build && yarn compile"
   },

--- a/run.sh
+++ b/run.sh
@@ -2,12 +2,6 @@
 
 AGENT="$1"
 YARN_COMMAND=yarn
-COMMAND=prod
-
-# Docker image already compiles. Not needed to do again
-if [ "$RUN_MODE" = "docker" ]; then
-  COMMAND="prod:start"
-fi
 
 if [[ "$AGENT" = "agency01" ]] || [[ "$AGENT" = "alice" ]]; then
   AGENT_URL=http://localhost
@@ -34,4 +28,9 @@ if [ "$2" = "server" ]; then
   YARN_COMMAND=.yarn/bin/yarn
 fi
 
-AGENT_URL=${AGENT_URL} AGENT_PORT=${AGENT_PORT} AGENT_LABEL=${AGENT_LABEL} WALLET_NAME=${WALLET_NAME} WALLET_KEY=${WALLET_KEY} PUBLIC_DID=${PUBLIC_DID} PUBLIC_DID_SEED=${PUBLIC_DID_SEED} ${YARN_COMMAND} ${COMMAND}
+# Docker image already compiles. Not needed to do again
+if [ "$RUN_MODE" != "docker" ]; then
+  ${YARN_COMMAND} prod:build
+fi
+
+AGENT_URL=${AGENT_URL} AGENT_PORT=${AGENT_PORT} AGENT_LABEL=${AGENT_LABEL} WALLET_NAME=${WALLET_NAME} WALLET_KEY=${WALLET_KEY} PUBLIC_DID=${PUBLIC_DID} PUBLIC_DID_SEED=${PUBLIC_DID_SEED} ${YARN_COMMAND} prod:debug

--- a/run.sh
+++ b/run.sh
@@ -2,6 +2,12 @@
 
 AGENT="$1"
 YARN_COMMAND=yarn
+COMMAND=prod
+
+# Docker image already compiles. Not needed to do again
+if [ "$RUN_MODE" = "docker" ]; then
+  COMMAND="prod:start"
+fi
 
 if [[ "$AGENT" = "agency01" ]] || [[ "$AGENT" = "alice" ]]; then
   AGENT_URL=http://localhost
@@ -28,4 +34,4 @@ if [ "$2" = "server" ]; then
   YARN_COMMAND=.yarn/bin/yarn
 fi
 
-AGENT_URL=${AGENT_URL} AGENT_PORT=${AGENT_PORT} AGENT_LABEL=${AGENT_LABEL} WALLET_NAME=${WALLET_NAME} WALLET_KEY=${WALLET_KEY} PUBLIC_DID=${PUBLIC_DID} PUBLIC_DID_SEED=${PUBLIC_DID_SEED} ${YARN_COMMAND} prod
+AGENT_URL=${AGENT_URL} AGENT_PORT=${AGENT_PORT} AGENT_LABEL=${AGENT_LABEL} WALLET_NAME=${WALLET_NAME} WALLET_KEY=${WALLET_KEY} PUBLIC_DID=${PUBLIC_DID} PUBLIC_DID_SEED=${PUBLIC_DID_SEED} ${YARN_COMMAND} ${COMMAND}


### PR DESCRIPTION
docker setup now allows to run tests in the docker files. It also makes use of a base indy-nodejs image to reduce build times

to test (from README):
```sh
# This build the docker image with all dependencies installed
docker build -t aries-framework-javascript .

# Run tests without network
docker run -it --rm aries-framework-javascript  yarn test -t "agents"

# Run test with network and agencies
docker-compose up # Run alice-agency and bob-agency
docker run -it --rm --network host aries-framework-javascript yarn test
```

Signed-off-by: Timo Glastra <timo@animo.id>