### PR TITLE
use dids without prefix for connections

### DIFF
--- a/src/lib/handlers/trustping/TrustPingMessageHandler.ts
+++ b/src/lib/handlers/trustping/TrustPingMessageHandler.ts
@@ -3,7 +3,6 @@ import { TrustPingService } from '../../protocols/trustping/TrustPingService';
 import { ConnectionService } from '../../protocols/connections/ConnectionService';
 import { ConnectionState } from '../../protocols/connections/domain/ConnectionState';
 import { TrustPingMessage } from '../../protocols/trustping/TrustPingMessage';
-import { ConnectionRole } from '../../protocols/connections/domain/ConnectionRole';
 
 export class TrustPingMessageHandler implements Handler {
   private trustPingService: TrustPingService;

--- a/src/lib/handlers/trustping/TrustPingMessageHandler.ts
+++ b/src/lib/handlers/trustping/TrustPingMessageHandler.ts
@@ -23,7 +23,7 @@ export class TrustPingMessageHandler implements Handler {
 
     // TODO: This is better addressed in a middleware of some kind because
     // any message can transition the state to complete, not just an ack or trust ping
-    if (connection.state === ConnectionState.Responded && connection.role === ConnectionRole.Inviter) {
+    if (connection.state === ConnectionState.Responded) {
       await this.connectionService.updateState(connection, ConnectionState.Complete);
     }
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -5,6 +5,7 @@ export { Agent } from './agent/Agent';
 export { InboundTransporter } from './transport/InboundTransporter';
 export { OutboundTransporter } from './transport/OutboundTransporter';
 export { encodeInvitationToUrl, decodeInvitationFromUrl } from './helpers';
+export { InitConfig, OutboundPackage } from './types';
 
 export { ConnectionRecord } from './storage/ConnectionRecord';
 export { EventType as ConnectionEventType } from './protocols/connections/ConnectionService';

--- a/src/lib/protocols/connections/ConnectionService.test.ts
+++ b/src/lib/protocols/connections/ConnectionService.test.ts
@@ -339,7 +339,7 @@ describe('ConnectionService', () => {
       expect.assertions(2);
 
       // Needed for signing connection~sig
-      const [did, verkey] = await wallet.createDid({ method_name: 'sov' });
+      const [did, verkey] = await wallet.createDid();
       const connectionRecord = getMockConnection({
         did,
         verkey,
@@ -387,8 +387,8 @@ describe('ConnectionService', () => {
     it('returns a connection record containing the information from the connection response', async () => {
       expect.assertions(3);
 
-      const [did, verkey] = await wallet.createDid({ method_name: 'sov' });
-      const [theirDid, theirVerkey] = await wallet.createDid({ method_name: 'sov' });
+      const [did, verkey] = await wallet.createDid();
+      const [theirDid, theirVerkey] = await wallet.createDid();
       const connectionRecord = getMockConnection({
         did,
         verkey,
@@ -433,8 +433,8 @@ describe('ConnectionService', () => {
     it('throws an error when the connection sig is not signed with the same key as the recipient key from the invitation', async () => {
       expect.assertions(1);
 
-      const [did, verkey] = await wallet.createDid({ method_name: 'sov' });
-      const [theirDid, theirVerkey] = await wallet.createDid({ method_name: 'sov' });
+      const [did, verkey] = await wallet.createDid();
+      const [theirDid, theirVerkey] = await wallet.createDid();
       const connectionRecord = getMockConnection({
         did,
         verkey,
@@ -504,8 +504,8 @@ describe('ConnectionService', () => {
     it('throws an error when the message does not contain a did doc with any recipientKeys', async () => {
       expect.assertions(1);
 
-      const [did, verkey] = await wallet.createDid({ method_name: 'sov' });
-      const [theirDid, theirVerkey] = await wallet.createDid({ method_name: 'sov' });
+      const [did, verkey] = await wallet.createDid();
+      const [theirDid, theirVerkey] = await wallet.createDid();
       const connectionRecord = getMockConnection({
         did,
         verkey,

--- a/src/lib/protocols/connections/ConnectionService.ts
+++ b/src/lib/protocols/connections/ConnectionService.ts
@@ -309,7 +309,7 @@ class ConnectionService extends EventEmitter {
     autoAcceptConnection?: boolean;
     tags?: ConnectionTags;
   }): Promise<ConnectionRecord> {
-    const [did, verkey] = await this.wallet.createDid({ method_name: 'sov' });
+    const [did, verkey] = await this.wallet.createDid();
     const publicKey = new PublicKey(`${did}#1`, PublicKeyType.ED25519_SIG_2018, did, verkey);
     const service = new Service(
       `${did};indy`,


### PR DESCRIPTION
This removes the `did:sov` prefix from dids to be interoperable with ACA-Py. It also contains some other fixes to make AFJ usable in AATH.

Fixes #124