### PR TITLE
feat: Validate credential record state transitions

### DIFF
--- a/src/lib/handlers/credentials/CredentialOfferHandler.ts
+++ b/src/lib/handlers/credentials/CredentialOfferHandler.ts
@@ -11,6 +11,6 @@ export class CredentialOfferHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<CredentialOfferHandler>) {
-    await this.credentialService.processCredentialOffer(messageContext);
+    await this.credentialService.processOffer(messageContext);
   }
 }

--- a/src/lib/handlers/credentials/CredentialRequestHandler.ts
+++ b/src/lib/handlers/credentials/CredentialRequestHandler.ts
@@ -12,8 +12,8 @@ export class CredentialRequestHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<CredentialRequestHandler>) {
-    const credential = await this.credentialService.processCredentialRequest(messageContext);
-    const message = await this.credentialService.createCredentialResponse(credential.id);
+    const credential = await this.credentialService.processRequest(messageContext);
+    const message = await this.credentialService.createResponse(credential.id);
     if (!messageContext.connection) {
       throw new Error('There is no connection in message context.');
     }

--- a/src/lib/handlers/credentials/CredentialResponseHandler.ts
+++ b/src/lib/handlers/credentials/CredentialResponseHandler.ts
@@ -19,7 +19,7 @@ export class CredentialResponseHandler implements Handler {
     const [responseAttachment] = messageContext.message.attachments;
     const cred = JsonEncoder.fromBase64(responseAttachment.data.base64);
     const credentialDefinition = await this.ledgerService.getCredentialDefinition(cred.cred_def_id);
-    const credential = await this.credentialService.processCredentialResponse(messageContext, credentialDefinition);
+    const credential = await this.credentialService.processResponse(messageContext, credentialDefinition);
 
     if (messageContext.message.requiresAck()) {
       if (!messageContext.connection) {

--- a/src/lib/modules/CredentialsModule.ts
+++ b/src/lib/modules/CredentialsModule.ts
@@ -29,7 +29,7 @@ export class CredentialsModule {
   }
 
   public async issueCredential(connection: ConnectionRecord, credentialTemplate: CredentialOfferTemplate) {
-    const credentialOfferMessage = await this.credentialService.createCredentialOffer(connection, credentialTemplate);
+    const credentialOfferMessage = await this.credentialService.createOffer(connection, credentialTemplate);
     const outboundMessage = createOutboundMessage(connection, credentialOfferMessage);
     await this.messageSender.sendMessage(outboundMessage);
   }
@@ -51,7 +51,7 @@ export class CredentialsModule {
       throw new Error(`There is no connection with ID ${credential.connectionId}`);
     }
 
-    const credentialRequestMessage = await this.credentialService.createCredentialRequest(
+    const credentialRequestMessage = await this.credentialService.createRequest(
       connection,
       credential,
       credentialDefinition

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -106,7 +106,7 @@ export class CredentialService extends EventEmitter {
     credentialDefinition: CredDef,
     options: CredentialRequestOptions = {}
   ): Promise<CredentialRequestMessage> {
-    this.validateState(credential.state, CredentialState.OfferReceived);
+    this.assertState(credential.state, CredentialState.OfferReceived);
 
     const proverDid = connection.did;
 
@@ -154,7 +154,7 @@ export class CredentialService extends EventEmitter {
       threadId: messageContext.message.thread?.threadId,
     });
 
-    this.validateState(credential.state, CredentialState.OfferSent);
+    this.assertState(credential.state, CredentialState.OfferSent);
 
     logger.log('Credential record found when processing credential request', credential);
 
@@ -179,7 +179,7 @@ export class CredentialService extends EventEmitter {
       throw new Error(`Credential does not contain request.`);
     }
 
-    this.validateState(credential.state, CredentialState.RequestReceived);
+    this.assertState(credential.state, CredentialState.RequestReceived);
 
     // FIXME: credential.offer is already CredentialOfferMessage type
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -229,7 +229,7 @@ export class CredentialService extends EventEmitter {
       throw new Error('Credential does not contain request metadata.');
     }
 
-    this.validateState(credential.state, CredentialState.RequestSent);
+    this.assertState(credential.state, CredentialState.RequestSent);
 
     const [responseAttachment] = messageContext.message.attachments;
     const cred = JsonEncoder.fromBase64(responseAttachment.data.base64);
@@ -249,7 +249,7 @@ export class CredentialService extends EventEmitter {
   public async createAck(credentialId: string): Promise<CredentialAckMessage> {
     const credential = await this.credentialRepository.find(credentialId);
 
-    this.validateState(credential.state, CredentialState.CredentialReceived);
+    this.assertState(credential.state, CredentialState.CredentialReceived);
 
     const ackMessage = new CredentialAckMessage({});
     ackMessage.setThread({ threadId: credential.tags.threadId });
@@ -266,7 +266,7 @@ export class CredentialService extends EventEmitter {
       throw new Error(`No credential found for threadId = ${threadId}`);
     }
 
-    this.validateState(credential.state, CredentialState.CredentialIssued);
+    this.assertState(credential.state, CredentialState.CredentialIssued);
 
     await this.updateState(credential, CredentialState.Done);
     return credential;
@@ -280,9 +280,9 @@ export class CredentialService extends EventEmitter {
     return this.credentialRepository.find(id);
   }
 
-  private validateState(current: CredentialState, valid: CredentialState) {
-    if (current !== valid) {
-      throw new Error(`Credential record is in invalid state ${current}. Valid states are: ${valid}.`);
+  private assertState(current: CredentialState, expected: CredentialState) {
+    if (current !== expected) {
+      throw new Error(`Credential record is in invalid state ${current}. Valid states are: ${expected}.`);
     }
   }
 

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -37,7 +37,7 @@ export class CredentialService extends EventEmitter {
    * @param credentialOfferTemplate Template for credential offer
    * @returns Credential offer message
    */
-  public async createCredentialOffer(
+  public async createOffer(
     connection: ConnectionRecord,
     credentialTemplate: CredentialOfferTemplate
   ): Promise<CredentialOfferMessage> {
@@ -74,9 +74,7 @@ export class CredentialService extends EventEmitter {
    *
    * @param messageContext
    */
-  public async processCredentialOffer(
-    messageContext: InboundMessageContext<CredentialOfferMessage>
-  ): Promise<CredentialRecord> {
+  public async processOffer(messageContext: InboundMessageContext<CredentialOfferMessage>): Promise<CredentialRecord> {
     const credentialOffer = messageContext.message;
     const connection = messageContext.connection;
 
@@ -102,7 +100,7 @@ export class CredentialService extends EventEmitter {
    * @param credential
    * @param credentialDefinition
    */
-  public async createCredentialRequest(
+  public async createRequest(
     connection: ConnectionRecord,
     credential: CredentialRecord,
     credentialDefinition: CredDef,
@@ -146,7 +144,7 @@ export class CredentialService extends EventEmitter {
    *
    * @param messageContext
    */
-  public async processCredentialRequest(
+  public async processRequest(
     messageContext: InboundMessageContext<CredentialRequestMessage>
   ): Promise<CredentialRecord> {
     const [requestAttachment] = messageContext.message.attachments;
@@ -171,7 +169,7 @@ export class CredentialService extends EventEmitter {
    * @param credentialId Credential record ID
    * @param credentialResponseOptions
    */
-  public async createCredentialResponse(
+  public async createResponse(
     credentialId: string,
     options: CredentialResponseOptions = {}
   ): Promise<CredentialResponseMessage> {
@@ -214,7 +212,7 @@ export class CredentialService extends EventEmitter {
    * @param messageContext
    * @param credentialDefinition
    */
-  public async processCredentialResponse(
+  public async processResponse(
     messageContext: InboundMessageContext<CredentialResponseMessage>,
     credentialDefinition: CredDef
   ): Promise<CredentialRecord> {

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -177,11 +177,11 @@ export class CredentialService extends EventEmitter {
   ): Promise<CredentialResponseMessage> {
     const credential = await this.credentialRepository.find(credentialId);
 
-    this.validateState(credential.state, CredentialState.RequestReceived);
-
     if (!credential.request) {
-      throw new Error(`Credential does not contain credReqMetadata.`);
+      throw new Error(`Credential does not contain request.`);
     }
+
+    this.validateState(credential.state, CredentialState.RequestReceived);
 
     // FIXME: credential.offer is already CredentialOfferMessage type
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -227,11 +227,11 @@ export class CredentialService extends EventEmitter {
 
     logger.log('Credential record found when processing credential response', credential);
 
-    this.validateState(credential.state, CredentialState.RequestSent);
-
     if (!credential.requestMetadata) {
-      throw new Error(`Credential does not contain credReqMetadata.`);
+      throw new Error('Credential does not contain request metadata.');
     }
+
+    this.validateState(credential.state, CredentialState.RequestSent);
 
     const [responseAttachment] = messageContext.message.attachments;
     const cred = JsonEncoder.fromBase64(responseAttachment.data.base64);

--- a/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
+++ b/src/lib/protocols/credentials/__tests__/CredentialService.test.ts
@@ -130,7 +130,7 @@ describe('CredentialService', () => {
       const repositorySaveSpy = jest.spyOn(credentialRepository, 'save');
 
       // when
-      const credentialOffer = await credentialService.createCredentialOffer(connection, credentialTemplate);
+      const credentialOffer = await credentialService.createOffer(connection, credentialTemplate);
 
       // then
       expect(repositorySaveSpy).toHaveBeenCalledTimes(1);
@@ -149,7 +149,7 @@ describe('CredentialService', () => {
       const eventListenerMock = jest.fn();
       credentialService.on(EventType.StateChanged, eventListenerMock);
 
-      await credentialService.createCredentialOffer(connection, credentialTemplate);
+      await credentialService.createOffer(connection, credentialTemplate);
 
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
       const [[event]] = eventListenerMock.mock.calls;
@@ -162,7 +162,7 @@ describe('CredentialService', () => {
     });
 
     test('returns credential offer message', async () => {
-      const credentialOffer = await credentialService.createCredentialOffer(connection, credentialTemplate);
+      const credentialOffer = await credentialService.createOffer(connection, credentialTemplate);
 
       expect(credentialOffer.toJSON()).toMatchObject({
         '@id': expect.any(String),
@@ -214,7 +214,7 @@ describe('CredentialService', () => {
       const repositorySaveSpy = jest.spyOn(credentialRepository, 'save');
 
       // when
-      const returnedCredentialRecrod = await credentialService.processCredentialOffer(messageContext);
+      const returnedCredentialRecrod = await credentialService.processOffer(messageContext);
 
       // then
       const expectedCredentialRecord = {
@@ -236,7 +236,7 @@ describe('CredentialService', () => {
       credentialService.on(EventType.StateChanged, eventListenerMock);
 
       // when
-      await credentialService.processCredentialOffer(messageContext);
+      await credentialService.processOffer(messageContext);
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
@@ -264,7 +264,7 @@ describe('CredentialService', () => {
       const repositoryUpdateSpy = jest.spyOn(credentialRepository, 'update');
 
       // when
-      await credentialService.createCredentialRequest(connection, credentialRecord, credDef);
+      await credentialService.createRequest(connection, credentialRecord, credDef);
 
       // then
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1);
@@ -280,7 +280,7 @@ describe('CredentialService', () => {
       credentialService.on(EventType.StateChanged, eventListenerMock);
 
       // when
-      await credentialService.createCredentialRequest(connection, credentialRecord, credDef);
+      await credentialService.createRequest(connection, credentialRecord, credDef);
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
@@ -298,7 +298,7 @@ describe('CredentialService', () => {
       const comment = 'credential request comment';
 
       // when
-      const credentialRequest = await credentialService.createCredentialRequest(connection, credentialRecord, credDef, {
+      const credentialRequest = await credentialService.createRequest(connection, credentialRecord, credDef, {
         comment,
       });
 
@@ -328,7 +328,7 @@ describe('CredentialService', () => {
       await Promise.all(
         invalidCredentialStates.map(async state => {
           await expect(
-            credentialService.createCredentialRequest(connection, mockCredentialRecord({ state }), credDef)
+            credentialService.createRequest(connection, mockCredentialRecord({ state }), credDef)
           ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`);
         })
       );
@@ -354,7 +354,7 @@ describe('CredentialService', () => {
       repositoryFindByQueryMock.mockReturnValue(Promise.resolve([credential]));
 
       // when
-      const returnedCredentialRecord = await credentialService.processCredentialRequest(messageContext);
+      const returnedCredentialRecord = await credentialService.processRequest(messageContext);
 
       // then
       expect(repositoryFindByQueryMock).toHaveBeenCalledTimes(1);
@@ -376,7 +376,7 @@ describe('CredentialService', () => {
       credentialService.on(EventType.StateChanged, eventListenerMock);
       repositoryFindByQueryMock.mockReturnValue(Promise.resolve([credential]));
 
-      await credentialService.processCredentialRequest(messageContext);
+      await credentialService.processRequest(messageContext);
 
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
       const [[event]] = eventListenerMock.mock.calls;
@@ -394,7 +394,7 @@ describe('CredentialService', () => {
       await Promise.all(
         invalidCredentialStates.map(async state => {
           repositoryFindByQueryMock.mockReturnValue(Promise.resolve([mockCredentialRecord({ state })]));
-          await expect(credentialService.processCredentialRequest(messageContext)).rejects.toThrowError(
+          await expect(credentialService.processRequest(messageContext)).rejects.toThrowError(
             `Credential record is in invalid state ${state}. Valid states are: ${validState}.`
           );
         })
@@ -421,7 +421,7 @@ describe('CredentialService', () => {
       repositoryFindMock.mockReturnValue(Promise.resolve(credential));
 
       // when
-      await credentialService.createCredentialResponse(credential.id);
+      await credentialService.createResponse(credential.id);
 
       // then
       expect(repositoryFindMock).toHaveBeenCalledTimes(1);
@@ -440,7 +440,7 @@ describe('CredentialService', () => {
       repositoryFindMock.mockReturnValue(Promise.resolve(credential));
 
       // when
-      await credentialService.createCredentialResponse(credential.id);
+      await credentialService.createResponse(credential.id);
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
@@ -459,7 +459,7 @@ describe('CredentialService', () => {
       const comment = 'credential response comment';
 
       // when
-      const credentialResponse = await credentialService.createCredentialResponse(credential.id, { comment });
+      const credentialResponse = await credentialService.createResponse(credential.id, { comment });
 
       // then
       expect(credentialResponse.toJSON()).toMatchObject({
@@ -492,7 +492,7 @@ describe('CredentialService', () => {
       repositoryFindMock.mockReturnValue(Promise.resolve(mockCredentialRecord({ state: CredentialState.RequestSent })));
 
       // when, then
-      await expect(credentialService.createCredentialResponse(credential.id)).rejects.toThrowError(
+      await expect(credentialService.createResponse(credential.id)).rejects.toThrowError(
         'Credential does not contain request.'
       );
     });
@@ -505,7 +505,7 @@ describe('CredentialService', () => {
           repositoryFindMock.mockReturnValue(
             Promise.resolve(mockCredentialRecord({ state, tags: { threadId }, request: credReq }))
           );
-          await expect(credentialService.createCredentialResponse(credential.id)).rejects.toThrowError(
+          await expect(credentialService.createResponse(credential.id)).rejects.toThrowError(
             `Credential record is in invalid state ${state}. Valid states are: ${validState}.`
           );
         })
@@ -535,7 +535,7 @@ describe('CredentialService', () => {
       repositoryFindByQueryMock.mockReturnValue(Promise.resolve([credential]));
 
       // when
-      await credentialService.processCredentialResponse(messageContext, credDef);
+      await credentialService.processResponse(messageContext, credDef);
 
       // then
       expect(repositoryFindByQueryMock).toHaveBeenCalledTimes(1);
@@ -566,7 +566,7 @@ describe('CredentialService', () => {
       repositoryFindByQueryMock.mockReturnValue(Promise.resolve([credential]));
 
       // when
-      const updatedCredential = await credentialService.processCredentialResponse(messageContext, credDef);
+      const updatedCredential = await credentialService.processResponse(messageContext, credDef);
 
       // then
       const expectedCredentialRecord = {
@@ -587,7 +587,7 @@ describe('CredentialService', () => {
       repositoryFindByQueryMock.mockReturnValue(Promise.resolve([credential]));
 
       // when
-      await credentialService.processCredentialResponse(messageContext, credDef);
+      await credentialService.processResponse(messageContext, credDef);
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1);
@@ -607,7 +607,7 @@ describe('CredentialService', () => {
       );
 
       // when, then
-      await expect(credentialService.processCredentialResponse(messageContext, credDef)).rejects.toThrowError(
+      await expect(credentialService.processResponse(messageContext, credDef)).rejects.toThrowError(
         'Credential does not contain request metadata.'
       );
     });
@@ -620,7 +620,7 @@ describe('CredentialService', () => {
           repositoryFindByQueryMock.mockReturnValue(
             Promise.resolve([mockCredentialRecord({ state, requestMetadata: { cred_req: 'meta-data' } })])
           );
-          await expect(credentialService.processCredentialResponse(messageContext, credDef)).rejects.toThrowError(
+          await expect(credentialService.processResponse(messageContext, credDef)).rejects.toThrowError(
             `Credential record is in invalid state ${state}. Valid states are: ${validState}.`
           );
         })


### PR DESCRIPTION
I added validation to every credential service method, not sure if it is necessary. I use different parametrized tests than `jest.each`. I'm aware that's not so simple to read in this way, but I wanted to have just one test for every invalid state. This should fix #123.

I also added two unrelated tests for credential record attributes.