### PR TITLE
auto init ledger pool if genesisPath is configured

### DIFF
--- a/src/lib/__tests__/credentials.test.ts
+++ b/src/lib/__tests__/credentials.test.ts
@@ -12,12 +12,18 @@ import { CredentialPreview } from '../protocols/credentials/messages/CredentialO
 import { CredentialState } from '../protocols/credentials/CredentialState';
 import { InitConfig } from '../types';
 
+const genesisPath = process.env.GENESIS_TXN_PATH
+  ? path.resolve(process.env.GENESIS_TXN_PATH)
+  : path.join(__dirname, '../../../network/genesis/local-genesis.txn');
+
 const faberConfig: InitConfig = {
   label: 'Faber',
   walletConfig: { id: 'credentials-test-faber' },
   walletCredentials: { key: '00000000000000000000000000000Test01' },
   publicDidSeed: process.env.TEST_AGENT_PUBLIC_DID_SEED,
   autoAcceptConnections: true,
+  genesisPath,
+  poolName: 'test-pool-credentials',
 };
 
 const aliceConfig: InitConfig = {
@@ -25,13 +31,6 @@ const aliceConfig: InitConfig = {
   walletConfig: { id: 'credentials-test-alice' },
   walletCredentials: { key: '00000000000000000000000000000Test01' },
   autoAcceptConnections: true,
-};
-
-const poolName = 'test-pool-credentials';
-const poolConfig = {
-  genesis_txn: process.env.GENESIS_TXN_PATH
-    ? path.resolve(process.env.GENESIS_TXN_PATH)
-    : path.join(__dirname, '../../../network/genesis/local-genesis.txn'),
 };
 
 const credentialPreview = new CredentialPreview({
@@ -67,9 +66,6 @@ describe('credentials', () => {
     aliceAgent = new Agent(aliceConfig, aliceAgentInbound, aliceAgentOutbound, indy);
     await faberAgent.init();
     await aliceAgent.init();
-
-    console.log(`Connecting to ledger pool ${poolName} with config:`, poolConfig);
-    await faberAgent.ledger.connect(poolName, poolConfig);
 
     const schemaTemplate = {
       name: `test-schema-${Date.now()}`,

--- a/src/lib/__tests__/ledger.test.ts
+++ b/src/lib/__tests__/ledger.test.ts
@@ -3,12 +3,19 @@ import path from 'path';
 import indy from 'indy-sdk';
 import { DidInfo } from '../wallet/Wallet';
 import { DID_IDENTIFIER_REGEX, VERKEY_REGEX, isFullVerkey, isAbbreviatedVerkey } from '../utils/did';
+import { InitConfig } from '../types';
 
-const faberConfig = {
+const genesisPath = process.env.GENESIS_TXN_PATH
+  ? path.resolve(process.env.GENESIS_TXN_PATH)
+  : path.join(__dirname, '../../../network/genesis/local-genesis.txn');
+
+const faberConfig: InitConfig = {
   label: 'Faber',
   walletConfig: { id: 'faber' },
   walletCredentials: { key: '00000000000000000000000000000Test01' },
   publicDidSeed: process.env.TEST_AGENT_PUBLIC_DID_SEED,
+  genesisPath,
+  poolName: 'test-pool',
 };
 
 describe('ledger', () => {
@@ -19,16 +26,6 @@ describe('ledger', () => {
   beforeAll(async () => {
     faberAgent = new Agent(faberConfig, new DummyInboundTransporter(), new DummyOutboundTransporter(), indy);
     await faberAgent.init();
-
-    const poolName = 'test-pool';
-    const poolConfig = {
-      genesis_txn: process.env.GENESIS_TXN_PATH
-        ? path.resolve(process.env.GENESIS_TXN_PATH)
-        : path.join(__dirname, '../../../network/genesis/local-genesis.txn'),
-    };
-
-    console.log(`Connecting to ledger pool ${poolName} with config:`, poolConfig);
-    await faberAgent.ledger.connect(poolName, poolConfig);
   });
 
   afterAll(async () => {

--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -115,10 +115,18 @@ export class Agent {
   public async init() {
     await this.wallet.init();
 
-    const { publicDidSeed } = this.agentConfig;
+    const { publicDidSeed, genesisPath, poolName } = this.agentConfig;
     if (publicDidSeed) {
       // If an agent has publicDid it will be used as routing key.
-      this.wallet.initPublicDid({ seed: publicDidSeed });
+      await this.wallet.initPublicDid({ seed: publicDidSeed });
+    }
+
+    // If the genesisPath is provided in the config, we will automatically handle ledger connection
+    // otherwise the framework consumer needs to do this manually
+    if (genesisPath) {
+      await this.ledger.connect(poolName, {
+        genesis_txn: genesisPath,
+      });
     }
 
     return this.inboundTransporter.start(this);

--- a/src/lib/agent/AgentConfig.ts
+++ b/src/lib/agent/AgentConfig.ts
@@ -24,6 +24,14 @@ export class AgentConfig {
     return this.initConfig.agencyUrl;
   }
 
+  public get poolName() {
+    return this.initConfig.poolName ?? 'default-pool';
+  }
+
+  public get genesisPath() {
+    return this.initConfig.genesisPath;
+  }
+
   public establishInbound(inboundConnection: InboundConnection) {
     this.inboundConnection = inboundConnection;
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -15,6 +15,8 @@ export interface InitConfig {
   walletConfig: WalletConfig;
   walletCredentials: WalletCredentials;
   autoAcceptConnections?: boolean;
+  genesisPath?: string;
+  poolName?: string;
 }
 
 export interface UnpackedMessage {


### PR DESCRIPTION
This is a small change that automatically connect to the ledger pool (instead of manually needing to do it) if `genesisPath` configuration is set. It is backwards compatible (by manually calling `ledger.connect`). 

In the future I'll like to optimise this to only connect when the pool is actually needed, but this way the configuration and API is already available. The optimisation can be an internal change. Maybe we can take a similar approach as Aries Framework .NET that uses an awaitable pool that initialises when you retrieve it.

Fixes #88 