### PR TITLE
fix: Correctly persist createdAt attribute

### DIFF
--- a/src/lib/protocols/connections/ConnectionService.ts
+++ b/src/lib/protocols/connections/ConnectionService.ts
@@ -1,4 +1,3 @@
-import { v4 as uuid } from 'uuid';
 import { EventEmitter } from 'events';
 import { classToPlain, plainToClass } from 'class-transformer';
 import { validateOrReject } from 'class-validator';
@@ -311,7 +310,6 @@ class ConnectionService extends EventEmitter {
     autoAcceptConnection?: boolean;
     tags?: ConnectionTags;
   }): Promise<ConnectionRecord> {
-    const id = uuid();
     const [did, verkey] = await this.wallet.createDid({ method_name: 'sov' });
     const publicKey = new PublicKey(`${did}#1`, PublicKeyType.ED25519_SIG_2018, did, verkey);
     const service = new Service(
@@ -326,7 +324,6 @@ class ConnectionService extends EventEmitter {
     const didDoc = new DidDoc(did, [auth], [publicKey], [service]);
 
     const connectionRecord = new ConnectionRecord({
-      id,
       did,
       didDoc,
       verkey,

--- a/src/lib/storage/BaseRecord.ts
+++ b/src/lib/storage/BaseRecord.ts
@@ -19,9 +19,9 @@ export abstract class BaseRecord {
   public static readonly type: RecordType = RecordType.BaseRecord;
   public readonly type = BaseRecord.type;
 
-  public constructor(id: string) {
+  public constructor(id: string, createdAt: number) {
     this.id = id;
-    this.createdAt = Date.now();
+    this.createdAt = createdAt;
     this.tags = {};
   }
 

--- a/src/lib/storage/BasicMessageRecord.ts
+++ b/src/lib/storage/BasicMessageRecord.ts
@@ -18,7 +18,7 @@ export class BasicMessageRecord extends BaseRecord implements BasicMessageStorag
   public readonly type = BasicMessageRecord.type;
 
   public constructor(props: BasicMessageStorageProps) {
-    super(props.id || uuid(), props.createdAt || Date.now());
+    super(props.id ?? uuid(), props.createdAt ?? Date.now());
     this.content = props.content;
     this.sentTime = props.sentTime;
     this.tags = props.tags;

--- a/src/lib/storage/BasicMessageRecord.ts
+++ b/src/lib/storage/BasicMessageRecord.ts
@@ -3,6 +3,7 @@ import { BaseRecord, RecordType, Tags } from './BaseRecord';
 
 export interface BasicMessageStorageProps {
   id?: string;
+  createdAt?: number;
   tags: Tags;
 
   content: string;
@@ -17,7 +18,7 @@ export class BasicMessageRecord extends BaseRecord implements BasicMessageStorag
   public readonly type = BasicMessageRecord.type;
 
   public constructor(props: BasicMessageStorageProps) {
-    super(props.id || uuid());
+    super(props.id || uuid(), props.createdAt || Date.now());
     this.content = props.content;
     this.sentTime = props.sentTime;
     this.tags = props.tags;

--- a/src/lib/storage/ConnectionRecord.ts
+++ b/src/lib/storage/ConnectionRecord.ts
@@ -51,7 +51,7 @@ export class ConnectionRecord extends BaseRecord implements ConnectionStoragePro
   public readonly type = ConnectionRecord.type;
 
   public constructor(props: ConnectionStorageProps) {
-    super(props.id || uuid(), props.createdAt || Date.now());
+    super(props.id ?? uuid(), props.createdAt ?? Date.now());
     this.did = props.did;
     this.didDoc = props.didDoc;
     this.verkey = props.verkey;

--- a/src/lib/storage/ConnectionRecord.ts
+++ b/src/lib/storage/ConnectionRecord.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { BaseRecord, RecordType, Tags } from './BaseRecord';
 import { DidDoc } from '../protocols/connections/domain/DidDoc';
 import { ConnectionState } from '../protocols/connections/domain/ConnectionState';
@@ -6,7 +7,8 @@ import { ConnectionRole } from '../protocols/connections/domain/ConnectionRole';
 import { MessageTransformer } from '../agent/MessageTransformer';
 
 interface ConnectionProps {
-  id: string;
+  id?: string;
+  createdAt?: number;
   did: Did;
   didDoc: DidDoc;
   verkey: Verkey;
@@ -49,7 +51,7 @@ export class ConnectionRecord extends BaseRecord implements ConnectionStoragePro
   public readonly type = ConnectionRecord.type;
 
   public constructor(props: ConnectionStorageProps) {
-    super(props.id);
+    super(props.id || uuid(), props.createdAt || Date.now());
     this.did = props.did;
     this.didDoc = props.didDoc;
     this.verkey = props.verkey;

--- a/src/lib/storage/CredentialRecord.ts
+++ b/src/lib/storage/CredentialRecord.ts
@@ -28,7 +28,7 @@ export class CredentialRecord extends BaseRecord implements CredentialStoragePro
   public state: CredentialState;
 
   public constructor(props: CredentialStorageProps) {
-    super(props.id || uuid(), props.createdAt || Date.now());
+    super(props.id ?? uuid(), props.createdAt ?? Date.now());
     this.offer = props.offer;
     this.state = props.state;
     this.connectionId = props.connectionId;

--- a/src/lib/storage/CredentialRecord.ts
+++ b/src/lib/storage/CredentialRecord.ts
@@ -5,6 +5,7 @@ import { CredentialState } from '../protocols/credentials/CredentialState';
 
 export interface CredentialStorageProps {
   id?: string;
+  createdAt?: number;
   offer: CredentialOfferMessage;
   state: CredentialState;
   connectionId: string;
@@ -27,7 +28,7 @@ export class CredentialRecord extends BaseRecord implements CredentialStoragePro
   public state: CredentialState;
 
   public constructor(props: CredentialStorageProps) {
-    super(props.id ? props.id : uuid());
+    super(props.id || uuid(), props.createdAt || Date.now());
     this.offer = props.offer;
     this.state = props.state;
     this.connectionId = props.connectionId;

--- a/src/lib/storage/IndyStorageService.test.ts
+++ b/src/lib/storage/IndyStorageService.test.ts
@@ -19,7 +19,7 @@ class TestRecord extends BaseRecord {
   public readonly type = TestRecord.type;
 
   public constructor(props: TestRecordProps) {
-    super(props.id || uuid(), props.createdAt || Date.now());
+    super(props.id ?? uuid(), props.createdAt ?? Date.now());
     this.foo = props.foo;
     this.tags = props.tags;
   }

--- a/src/lib/storage/IndyStorageService.test.ts
+++ b/src/lib/storage/IndyStorageService.test.ts
@@ -7,6 +7,7 @@ import indy from 'indy-sdk';
 
 interface TestRecordProps {
   id?: string;
+  createdAt?: number;
   tags: { [keys: string]: string };
   foo: string;
 }
@@ -18,20 +19,20 @@ class TestRecord extends BaseRecord {
   public readonly type = TestRecord.type;
 
   public constructor(props: TestRecordProps) {
-    super(props.id || uuid());
+    super(props.id || uuid(), props.createdAt || Date.now());
     this.foo = props.foo;
     this.tags = props.tags;
   }
 }
 
-describe('connection repository', () => {
+describe('IndyStorageService', () => {
   let wallet: IndyWallet;
-  let tr: Repository<TestRecord>;
+  let testRepository: Repository<TestRecord>;
 
   beforeEach(async () => {
     wallet = new IndyWallet({ id: 'testWallet' }, { key: 'asbdabsd' }, indy);
     const storageService = new IndyStorageService(wallet);
-    tr = new Repository<TestRecord>(TestRecord, storageService);
+    testRepository = new Repository<TestRecord>(TestRecord, storageService);
     await wallet.init();
   });
 
@@ -46,7 +47,7 @@ describe('connection repository', () => {
       tags: { myTag: 'foobar' },
     };
     const record = new TestRecord(props);
-    await tr.save(record);
+    await testRepository.save(record);
     return record;
   };
 
@@ -54,9 +55,16 @@ describe('connection repository', () => {
     await insertRecord();
   });
 
+  test('does not change id, createdAt attributes', async () => {
+    const record = await insertRecord();
+    const found = await testRepository.find(record.id);
+    expect(found.id).toEqual(record.id);
+    expect(found.createdAt).toEqual(record.createdAt);
+  });
+
   test('it is able to get the record', async () => {
     const record = await insertRecord();
-    const found = await tr.find(record.id);
+    const found = await testRepository.find(record.id);
     expect(found.id).toStrictEqual(record.id);
   });
 
@@ -67,10 +75,10 @@ describe('connection repository', () => {
         tags: {},
       };
       const rec = new TestRecord(props);
-      await tr.save(rec);
+      await testRepository.save(rec);
     }
 
-    const records = await tr.findAll();
+    const records = await testRepository.findAll();
     expect(records.length).toStrictEqual(10);
   });
 
@@ -78,23 +86,23 @@ describe('connection repository', () => {
     const record = await insertRecord();
     record.tags = { ...record.tags, foo: 'bar' };
     record.foo = 'foobaz';
-    await tr.update(record);
-    const got = await tr.find(record.id);
+    await testRepository.update(record);
+    const got = await testRepository.find(record.id);
     expect(got.foo).toStrictEqual(record.foo);
     expect(got.tags).toStrictEqual(record.tags);
   });
 
   test('it is able to delete a record', async () => {
     const record = await insertRecord();
-    await tr.delete(record);
+    await testRepository.delete(record);
     expect(async () => {
-      await tr.find(record.id);
+      await testRepository.find(record.id);
     }).rejects;
   });
 
   test('it is able to query a record', async () => {
     await insertRecord();
-    const result = await tr.findByQuery({ myTag: 'foobar' });
+    const result = await testRepository.findByQuery({ myTag: 'foobar' });
     expect(result.length).toBe(1);
   });
 });

--- a/src/lib/storage/ProvisioningRecord.ts
+++ b/src/lib/storage/ProvisioningRecord.ts
@@ -1,7 +1,9 @@
+import { v4 as uuid } from 'uuid';
 import { BaseRecord, RecordType } from './BaseRecord';
 
 interface ProvisioningRecordProps {
   id: string;
+  createdAt?: number;
   tags?: { [keys: string]: string };
   agencyConnectionId: string;
   agencyPublicVerkey: Verkey;
@@ -15,7 +17,7 @@ export class ProvisioningRecord extends BaseRecord {
   public readonly type = ProvisioningRecord.type;
 
   public constructor(props: ProvisioningRecordProps) {
-    super(props.id);
+    super(props.id || uuid(), props.createdAt || Date.now());
     this.agencyConnectionId = props.agencyConnectionId;
     this.agencyPublicVerkey = props.agencyPublicVerkey;
     this.tags = props.tags || {};

--- a/src/lib/storage/ProvisioningRecord.ts
+++ b/src/lib/storage/ProvisioningRecord.ts
@@ -17,7 +17,7 @@ export class ProvisioningRecord extends BaseRecord {
   public readonly type = ProvisioningRecord.type;
 
   public constructor(props: ProvisioningRecordProps) {
-    super(props.id || uuid(), props.createdAt || Date.now());
+    super(props.id ?? uuid(), props.createdAt ?? Date.now());
     this.agencyConnectionId = props.agencyConnectionId;
     this.agencyPublicVerkey = props.agencyPublicVerkey;
     this.tags = props.tags || {};


### PR DESCRIPTION
I needed to move `createAt` attribute initialization up in the inheritance chain to every particular record. I'm not sure if this is a good approach in the long-term but it at least fixes the issue for now. I also aligned `id` attribute initialization across all records, so even if this is a wrong approach we have it wrong in the same way everywhere :)