### PR TITLE
Feature/ack credential

### DIFF
--- a/src/lib/__tests__/credentials.test.ts
+++ b/src/lib/__tests__/credentials.test.ts
@@ -161,14 +161,13 @@ describe('credentials', () => {
       (credentialRecord: CredentialRecord) => !credentialRecord || credentialRecord.state !== CredentialState.Done,
       100
     );
+    console.log('aliceCredential', aliceCredential);
 
     faberCredential = await poll(
       async () => faberAgent.credentials.find(faberCredential.id),
       (credentialRecord: CredentialRecord) => !credentialRecord || credentialRecord.state !== CredentialState.Done,
       100
     );
-
-    console.log('aliceCredential', aliceCredential);
     console.log('faberCredential', faberCredential);
 
     expect(aliceCredential).toMatchObject({

--- a/src/lib/__tests__/credentials.test.ts
+++ b/src/lib/__tests__/credentials.test.ts
@@ -104,7 +104,7 @@ describe('credentials', () => {
 
     // Issue credential from Faber to Alice
     await faberAgent.credentials.issueCredential(firstConnection, {
-      credDefId,
+      credentialDefinitionId: credDefId,
       comment: 'some comment about credential',
       preview: credentialPreview,
     });

--- a/src/lib/__tests__/credentials.test.ts
+++ b/src/lib/__tests__/credentials.test.ts
@@ -158,15 +158,13 @@ describe('credentials', () => {
 
     aliceCredential = await poll(
       () => aliceAgent.credentials.find(aliceCredential.id),
-      (credentialRecord: CredentialRecord) =>
-        !credentialRecord || credentialRecord.state !== CredentialState.CredentialReceived,
+      (credentialRecord: CredentialRecord) => !credentialRecord || credentialRecord.state !== CredentialState.Done,
       100
     );
 
     faberCredential = await poll(
       async () => faberAgent.credentials.find(faberCredential.id),
-      (credentialRecord: CredentialRecord) =>
-        !credentialRecord || credentialRecord.state !== CredentialState.CredentialIssued,
+      (credentialRecord: CredentialRecord) => !credentialRecord || credentialRecord.state !== CredentialState.Done,
       100
     );
 
@@ -184,7 +182,7 @@ describe('credentials', () => {
       request: undefined,
       requestMetadata: expect.any(Object),
       credentialId: expect.any(String),
-      state: CredentialState.CredentialReceived,
+      state: CredentialState.Done,
     });
 
     expect(faberCredential).toMatchObject({
@@ -198,7 +196,7 @@ describe('credentials', () => {
       request: expect.any(Object),
       requestMetadata: undefined,
       credentialId: undefined,
-      state: CredentialState.CredentialIssued,
+      state: CredentialState.Done,
     });
   });
 });

--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -42,6 +42,7 @@ import { CredentialRecord } from '../storage/CredentialRecord';
 import { CredentialOfferHandler } from '../handlers/credentials/CredentialOfferHandler';
 import { CredentialRequestHandler } from '../handlers/credentials/CredentialRequestHandler';
 import { CredentialResponseHandler } from '../handlers/credentials/CredentialResponseHandler';
+import { CredentialAckHandler } from '../handlers/credentials/CredentialAckHandler';
 
 export class Agent {
   protected wallet: Wallet;
@@ -164,6 +165,7 @@ export class Agent {
     this.dispatcher.registerHandler(new CredentialOfferHandler(this.credentialService));
     this.dispatcher.registerHandler(new CredentialRequestHandler(this.credentialService));
     this.dispatcher.registerHandler(new CredentialResponseHandler(this.credentialService, this.ledgerService));
+    this.dispatcher.registerHandler(new CredentialAckHandler(this.credentialService));
   }
 
   protected registerModules() {

--- a/src/lib/agent/AgentMessage.ts
+++ b/src/lib/agent/AgentMessage.ts
@@ -5,8 +5,9 @@ import { TransportDecorated } from '../decorators/transport/TransportDecoratorEx
 import { TimingDecorated } from '../decorators/timing/TimingDecoratorExtension';
 import { BaseMessage } from './BaseMessage';
 import { JsonTransformer } from '../utils/JsonTransformer';
+import { AckDecorated } from '../decorators/ack/AckDecoratorExtension';
 
-const DefaultDecorators = [ThreadDecorated, L10nDecorated, TransportDecorated, TimingDecorated];
+const DefaultDecorators = [ThreadDecorated, L10nDecorated, TransportDecorated, TimingDecorated, AckDecorated];
 
 export class AgentMessage extends Compose(BaseMessage, DefaultDecorators) {
   public toJSON(): Record<string, unknown> {

--- a/src/lib/decorators/ack/AckDecorator.test.ts
+++ b/src/lib/decorators/ack/AckDecorator.test.ts
@@ -1,27 +1,26 @@
 import { JsonTransformer } from '../../utils/JsonTransformer';
+import { Compose } from '../../utils/mixins';
 
-import { AckDecorator } from './AckDecorator';
+import { BaseMessage } from '../../agent/BaseMessage';
+import { AckDecorated } from './AckDecoratorExtension';
 
-describe('Decorators | AckDecorator', () => {
-  it('should correctly transform Json to AckDecorator class', () => {
-    const pleaseAck = {};
-    const decorator = JsonTransformer.fromJSON({ pleaseAck }, AckDecorator);
+describe('Decorators | AckDecoratorExtension', () => {
+  class TestMessage extends Compose(BaseMessage, [AckDecorated]) {
+    public toJSON(): Record<string, unknown> {
+      return JsonTransformer.toJSON(this);
+    }
+  }
 
-    expect(decorator.pleaseAck).toEqual(pleaseAck);
+  test('transforms AckDecorator class to JSON', () => {
+    const message = new TestMessage();
+    message.setPleaseAck();
+    expect(message.toJSON()).toEqual({ '~please_ack': {} });
   });
 
-  it('should correctly transform AckDecorator class to Json', () => {
-    const pleaseAck = {};
+  test('transforms Json to AckDecorator class', () => {
+    const transformed = JsonTransformer.fromJSON({ '~please_ack': {} }, TestMessage);
 
-    const decorator = new AckDecorator({
-      pleaseAck,
-    });
-
-    const json = JsonTransformer.toJSON(decorator);
-    const transformed = {
-      pleaseAck,
-    };
-
-    expect(json).toEqual(transformed);
+    expect(transformed).toEqual({ pleaseAck: {} });
+    expect(transformed).toBeInstanceOf(TestMessage);
   });
 });

--- a/src/lib/decorators/ack/AckDecorator.test.ts
+++ b/src/lib/decorators/ack/AckDecorator.test.ts
@@ -1,0 +1,27 @@
+import { JsonTransformer } from '../../utils/JsonTransformer';
+
+import { AckDecorator } from './AckDecorator';
+
+describe('Decorators | AckDecorator', () => {
+  it('should correctly transform Json to AckDecorator class', () => {
+    const pleaseAck = {};
+    const decorator = JsonTransformer.fromJSON({ pleaseAck }, AckDecorator);
+
+    expect(decorator.pleaseAck).toEqual(pleaseAck);
+  });
+
+  it('should correctly transform AckDecorator class to Json', () => {
+    const pleaseAck = {};
+
+    const decorator = new AckDecorator({
+      pleaseAck,
+    });
+
+    const json = JsonTransformer.toJSON(decorator);
+    const transformed = {
+      pleaseAck,
+    };
+
+    expect(json).toEqual(transformed);
+  });
+});

--- a/src/lib/decorators/ack/AckDecorator.ts
+++ b/src/lib/decorators/ack/AckDecorator.ts
@@ -1,10 +1,4 @@
 /**
  * Represents `~please_ack` decorator
  */
-export class AckDecorator {
-  public constructor(partial?: Partial<AckDecorator>) {
-    this.pleaseAck = partial?.pleaseAck;
-  }
-
-  public pleaseAck?: Record<string, unknown>;
-}
+export class AckDecorator {}

--- a/src/lib/decorators/ack/AckDecorator.ts
+++ b/src/lib/decorators/ack/AckDecorator.ts
@@ -1,0 +1,10 @@
+/**
+ * Represents `~please_ack` decorator
+ */
+export class AckDecorator {
+  public constructor(partial?: Partial<AckDecorator>) {
+    this.pleaseAck = partial?.pleaseAck;
+  }
+
+  public pleaseAck?: Record<string, unknown>;
+}

--- a/src/lib/decorators/ack/AckDecoratorExtension.ts
+++ b/src/lib/decorators/ack/AckDecoratorExtension.ts
@@ -1,0 +1,28 @@
+import { Expose, Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+
+import { BaseMessageConstructor } from '../../agent/BaseMessage';
+import { AckDecorator } from './AckDecorator';
+
+export function AckDecorated<T extends BaseMessageConstructor>(Base: T) {
+  class AckDecoratorExtension extends Base {
+    @Expose({ name: '~please_ack' })
+    @Type(() => AckDecorator)
+    @ValidateNested()
+    public pleaseAck?: AckDecorator;
+
+    public setPleaseAck(pleaseAck: Record<string, unknown>) {
+      this.pleaseAck = new AckDecorator({
+        pleaseAck,
+      });
+    }
+
+    public getPleaseAck(): AckDecorator | undefined {
+      if (this.pleaseAck) return this.pleaseAck;
+
+      return undefined;
+    }
+  }
+
+  return AckDecoratorExtension;
+}

--- a/src/lib/decorators/ack/AckDecoratorExtension.ts
+++ b/src/lib/decorators/ack/AckDecoratorExtension.ts
@@ -11,10 +11,8 @@ export function AckDecorated<T extends BaseMessageConstructor>(Base: T) {
     @ValidateNested()
     public pleaseAck?: AckDecorator;
 
-    public setPleaseAck(pleaseAck: Record<string, unknown>) {
-      this.pleaseAck = new AckDecorator({
-        pleaseAck,
-      });
+    public setPleaseAck() {
+      this.pleaseAck = new AckDecorator();
     }
 
     public getPleaseAck(): AckDecorator | undefined {
@@ -22,7 +20,7 @@ export function AckDecorated<T extends BaseMessageConstructor>(Base: T) {
     }
 
     public requiresAck(): boolean {
-      return !!this.pleaseAck;
+      return this.pleaseAck !== undefined;
     }
   }
 

--- a/src/lib/decorators/ack/AckDecoratorExtension.ts
+++ b/src/lib/decorators/ack/AckDecoratorExtension.ts
@@ -18,9 +18,11 @@ export function AckDecorated<T extends BaseMessageConstructor>(Base: T) {
     }
 
     public getPleaseAck(): AckDecorator | undefined {
-      if (this.pleaseAck) return this.pleaseAck;
+      return this.pleaseAck;
+    }
 
-      return undefined;
+    public requiresAck(): boolean {
+      return !!this.pleaseAck;
     }
   }
 

--- a/src/lib/handlers/credentials/CredentialAckHandler.ts
+++ b/src/lib/handlers/credentials/CredentialAckHandler.ts
@@ -1,0 +1,16 @@
+import { Handler, HandlerInboundMessage } from '../Handler';
+import { CredentialService } from '../../protocols/credentials/CredentialService';
+import { CredentialAckMessage } from '../../protocols/credentials/messages/CredentialAckMessage';
+
+export class CredentialAckHandler implements Handler {
+  private credentialService: CredentialService;
+  public supportedMessages = [CredentialAckMessage];
+
+  public constructor(credentialService: CredentialService) {
+    this.credentialService = credentialService;
+  }
+
+  public async handle(messageContext: HandlerInboundMessage<CredentialAckHandler>) {
+    await this.credentialService.processAck(messageContext);
+  }
+}

--- a/src/lib/handlers/credentials/CredentialOfferHandler.ts
+++ b/src/lib/handlers/credentials/CredentialOfferHandler.ts
@@ -11,7 +11,6 @@ export class CredentialOfferHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<CredentialOfferHandler>) {
-    const outboudMessage = await this.credentialService.processCredentialOffer(messageContext);
-    return outboudMessage;
+    await this.credentialService.processCredentialOffer(messageContext);
   }
 }

--- a/src/lib/handlers/credentials/CredentialResponseHandler.ts
+++ b/src/lib/handlers/credentials/CredentialResponseHandler.ts
@@ -3,6 +3,7 @@ import { CredentialService } from '../../protocols/credentials/CredentialService
 import { CredentialResponseMessage } from '../../protocols/credentials/messages/CredentialResponseMessage';
 import { LedgerService } from '../../agent/LedgerService';
 import { JsonEncoder } from '../../utils/JsonEncoder';
+import { createOutboundMessage } from '../../protocols/helpers';
 
 export class CredentialResponseHandler implements Handler {
   private credentialService: CredentialService;
@@ -18,9 +19,14 @@ export class CredentialResponseHandler implements Handler {
     const [responseAttachment] = messageContext.message.attachments;
     const cred = JsonEncoder.fromBase64(responseAttachment.data.base64);
     const credentialDefinition = await this.ledgerService.getCredentialDefinition(cred.cred_def_id);
-    await this.credentialService.processCredentialResponse(messageContext, credentialDefinition);
-    // check if contians please ack
-    // create ack message
-    // send ack message
+    const credential = await this.credentialService.processCredentialResponse(messageContext, credentialDefinition);
+
+    if (messageContext.message.requiresAck()) {
+      if (!messageContext.connection) {
+        throw new Error('There is no connection in message context.');
+      }
+      const message = await this.credentialService.createAck(credential.id);
+      return createOutboundMessage(messageContext.connection, message);
+    }
   }
 }

--- a/src/lib/handlers/credentials/CredentialResponseHandler.ts
+++ b/src/lib/handlers/credentials/CredentialResponseHandler.ts
@@ -19,5 +19,8 @@ export class CredentialResponseHandler implements Handler {
     const cred = JsonEncoder.fromBase64(responseAttachment.data.base64);
     const credentialDefinition = await this.ledgerService.getCredentialDefinition(cred.cred_def_id);
     await this.credentialService.processCredentialResponse(messageContext, credentialDefinition);
+    // check if contians please ack
+    // create ack message
+    // send ack message
   }
 }

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -73,7 +73,9 @@ export class CredentialService extends EventEmitter {
    *
    * @param messageContext
    */
-  public async processCredentialOffer(messageContext: InboundMessageContext<CredentialOfferMessage>): Promise<void> {
+  public async processCredentialOffer(
+    messageContext: InboundMessageContext<CredentialOfferMessage>
+  ): Promise<CredentialRecord> {
     const credentialOffer = messageContext.message;
     const connection = messageContext.connection;
 
@@ -81,14 +83,15 @@ export class CredentialService extends EventEmitter {
       throw new Error('There is no connection in message context.');
     }
 
-    const credential = new CredentialRecord({
+    const credentialRecord = new CredentialRecord({
       connectionId: connection.id,
       offer: credentialOffer,
       state: CredentialState.OfferReceived,
       tags: { threadId: credentialOffer.id },
     });
-    await this.credentialRepository.save(credential);
-    this.emit(EventType.StateChanged, { credential, prevState: null });
+    await this.credentialRepository.save(credentialRecord);
+    this.emit(EventType.StateChanged, { credential: credentialRecord, prevState: null });
+    return credentialRecord;
   }
 
   /**

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -235,6 +235,7 @@ export class CredentialService extends EventEmitter {
     const credential = await this.credentialRepository.find(credentialId);
     const ackMessage = new CredentialAckMessage({});
     ackMessage.setThread({ threadId: credential.tags.threadId });
+    ackMessage.setPleaseAck({});
     await this.updateState(credential, CredentialState.Done);
     return ackMessage;
   }

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -250,6 +250,7 @@ export class CredentialService extends EventEmitter {
     }
 
     await this.updateState(credential, CredentialState.Done);
+    return credential;
   }
 
   public async getAll(): Promise<CredentialRecord[]> {

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -14,6 +14,7 @@ import { CredentialResponseMessage } from './messages/CredentialResponseMessage'
 import { JsonEncoder } from '../../utils/JsonEncoder';
 import { CredentialUtils } from './CredentialUtils';
 import { JsonTransformer } from '../../utils/JsonTransformer';
+import { CredentialAckMessage } from './messages/CredentialAckMessage';
 
 export enum EventType {
   StateChanged = 'stateChanged',
@@ -228,6 +229,10 @@ export class CredentialService extends EventEmitter {
 
     credential.credentialId = credentialId;
     await this.updateState(credential, CredentialState.CredentialReceived);
+  }
+
+  public createAck(id: string): Promise<CredentialAckMessage> {
+    throw new Error('Method not implemented.');
   }
 
   public async getAll(): Promise<CredentialRecord[]> {

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -241,6 +241,17 @@ export class CredentialService extends EventEmitter {
     return ackMessage;
   }
 
+  public async processAck(messageContext: InboundMessageContext<CredentialAckMessage>) {
+    const threadId = messageContext.message.thread?.threadId;
+    const [credential] = await this.credentialRepository.findByQuery({ threadId });
+
+    if (!credential) {
+      throw new Error(`No credential found for threadId = ${threadId}`);
+    }
+
+    await this.updateState(credential, CredentialState.Done);
+  }
+
   public async getAll(): Promise<CredentialRecord[]> {
     return this.credentialRepository.findAll();
   }

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -192,6 +192,7 @@ export class CredentialService extends EventEmitter {
       attachments: [responseAttachment],
     });
     credentialResponse.setThread({ threadId: credential.tags.threadId });
+    credentialResponse.setPleaseAck({});
 
     await this.updateState(credential, CredentialState.CredentialIssued);
     return credentialResponse;
@@ -229,13 +230,13 @@ export class CredentialService extends EventEmitter {
 
     credential.credentialId = credentialId;
     await this.updateState(credential, CredentialState.CredentialReceived);
+    return credential;
   }
 
   public async createAck(credentialId: string): Promise<CredentialAckMessage> {
     const credential = await this.credentialRepository.find(credentialId);
     const ackMessage = new CredentialAckMessage({});
     ackMessage.setThread({ threadId: credential.tags.threadId });
-    ackMessage.setPleaseAck({});
     await this.updateState(credential, CredentialState.Done);
     return ackMessage;
   }

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -231,8 +231,12 @@ export class CredentialService extends EventEmitter {
     await this.updateState(credential, CredentialState.CredentialReceived);
   }
 
-  public createAck(id: string): Promise<CredentialAckMessage> {
-    throw new Error('Method not implemented.');
+  public async createAck(credentialId: string): Promise<CredentialAckMessage> {
+    const credential = await this.credentialRepository.find(credentialId);
+    const ackMessage = new CredentialAckMessage({});
+    ackMessage.setThread({ threadId: credential.tags.threadId });
+    await this.updateState(credential, CredentialState.Done);
+    return ackMessage;
   }
 
   public async getAll(): Promise<CredentialRecord[]> {

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -39,9 +39,10 @@ export class CredentialService extends EventEmitter {
    */
   public async createCredentialOffer(
     connection: ConnectionRecord,
-    { credDefId, comment, preview }: CredentialOfferTemplate
+    credentialTemplate: CredentialOfferTemplate
   ): Promise<CredentialOfferMessage> {
-    const credOffer = await this.wallet.createCredentialOffer(credDefId);
+    const { credentialDefinitionId, comment, preview } = credentialTemplate;
+    const credOffer = await this.wallet.createCredentialOffer(credentialDefinitionId);
     const attachment = new Attachment({
       mimeType: 'application/json',
       data: {
@@ -195,7 +196,7 @@ export class CredentialService extends EventEmitter {
       attachments: [responseAttachment],
     });
     credentialResponse.setThread({ threadId: credential.tags.threadId });
-    credentialResponse.setPleaseAck({});
+    credentialResponse.setPleaseAck();
 
     await this.updateState(credential, CredentialState.CredentialIssued);
     return credentialResponse;
@@ -273,7 +274,7 @@ export class CredentialService extends EventEmitter {
 }
 
 export interface CredentialOfferTemplate {
-  credDefId: CredDefId;
+  credentialDefinitionId: CredDefId;
   comment?: string;
   preview: CredentialPreview;
 }

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -227,8 +227,7 @@ export class CredentialService extends EventEmitter {
     );
 
     credential.credentialId = credentialId;
-    credential.state = CredentialState.CredentialReceived;
-    this.credentialRepository.update(credential);
+    await this.updateState(credential, CredentialState.CredentialReceived);
   }
 
   public async getAll(): Promise<CredentialRecord[]> {

--- a/src/lib/protocols/credentials/CredentialState.ts
+++ b/src/lib/protocols/credentials/CredentialState.ts
@@ -5,4 +5,5 @@ export enum CredentialState {
   RequestReceived = 'REQUEST_RECEIVED',
   CredentialIssued = 'CREDENTIAL_ISSUED',
   CredentialReceived = 'CREDENTIAL_RECEIVED',
+  Done = 'DONE',
 }

--- a/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
+++ b/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
@@ -430,6 +430,7 @@ describe('CredentialService', () => {
             },
           },
         ],
+        '~please_ack': {},
       });
 
       // We're using instance of `StubWallet`. Value of `cred` should be as same as in the credential response message.

--- a/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
+++ b/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
@@ -291,7 +291,6 @@ describe('CredentialService', () => {
         '@id': expect.any(String),
         '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/request-credential',
         '~thread': {
-          // @ts-ignore
           thid: 'fd9c5ddb-ec11-4acd-bc32-540736249746',
         },
         comment: 'some credential request comment',
@@ -419,7 +418,6 @@ describe('CredentialService', () => {
         '@id': expect.any(String),
         '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/issue-credential',
         '~thread': {
-          // @ts-ignore
           thid: 'fd9c5ddb-ec11-4acd-bc32-540736249746',
         },
         comment,
@@ -504,6 +502,36 @@ describe('CredentialService', () => {
           state: 'CREDENTIAL_RECEIVED',
         },
       });
+    });
+  });
+
+  describe('createAck', () => {
+    let repositoryFindMock: jest.Mock<Promise<CredentialRecord>, [string]>;
+
+    beforeEach(() => {
+      credentialRepository = new CredentialRepository();
+      credentialService = new CredentialService(wallet, credentialRepository);
+      // make separate mockFind variable to get the correct jest mock typing
+      repositoryFindMock = credentialRepository.find as jest.Mock<Promise<CredentialRecord>, [string]>;
+    });
+
+    test('returns credential response message base on credential request message', async () => {
+      const credential = mockCredentialRecord({
+        state: CredentialState.CredentialReceived,
+        tags: { threadId: 'fd9c5ddb-ec11-4acd-bc32-540736249746' },
+      });
+      repositoryFindMock.mockReturnValue(Promise.resolve(credential));
+
+      const ackMessage = await credentialService.createAck(credential.id);
+
+      expect(ackMessage.toJSON()).toMatchObject({
+        '@id': expect.any(String),
+        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/ack',
+        '~thread': {
+          thid: 'fd9c5ddb-ec11-4acd-bc32-540736249746',
+        },
+      });
+      expect(false).toEqual(true);
     });
   });
 });

--- a/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
+++ b/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
@@ -199,23 +199,25 @@ describe('CredentialService', () => {
       credentialService = new CredentialService(wallet, credentialRepository);
     });
 
-    test('creates credential record in OFFER_RECEIVED state with offer, thread ID', async () => {
+    test('creates and return credential record in OFFER_RECEIVED state with offer, thread ID', async () => {
       const repositorySaveSpy = jest.spyOn(credentialRepository, 'save');
 
       // when
-      await credentialService.processCredentialOffer(messageContext);
+      const returnedCredentialRecrod = await credentialService.processCredentialOffer(messageContext);
 
       // then
-      expect(repositorySaveSpy).toHaveBeenCalledTimes(1);
-      const [[createdCredentialRecord]] = repositorySaveSpy.mock.calls;
-      expect(createdCredentialRecord).toMatchObject({
+      const expectedCredentialRecord = {
         type: CredentialRecord.name,
         id: expect.any(String),
         createdAt: expect.any(Number),
         offer: credentialOfferMessage,
         tags: { threadId: credentialOfferMessage.id },
         state: 'OFFER_RECEIVED',
-      });
+      };
+      expect(repositorySaveSpy).toHaveBeenCalledTimes(1);
+      const [[createdCredentialRecord]] = repositorySaveSpy.mock.calls;
+      expect(createdCredentialRecord).toMatchObject(expectedCredentialRecord);
+      expect(returnedCredentialRecrod).toMatchObject(expectedCredentialRecord);
     });
 
     test(`emits stateChange event with OFFER_RECEIVED`, async () => {

--- a/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
+++ b/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
@@ -99,13 +99,13 @@ describe('CredentialService', () => {
   });
 
   describe('createCredentialOffer', () => {
-    let credentialOfferTemplate: CredentialOfferTemplate;
+    let credentialTemplate: CredentialOfferTemplate;
 
     beforeEach(() => {
       credentialRepository = new CredentialRepository();
       credentialService = new CredentialService(wallet, credentialRepository);
-      credentialOfferTemplate = {
-        credDefId: 'Th7MpTaRZVRYnPiabds81Y:3:CL:17:TAG',
+      credentialTemplate = {
+        credentialDefinitionId: 'Th7MpTaRZVRYnPiabds81Y:3:CL:17:TAG',
         comment: 'some comment',
         preview,
       };
@@ -116,7 +116,7 @@ describe('CredentialService', () => {
       const repositorySaveSpy = jest.spyOn(credentialRepository, 'save');
 
       // when
-      const credentialOffer = await credentialService.createCredentialOffer(connection, credentialOfferTemplate);
+      const credentialOffer = await credentialService.createCredentialOffer(connection, credentialTemplate);
 
       // then
       expect(repositorySaveSpy).toHaveBeenCalledTimes(1);
@@ -135,7 +135,7 @@ describe('CredentialService', () => {
       const eventListenerMock = jest.fn();
       credentialService.on(EventType.StateChanged, eventListenerMock);
 
-      await credentialService.createCredentialOffer(connection, credentialOfferTemplate);
+      await credentialService.createCredentialOffer(connection, credentialTemplate);
 
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
       const [[event]] = eventListenerMock.mock.calls;
@@ -148,7 +148,7 @@ describe('CredentialService', () => {
     });
 
     test('returns credential offer message', async () => {
-      const credentialOffer = await credentialService.createCredentialOffer(connection, credentialOfferTemplate);
+      const credentialOffer = await credentialService.createCredentialOffer(connection, credentialTemplate);
 
       expect(credentialOffer.toJSON()).toMatchObject({
         '@id': expect.any(String),

--- a/src/lib/protocols/credentials/messages/CredentialAckMessage.ts
+++ b/src/lib/protocols/credentials/messages/CredentialAckMessage.ts
@@ -1,12 +1,9 @@
 import { Equals } from 'class-validator';
 import { AgentMessage } from '../../../agent/AgentMessage';
 import { MessageType } from './MessageType';
-import { Attachment } from './Attachment';
 
 interface CredentialAckMessageOptions {
   id?: string;
-  comment?: string;
-  attachments: Attachment[];
 }
 
 export class CredentialAckMessage extends AgentMessage {
@@ -20,5 +17,5 @@ export class CredentialAckMessage extends AgentMessage {
 
   @Equals(CredentialAckMessage.type)
   public readonly type = CredentialAckMessage.type;
-  public static readonly type = MessageType.CredentialResponse;
+  public static readonly type = MessageType.CredentialAck;
 }

--- a/src/lib/protocols/credentials/messages/CredentialAckMessage.ts
+++ b/src/lib/protocols/credentials/messages/CredentialAckMessage.ts
@@ -1,0 +1,24 @@
+import { Equals } from 'class-validator';
+import { AgentMessage } from '../../../agent/AgentMessage';
+import { MessageType } from './MessageType';
+import { Attachment } from './Attachment';
+
+interface CredentialAckMessageOptions {
+  id?: string;
+  comment?: string;
+  attachments: Attachment[];
+}
+
+export class CredentialAckMessage extends AgentMessage {
+  public constructor(options: CredentialAckMessageOptions) {
+    super();
+
+    if (options) {
+      this.id = options.id || this.generateId();
+    }
+  }
+
+  @Equals(CredentialAckMessage.type)
+  public readonly type = CredentialAckMessage.type;
+  public static readonly type = MessageType.CredentialResponse;
+}

--- a/src/lib/protocols/credentials/messages/CredentialAckMessage.ts
+++ b/src/lib/protocols/credentials/messages/CredentialAckMessage.ts
@@ -11,7 +11,7 @@ export class CredentialAckMessage extends AgentMessage {
     super();
 
     if (options) {
-      this.id = options.id || this.generateId();
+      this.id = options.id ?? this.generateId();
     }
   }
 

--- a/src/lib/protocols/credentials/messages/MessageType.ts
+++ b/src/lib/protocols/credentials/messages/MessageType.ts
@@ -3,4 +3,5 @@ export enum MessageType {
   CredentialPreview = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview',
   CredentialRequest = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/request-credential',
   CredentialResponse = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/issue-credential',
+  CredentialAck = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/ack',
 }


### PR DESCRIPTION
This implements the ack part of the issue #64. I suggest closing that issue after the merge of this PR and eventually create other issues for the remaining functionality we would like to implement related to credential exchange.

What I see as remaining:
* full implementation of message threading with attributes like `sender_order` and `received_orders`
* alternative beginning with a credential proposal