### PR TITLE
only return object for get schema and cred def

### DIFF
--- a/src/lib/__tests__/credentials.test.ts
+++ b/src/lib/__tests__/credentials.test.ts
@@ -177,16 +177,16 @@ describe('credentials', () => {
 async function registerSchema(agent: Agent, schemaTemplate: SchemaTemplate): Promise<[SchemaId, Schema]> {
   const [schemaId] = await agent.ledger.registerCredentialSchema(schemaTemplate);
   console.log('schemaId', schemaId);
-  const [ledgerSchemaId, ledgerSchema] = await agent.ledger.getSchema(schemaId);
-  console.log('ledgerSchemaId, ledgerSchema', ledgerSchemaId, ledgerSchema);
-  return [ledgerSchemaId, ledgerSchema];
+  const ledgerSchema = await agent.ledger.getSchema(schemaId);
+  console.log('ledgerSchemaId, ledgerSchema', schemaId, ledgerSchema);
+  return [schemaId, ledgerSchema];
 }
 
 async function registerDefinition(agent: Agent, definitionTemplate: CredDefTemplate): Promise<[CredDefId, CredDef]> {
   const [credDefId] = await agent.ledger.registerCredentialDefinition(definitionTemplate);
-  const [ledgerCredDefId, ledgerCredDef] = await agent.ledger.getCredentialDefinition(credDefId);
-  console.log('ledgerCredDefId, ledgerCredDef', ledgerCredDefId, ledgerCredDef);
-  return [ledgerCredDefId, ledgerCredDef];
+  const ledgerCredDef = await agent.ledger.getCredentialDefinition(credDefId);
+  console.log('ledgerCredDefId, ledgerCredDef', credDefId, ledgerCredDef);
+  return [credDefId, ledgerCredDef];
 }
 
 async function ensurePublicDidIsOnLedger(agent: Agent, publicDid: Did) {

--- a/src/lib/__tests__/ledger.test.ts
+++ b/src/lib/__tests__/ledger.test.ts
@@ -80,9 +80,9 @@ describe('ledger', () => {
     };
 
     [schemaId] = await faberAgent.ledger.registerCredentialSchema(schemaTemplate);
-    const [ledgerSchemaId, ledgerSchema] = await faberAgent.ledger.getSchema(schemaId);
+    const ledgerSchema = await faberAgent.ledger.getSchema(schemaId);
 
-    expect(ledgerSchemaId).toBe(`${faberAgentPublicDid.did}:2:${schemaName}:1.0`);
+    expect(schemaId).toBe(`${faberAgentPublicDid.did}:2:${schemaName}:1.0`);
     expect(ledgerSchema).toEqual(
       expect.objectContaining({
         attrNames: expect.arrayContaining(['name', 'age']),
@@ -99,7 +99,7 @@ describe('ledger', () => {
     if (!faberAgentPublicDid) {
       throw new Error('Agent does not have publid did.');
     }
-    const [, schema] = await faberAgent.ledger.getSchema(schemaId);
+    const schema = await faberAgent.ledger.getSchema(schemaId);
     const credentialDefinitionTemplate = {
       schema: schema,
       tag: 'TAG',
@@ -108,10 +108,10 @@ describe('ledger', () => {
     };
 
     const [credDefId] = await faberAgent.ledger.registerCredentialDefinition(credentialDefinitionTemplate);
-    const [ledgerCredDefId, ledgerCredDef] = await faberAgent.ledger.getCredentialDefinition(credDefId);
+    const ledgerCredDef = await faberAgent.ledger.getCredentialDefinition(credDefId);
 
     const credDefIdRegExp = new RegExp(`${faberAgentPublicDid.did}:3:CL:[0-9]+:TAG`);
-    expect(ledgerCredDefId).toEqual(expect.stringMatching(credDefIdRegExp));
+    expect(credDefId).toEqual(expect.stringMatching(credDefIdRegExp));
     expect(ledgerCredDef).toEqual(
       expect.objectContaining({
         id: expect.stringMatching(credDefIdRegExp),

--- a/src/lib/agent/LedgerService.ts
+++ b/src/lib/agent/LedgerService.ts
@@ -77,10 +77,10 @@ export class LedgerService {
     const response = await this.indy.submitRequest(this.poolHandle, request);
     logger.log('Get schema response', response);
 
-    const result = await this.indy.parseGetSchemaResponse(response);
-    logger.log('Get schema result: ', result);
+    const [, schema] = await this.indy.parseGetSchemaResponse(response);
+    logger.log('Get schema result: ', schema);
 
-    return result;
+    return schema;
   }
 
   public async registerCredentialDefinition(
@@ -117,10 +117,10 @@ export class LedgerService {
     const response = await this.indy.submitRequest(this.poolHandle, request);
     logger.log('Get credential definition response:', response);
 
-    const result = await this.indy.parseGetCredDefResponse(response);
-    logger.log('Get credential definition result: ', result);
+    const [, credentialDefinition] = await this.indy.parseGetCredDefResponse(response);
+    logger.log('Get credential definition result: ', credentialDefinition);
 
-    return result;
+    return credentialDefinition;
   }
 
   private async appendTaa(request: LedgerRequest) {

--- a/src/lib/handlers/credentials/CredentialResponseHandler.ts
+++ b/src/lib/handlers/credentials/CredentialResponseHandler.ts
@@ -17,7 +17,7 @@ export class CredentialResponseHandler implements Handler {
   public async handle(messageContext: HandlerInboundMessage<CredentialResponseHandler>) {
     const [responseAttachment] = messageContext.message.attachments;
     const cred = JsonEncoder.fromBase64(responseAttachment.data.base64);
-    const [, credentialDefinition] = await this.ledgerService.getCredentialDefinition(cred.cred_def_id);
+    const credentialDefinition = await this.ledgerService.getCredentialDefinition(cred.cred_def_id);
     await this.credentialService.processCredentialResponse(messageContext, credentialDefinition);
   }
 }

--- a/src/lib/modules/CredentialsModule.ts
+++ b/src/lib/modules/CredentialsModule.ts
@@ -41,7 +41,7 @@ export class CredentialsModule {
     const [offerAttachment] = offer.attachments;
     const credOffer = JsonEncoder.fromBase64(offerAttachment.data.base64);
 
-    const [, credentialDefinition] = await this.ledgerService.getCredentialDefinition(credOffer.cred_def_id);
+    const credentialDefinition = await this.ledgerService.getCredentialDefinition(credOffer.cred_def_id);
     const connection = await this.connectionService.find(credential.connectionId);
 
     if (!connection) {


### PR DESCRIPTION
Only return the objects for `getCredentialSchema` and `getCredentialDefinition` instead of both object and id

Fixes #105