### PR TITLE
add github actions pipeline

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,22 +21,16 @@ jobs:
         with:
           repository: bcgov/von-network
           path: von-network
-          ref: ad1f84f64d4f4c106a81462f5fbff496c5fbf10e
+          ref: 736de6da81df3a8e7409908acb8bef5819780acc
 
       - name: Get docker cache
         uses: satackey/action-docker-layer-caching@v0.0.5
 
-      # We need to add taa.json and aml.json for Von to start with an TAA and AML.
-      # Without this we can't properly test appendTAA.
-      # However the  von-network doesn't add the newly required `ratification_ts` parameter
-      # ERROR: Cannot create transaction author agreement without a 'ratification_ts' field.
-      # We need to wait this PR to be merged: https://github.com/bcgov/von-network/pull/126
-      # https://github.com/hyperledger/indy-sdk/blob/master/docs/how-tos/transaction-author-agreement.md
-      # cp config/sample_taa.json config/taa.json
-      # cp config/sample_aml.json config/aml.json
       - name: Start von-network
         run: |
           cd von-network
+          cp config/sample_taa.json config/taa.json
+          cp config/sample_aml.json config/aml.json
           ./manage build
           ./manage start
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,90 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+    branches: [master]
+
+env:
+  TEST_AGENT_PUBLIC_DID_SEED: 000000000000000000000000Trustee8
+  GENESIS_TXN_PATH: src/lib/__tests__/genesis-von.txn
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-18.04
+    name: Integration Tests
+    steps:
+      - name: Checkout aries-framework-javascript
+        uses: actions/checkout@v2
+
+      - name: Checkout von-network
+        uses: actions/checkout@v2
+        with:
+          repository: bcgov/von-network
+          path: von-network
+          ref: ad1f84f64d4f4c106a81462f5fbff496c5fbf10e
+
+      - name: Get docker cache
+        uses: satackey/action-docker-layer-caching@v0.0.5
+
+      # We need to add taa.json and aml.json for Von to start with an TAA and AML.
+      # Without this we can't properly test appendTAA.
+      # However the  von-network doesn't add the newly required `ratification_ts` parameter
+      # ERROR: Cannot create transaction author agreement without a 'ratification_ts' field.
+      # We need to wait this PR to be merged: https://github.com/bcgov/von-network/pull/126
+      # https://github.com/hyperledger/indy-sdk/blob/master/docs/how-tos/transaction-author-agreement.md
+      # cp config/sample_taa.json config/taa.json
+      # cp config/sample_aml.json config/aml.json
+      - name: Start von-network
+        run: |
+          cd von-network
+          ./manage build
+          ./manage start
+
+      # Von network takes some time to start
+      # we will retry downloading the genesis
+      - name: Download genesis transaction
+        uses: nick-invision/retry@v1
+        with:
+          timeout_minutes: 2
+          max_attempts: 10
+          command: >-
+            curl http://localhost:9000/genesis
+            -o ${GENESIS_TXN_PATH}
+
+      - name: Register DID on ledger
+        run: >-
+          curl http://localhost:9000/register
+          -X POST
+          -d '{"alias":"Test","seed":"'${TEST_AGENT_PUBLIC_DID_SEED}'","role":"TRUST_ANCHOR"}'
+
+      - name: Build framework docker image
+        run: docker build -t aries-framework-javascript .
+
+      - name: Start mediator agents
+        run: docker-compose up -d
+
+      - name: Run tests
+        run: >-
+          docker run 
+          --network host
+          --name framework-jest-tests 
+          --env TEST_AGENT_PUBLIC_DID_SEED=${TEST_AGENT_PUBLIC_DID_SEED}
+          --env GENESIS_TXN_PATH=${GENESIS_TXN_PATH}
+          aries-framework-javascript 
+          yarn test
+
+      - name: Export docker logs
+        if: always()
+        run: |
+          mkdir logs
+          docker-compose logs --no-color > logs/docker-mediator-agents.log
+          docker logs framework-jest-tests > logs/docker-framework-jest-tests.log
+          cd von-network
+          ./manage logs --no-tail > ../logs/docker-von.log
+
+      - name: Upload docker logs
+        uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: docker-logs
+          path: logs

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 yarn-error.log
 .idea
 aries-framework-javascript-*.tgz
+src/lib/__tests__/genesis-von.txn


### PR DESCRIPTION
Replacement for #85. This only adds the Github actions pipeline, but doesn't remove the azure pipeline yet. Although current master doesn't use the ledger yet, it will work when #82 is merged.

Currently the ledger doesn't have a TAA due to a bug in von network, but I already opened a PR for that. We just have to wait for it to get merged to test with TAA: https://github.com/bcgov/von-network/pull/126.

However this showed something: we need to apply custom logic if there is no TAA on the ledger. In this case we don't need to append to the TAA, and it will fail if we do. I'll add the required changes to the credential schema branch.

