### PR TITLE
fix did and verkey regexes and add tests

### DIFF
--- a/src/lib/utils/did.test.ts
+++ b/src/lib/utils/did.test.ts
@@ -22,6 +22,7 @@ const validFullVerkeys = [
   '9wMLhw9SSxtTUyosrndMbvWY4TtDbVvRnMtzG2NysniP',
   '6m2XT39vivJ7tLSxNPM8siMnhYCZcdMxbkTcJDSzAQTu',
   'CAgL85iEecPNQMmxQ1hgbqczwq7SAerQ8RbWTRtC7SoK',
+  'MqXmB7cTsTXqyxDPBbrgu5EPqw61kouK1qjMvnoPa96',
 ];
 
 const invalidFullVerkeys = [
@@ -64,6 +65,7 @@ const invalidDids = [
 
 const validDidIdentifiers = [
   '8kyt-fzzq-qpqq-ljsc-5l',
+  'fEMDp21GvaafC5hXLaLHf',
   '9noxi4nL4SiJAsFcMLp2U4',
   'QdAJFDpbVoHYrUpNAMe3An',
   'B9Y3e8PUKrM1ShumWU36xW',

--- a/src/lib/utils/did.ts
+++ b/src/lib/utils/did.ts
@@ -15,8 +15,8 @@
  *  https://github.com/hyperledger/aries-framework-dotnet/blob/f90eaf9db8548f6fc831abea917e906201755763/src/Hyperledger.Aries/Ledger/DefaultLedgerService.cs#L139-L147
  */
 
-export const FULL_VERKEY_REGEX = /^[1-9A-HJ-NP-Za-km-z]{44}$/;
-export const ABBREVIATED_VERKEY_REGEX = /^~[1-9A-HJ-NP-Za-km-z]{22}$/;
+export const FULL_VERKEY_REGEX = /^[1-9A-HJ-NP-Za-km-z]{43,44}$/;
+export const ABBREVIATED_VERKEY_REGEX = /^~[1-9A-HJ-NP-Za-km-z]{21,22}$/;
 export const VERKEY_REGEX = new RegExp(`${FULL_VERKEY_REGEX.source}|${ABBREVIATED_VERKEY_REGEX.source}`);
 export const DID_REGEX = /^did:([a-z]+):([a-zA-z\d]+)/;
 export const DID_IDENTIFIER_REGEX = /^[a-zA-z\d-]+$/;


### PR DESCRIPTION
The regexes for DID and verkey were not 100% correct. They specified a length of 22 and 44 characters, but they can also be 21 and 43 characters (I don't know why).

I've added a 43 character verkey and a 21 character did identifier to the tests. This are definitely valid as they are generated from `000000000000000000000000Trustee8` seed

Discovered after reading: https://hackmd.io/2IKUPROnRXW57Lmal_SGaQ
