### PR TITLE
add indyError util for consistent error handling

### DIFF
--- a/src/lib/agent/MessageReceiver.ts
+++ b/src/lib/agent/MessageReceiver.ts
@@ -90,11 +90,6 @@ class MessageReceiver {
       } catch (error) {
         logger.log('error while unpacking message', error);
         throw error;
-        // if (error.indyName && error.indyName === 'WalletAlreadyExistsError') {
-        //   logger.log(error.indyName);
-        // } else {
-        //   throw error;
-        // }
       }
 
       // if the message is of type forward we should check whether the

--- a/src/lib/agent/ProvisioningService.ts
+++ b/src/lib/agent/ProvisioningService.ts
@@ -1,6 +1,7 @@
 import { Repository } from '../storage/Repository';
 import { ProvisioningRecord } from '../storage/ProvisioningRecord';
 import logger from '../logger';
+import { isIndyError } from '../utils/indyError';
 
 const UNIQUE_PROVISIONING_ID = 'UNIQUE_PROVISIONING_ID';
 
@@ -16,8 +17,7 @@ export class ProvisioningService {
       const provisioningRecord = await this.provisioningRepository.find(UNIQUE_PROVISIONING_ID);
       return provisioningRecord;
     } catch (error) {
-      if (error.name === 'IndyError' && error.message === '212') {
-        // WalletItemNotFound
+      if (isIndyError(error, 'WalletItemNotFound')) {
         logger.log('WalletItemNotFound');
         return null;
       } else {

--- a/src/lib/utils/__tests__/indyError.test.ts
+++ b/src/lib/utils/__tests__/indyError.test.ts
@@ -1,0 +1,49 @@
+import { isIndyError } from '../indyError';
+
+describe('isIndyError()', () => {
+  it('should return true when the name is "IndyError" and no errorName is passed', () => {
+    const error = { name: 'IndyError' };
+
+    expect(isIndyError(error)).toBe(true);
+  });
+
+  it('should return false when the name is not "IndyError"', () => {
+    const error = { name: 'IndyError2' };
+
+    expect(isIndyError(error)).toBe(false);
+    expect(isIndyError(error, 'WalletAlreadyExistsError')).toBe(false);
+  });
+
+  it('should return true when indyName matches the passed errorName', () => {
+    const error = { name: 'IndyError', indyName: 'WalletAlreadyExistsError' };
+
+    expect(isIndyError(error, 'WalletAlreadyExistsError')).toBe(true);
+  });
+
+  it('should return false when the indyName does not match the passes errorName', () => {
+    const error = { name: 'IndyError', indyName: 'WalletAlreadyExistsError' };
+
+    expect(isIndyError(error, 'DoesNotMatchError')).toBe(false);
+  });
+
+  // Below here are temporary until indy-sdk releases new version
+  it('should return true when the indyName is missing but the message contains a matching error code', () => {
+    const error = { name: 'IndyError', message: '212' };
+
+    expect(isIndyError(error, 'WalletItemNotFound')).toBe(true);
+  });
+
+  it('should return false when the indyName is missing and the message contains a valid but not matching error code', () => {
+    const error = { name: 'IndyError', message: '212' };
+
+    expect(isIndyError(error, 'DoesNotMatchError')).toBe(false);
+  });
+
+  it('should throw an error when the indyName is missing and the message contains an invalid error code', () => {
+    const error = { name: 'IndyError', message: '832882' };
+
+    expect(() => isIndyError(error, 'SomeNewErrorWeDoNotHave')).toThrowError(
+      'Could not determine errorName of indyError 832882'
+    );
+  });
+});

--- a/src/lib/utils/indyError.ts
+++ b/src/lib/utils/indyError.ts
@@ -1,0 +1,84 @@
+export const indyErrors: { [key: number]: string } = {
+  100: 'CommonInvalidParam1',
+  101: 'CommonInvalidParam2',
+  102: 'CommonInvalidParam3',
+  103: 'CommonInvalidParam4',
+  104: 'CommonInvalidParam5',
+  105: 'CommonInvalidParam6',
+  106: 'CommonInvalidParam7',
+  107: 'CommonInvalidParam8',
+  108: 'CommonInvalidParam9',
+  109: 'CommonInvalidParam10',
+  110: 'CommonInvalidParam11',
+  111: 'CommonInvalidParam12',
+  112: 'CommonInvalidState',
+  113: 'CommonInvalidStructure',
+  114: 'CommonIOError',
+  115: 'CommonInvalidParam13',
+  116: 'CommonInvalidParam14',
+  200: 'WalletInvalidHandle',
+  201: 'WalletUnknownTypeError',
+  202: 'WalletTypeAlreadyRegisteredError',
+  203: 'WalletAlreadyExistsError',
+  204: 'WalletNotFoundError',
+  205: 'WalletIncompatiblePoolError',
+  206: 'WalletAlreadyOpenedError',
+  207: 'WalletAccessFailed',
+  208: 'WalletInputError',
+  209: 'WalletDecodingError',
+  210: 'WalletStorageError',
+  211: 'WalletEncryptionError',
+  212: 'WalletItemNotFound',
+  213: 'WalletItemAlreadyExists',
+  214: 'WalletQueryError',
+  300: 'PoolLedgerNotCreatedError',
+  301: 'PoolLedgerInvalidPoolHandle',
+  302: 'PoolLedgerTerminated',
+  303: 'LedgerNoConsensusError',
+  304: 'LedgerInvalidTransaction',
+  305: 'LedgerSecurityError',
+  306: 'PoolLedgerConfigAlreadyExistsError',
+  307: 'PoolLedgerTimeout',
+  308: 'PoolIncompatibleProtocolVersion',
+  309: 'LedgerNotFound',
+  400: 'AnoncredsRevocationRegistryFullError',
+  401: 'AnoncredsInvalidUserRevocId',
+  404: 'AnoncredsMasterSecretDuplicateNameError',
+  405: 'AnoncredsProofRejected',
+  406: 'AnoncredsCredentialRevoked',
+  407: 'AnoncredsCredDefAlreadyExistsError',
+  500: 'UnknownCryptoTypeError',
+  600: 'DidAlreadyExistsError',
+  700: 'PaymentUnknownMethodError',
+  701: 'PaymentIncompatibleMethodsError',
+  702: 'PaymentInsufficientFundsError',
+  703: 'PaymentSourceDoesNotExistError',
+  704: 'PaymentOperationNotSupportedError',
+  705: 'PaymentExtraFundsError',
+  706: 'TransactionNotAllowedError',
+};
+
+export function isIndyError(error: any, errorName?: string) {
+  const indyError = error.name === 'IndyError';
+
+  // if no specific indy error name is passed
+  // or the error is no indy error
+  // we can already return
+  if (!indyError || !errorName) return indyError;
+
+  // NodeJS Wrapper is missing some type names. When a type is missing it will
+  // only have the error code as string in the message field
+  // Until that is fixed we take that into account to make AFJ work with rn-indy-sdk
+  // See: https://github.com/AbsaOSS/rn-indy-sdk/pull/24
+  // See: https://github.com/hyperledger/indy-sdk/pull/2283
+  if (!error.indyName) {
+    const errorCode = Number(error.message);
+    if (errorCode !== NaN && indyErrors.hasOwnProperty(errorCode)) {
+      return errorName === indyErrors[errorCode];
+    }
+
+    throw new Error(`Could not determine errorName of indyError ${error.message}`);
+  }
+
+  return error.indyName === errorName;
+}

--- a/src/lib/utils/indyError.ts
+++ b/src/lib/utils/indyError.ts
@@ -73,7 +73,7 @@ export function isIndyError(error: any, errorName?: string) {
   // See: https://github.com/hyperledger/indy-sdk/pull/2283
   if (!error.indyName) {
     const errorCode = Number(error.message);
-    if (errorCode !== NaN && indyErrors.hasOwnProperty(errorCode)) {
+    if (!isNaN(errorCode) && indyErrors.hasOwnProperty(errorCode)) {
       return errorName === indyErrors[errorCode];
     }
 

--- a/src/lib/wallet/IndyWallet.ts
+++ b/src/lib/wallet/IndyWallet.ts
@@ -1,5 +1,6 @@
 import logger from '../logger';
 import { UnpackedMessageContext } from '../types';
+import { isIndyError } from '../utils/indyError';
 import { Wallet, DidInfo } from './Wallet';
 
 export class IndyWallet implements Wallet {
@@ -25,7 +26,7 @@ export class IndyWallet implements Wallet {
       await this.indy.createWallet(this.walletConfig, this.walletCredentials);
     } catch (error) {
       logger.log('error', error);
-      if (error.indyName && error.indyName === 'WalletAlreadyExistsError') {
+      if (isIndyError(error, 'WalletAlreadyExistsError')) {
         logger.log(error.indyName);
       } else {
         throw error;
@@ -39,7 +40,7 @@ export class IndyWallet implements Wallet {
       this.masterSecretId = await this.indy.proverCreateMasterSecret(this.wh, this.walletConfig.id);
     } catch (error) {
       logger.log('error', error);
-      if (error.indyName && error.indyName === 'AnoncredsMasterSecretDuplicateNameError') {
+      if (isIndyError(error, 'AnoncredsMasterSecretDuplicateNameError')) {
         // master secret id is the same as the master secret id passed in the create function
         // so if it already exists we can just assign it.
         this.masterSecretId = this.walletConfig.id;


### PR DESCRIPTION
Adds indyError util for consistent error handling. As it can take a while before a new version of indy-sdk is released with the changes (hyperledger/indy-sdk#2283), it takes inconsistencies between indy-sdk and rn-indy-sdk into account. This can be removed once indy-sdk updates

Related to AbsaOSS/rn-indy-sdk#24