### PR TITLE
create master secret per wallet

### DIFF
--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -120,8 +120,7 @@ export class CredentialService extends EventEmitter {
     const [credReq, credReqMetadata] = await this.wallet.createCredentialRequest(
       proverDid,
       credOffer,
-      credentialDefinition,
-      'master_secret'
+      credentialDefinition
     );
     const attachment = new Attachment({
       mimeType: 'application/json',

--- a/src/lib/protocols/credentials/__tests__/StubWallet.ts
+++ b/src/lib/protocols/credentials/__tests__/StubWallet.ts
@@ -43,8 +43,7 @@ export class StubWallet implements Wallet {
   public createCredentialRequest(
     proverDid: string,
     offer: CredOffer,
-    credDef: CredDef,
-    masterSecretName: string
+    credDef: CredDef
   ): Promise<[CredReq, CredReqMetadata]> {
     return Promise.resolve([
       {

--- a/src/lib/wallet/Wallet.ts
+++ b/src/lib/wallet/Wallet.ts
@@ -15,12 +15,7 @@ export interface Wallet {
     config?: CredDefConfig
   ): Promise<[CredDefId, CredDef]>;
   createCredentialOffer(credDefId: CredDefId): Promise<CredOffer>;
-  createCredentialRequest(
-    proverDid: Did,
-    offer: CredOffer,
-    credDef: CredDef,
-    masterSecretName: string
-  ): Promise<[CredReq, CredReqMetadata]>;
+  createCredentialRequest(proverDid: Did, offer: CredOffer, credDef: CredDef): Promise<[CredReq, CredReqMetadata]>;
   createCredential(
     credOffer: CredOffer,
     credReq: CredReq,


### PR DESCRIPTION
Taken from the [ACA-Py implementation](https://github.com/hyperledger/aries-cloudagent-python/blob/ec9871f84d1faae696284c1d399ff8e4eb1f86e7/aries_cloudagent/wallet/indy.py#L278-L289). They create a master secret on wallet open that uses the same id as the wallet.

The current method created a master secret for each credential, with the same id. Which wouldn't allow to request more than one credential because the second time `proverCreateMasterSecret` would be called `AnoncredsMasterSecretDuplicateNameError` error would be thrown.

Fixes #131 