### PR TITLE
refactor: Credential service method signatures

### DIFF
--- a/src/lib/handlers/credentials/CredentialRequestHandler.ts
+++ b/src/lib/handlers/credentials/CredentialRequestHandler.ts
@@ -13,7 +13,7 @@ export class CredentialRequestHandler implements Handler {
 
   public async handle(messageContext: HandlerInboundMessage<CredentialRequestHandler>) {
     const credential = await this.credentialService.processCredentialRequest(messageContext);
-    const message = await this.credentialService.createCredentialResponse(credential.id, { comment: '' });
+    const message = await this.credentialService.createCredentialResponse(credential.id);
     if (!messageContext.connection) {
       throw new Error('There is no connection in message context.');
     }

--- a/src/lib/modules/CredentialsModule.ts
+++ b/src/lib/modules/CredentialsModule.ts
@@ -54,8 +54,7 @@ export class CredentialsModule {
     const credentialRequestMessage = await this.credentialService.createCredentialRequest(
       connection,
       credential,
-      credentialDefinition,
-      {}
+      credentialDefinition
     );
 
     const outboundMessage = createOutboundMessage(connection, credentialRequestMessage);

--- a/src/lib/modules/CredentialsModule.ts
+++ b/src/lib/modules/CredentialsModule.ts
@@ -54,7 +54,8 @@ export class CredentialsModule {
     const credentialRequestMessage = await this.credentialService.createCredentialRequest(
       connection,
       credential,
-      credentialDefinition
+      credentialDefinition,
+      {}
     );
 
     const outboundMessage = createOutboundMessage(connection, credentialRequestMessage);

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -106,7 +106,7 @@ export class CredentialService extends EventEmitter {
     connection: ConnectionRecord,
     credential: CredentialRecord,
     credentialDefinition: CredDef,
-    options: CredentialRequestOptions
+    options: CredentialRequestOptions = {}
   ): Promise<CredentialRequestMessage> {
     const proverDid = connection.did;
 
@@ -169,7 +169,7 @@ export class CredentialService extends EventEmitter {
    */
   public async createCredentialResponse(
     credentialId: string,
-    options: CredentialResponseOptions
+    options: CredentialResponseOptions = {}
   ): Promise<CredentialResponseMessage> {
     const credential = await this.credentialRepository.find(credentialId);
 

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -100,12 +100,13 @@ export class CredentialService extends EventEmitter {
    *
    * @param connection Connection between holder and issuer
    * @param credential
-   * @param credDef
+   * @param credentialDefinition
    */
   public async createCredentialRequest(
     connection: ConnectionRecord,
     credential: CredentialRecord,
-    credDef: CredDef
+    credentialDefinition: CredDef,
+    options: CredentialRequestOptions
   ): Promise<CredentialRequestMessage> {
     const proverDid = connection.did;
 
@@ -119,7 +120,7 @@ export class CredentialService extends EventEmitter {
     const [credReq, credReqMetadata] = await this.wallet.createCredentialRequest(
       proverDid,
       credOffer,
-      credDef,
+      credentialDefinition,
       'master_secret'
     );
     const attachment = new Attachment({
@@ -128,10 +129,9 @@ export class CredentialService extends EventEmitter {
         base64: JsonEncoder.toBase64(credReq),
       },
     });
-    const credentialRequest = new CredentialRequestMessage({
-      comment: 'some credential request comment',
-      attachments: [attachment],
-    });
+
+    const { comment } = options;
+    const credentialRequest = new CredentialRequestMessage({ comment, attachments: [attachment] });
     credentialRequest.setThread({ threadId: credential.tags.threadId });
 
     credential.requestMetadata = credReqMetadata;
@@ -167,7 +167,10 @@ export class CredentialService extends EventEmitter {
    * @param credentialId Credential record ID
    * @param credentialResponseOptions
    */
-  public async createCredentialResponse(credentialId: string, { comment }: CredentialResponseOptions) {
+  public async createCredentialResponse(
+    credentialId: string,
+    options: CredentialResponseOptions
+  ): Promise<CredentialResponseMessage> {
     const credential = await this.credentialRepository.find(credentialId);
 
     // FIXME: credential.offer is already CredentialOfferMessage type
@@ -191,10 +194,8 @@ export class CredentialService extends EventEmitter {
       },
     });
 
-    const credentialResponse = new CredentialResponseMessage({
-      comment,
-      attachments: [responseAttachment],
-    });
+    const { comment } = options;
+    const credentialResponse = new CredentialResponseMessage({ comment, attachments: [responseAttachment] });
     credentialResponse.setThread({ threadId: credential.tags.threadId });
     credentialResponse.setPleaseAck();
 
@@ -211,7 +212,7 @@ export class CredentialService extends EventEmitter {
   public async processCredentialResponse(
     messageContext: InboundMessageContext<CredentialResponseMessage>,
     credentialDefinition: CredDef
-  ) {
+  ): Promise<CredentialRecord> {
     const [responseAttachment] = messageContext.message.attachments;
     const cred = JsonEncoder.fromBase64(responseAttachment.data.base64);
 
@@ -245,7 +246,7 @@ export class CredentialService extends EventEmitter {
     return ackMessage;
   }
 
-  public async processAck(messageContext: InboundMessageContext<CredentialAckMessage>) {
+  public async processAck(messageContext: InboundMessageContext<CredentialAckMessage>): Promise<CredentialRecord> {
     const threadId = messageContext.message.thread?.threadId;
     const [credential] = await this.credentialRepository.findByQuery({ threadId });
 
@@ -277,6 +278,10 @@ export interface CredentialOfferTemplate {
   credentialDefinitionId: CredDefId;
   comment?: string;
   preview: CredentialPreview;
+}
+
+interface CredentialRequestOptions {
+  comment?: string;
 }
 
 interface CredentialResponseOptions {

--- a/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
+++ b/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
@@ -256,7 +256,7 @@ describe('CredentialService', () => {
       const repositoryUpdateSpy = jest.spyOn(credentialRepository, 'update');
 
       // when
-      await credentialService.createCredentialRequest(connection, credentialRecord, credDef);
+      await credentialService.createCredentialRequest(connection, credentialRecord, credDef, {});
 
       // then
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1);
@@ -272,7 +272,7 @@ describe('CredentialService', () => {
       credentialService.on(EventType.StateChanged, eventListenerMock);
 
       // when
-      await credentialService.createCredentialRequest(connection, credentialRecord, credDef);
+      await credentialService.createCredentialRequest(connection, credentialRecord, credDef, {});
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
@@ -286,15 +286,22 @@ describe('CredentialService', () => {
     });
 
     test('returns credential request message base on existing credential offer message', async () => {
-      const credentialRequest = await credentialService.createCredentialRequest(connection, credentialRecord, credDef);
+      // given
+      const comment = 'credential request comment';
 
+      // when
+      const credentialRequest = await credentialService.createCredentialRequest(connection, credentialRecord, credDef, {
+        comment,
+      });
+
+      // then
       expect(credentialRequest.toJSON()).toMatchObject({
         '@id': expect.any(String),
         '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/request-credential',
         '~thread': {
           thid: 'fd9c5ddb-ec11-4acd-bc32-540736249746',
         },
-        comment: 'some credential request comment',
+        comment,
         'requests~attach': [
           {
             '@id': expect.any(String),
@@ -412,7 +419,6 @@ describe('CredentialService', () => {
 
       // when
       await credentialService.createCredentialResponse(credential.id, {});
-      expect(eventListenerMock).toHaveBeenCalledTimes(1);
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1);

--- a/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
+++ b/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
@@ -256,7 +256,7 @@ describe('CredentialService', () => {
       const repositoryUpdateSpy = jest.spyOn(credentialRepository, 'update');
 
       // when
-      await credentialService.createCredentialRequest(connection, credentialRecord, credDef, {});
+      await credentialService.createCredentialRequest(connection, credentialRecord, credDef);
 
       // then
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1);
@@ -272,7 +272,7 @@ describe('CredentialService', () => {
       credentialService.on(EventType.StateChanged, eventListenerMock);
 
       // when
-      await credentialService.createCredentialRequest(connection, credentialRecord, credDef, {});
+      await credentialService.createCredentialRequest(connection, credentialRecord, credDef);
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
@@ -401,7 +401,7 @@ describe('CredentialService', () => {
       repositoryFindMock.mockReturnValue(Promise.resolve(credential));
 
       // when
-      await credentialService.createCredentialResponse(credential.id, {});
+      await credentialService.createCredentialResponse(credential.id);
 
       // then
       const [[updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls;
@@ -418,7 +418,7 @@ describe('CredentialService', () => {
       repositoryFindMock.mockReturnValue(Promise.resolve(credential));
 
       // when
-      await credentialService.createCredentialResponse(credential.id, {});
+      await credentialService.createCredentialResponse(credential.id);
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Small changes in credential service method signatures, renaming params, add typing. This PR together with #122 fixes #117.