### PR TITLE
Add iOS indy error handling

### DIFF
--- a/src/lib/utils/__tests__/indyError.test.ts
+++ b/src/lib/utils/__tests__/indyError.test.ts
@@ -20,6 +20,12 @@ describe('isIndyError()', () => {
     expect(isIndyError(error, 'WalletAlreadyExistsError')).toBe(true);
   });
 
+  it('should return true when the name is "IndyError" and error contains a matching error code', () => {
+    const error = { name: 'IndyError', code: 212 };
+
+    expect(isIndyError(error, 'WalletAlreadyExistsError')).toBe(true);
+  });
+
   it('should return false when the indyName does not match the passes errorName', () => {
     const error = { name: 'IndyError', indyName: 'WalletAlreadyExistsError' };
 

--- a/src/lib/utils/indyError.ts
+++ b/src/lib/utils/indyError.ts
@@ -77,6 +77,10 @@ export function isIndyError(error: any, errorName?: string) {
       return errorName === indyErrors[errorCode];
     }
 
+    if (!isNaN(error.code) && indyErrors.hasOwnProperty(error.code)) {
+      return true;
+    }
+
     throw new Error(`Could not determine errorName of indyError ${error.message}`);
   }
 


### PR DESCRIPTION
This is just a quick fix to make it work on iOS. There is a related PR https://github.com/AbsaOSS/rn-indy-sdk/pull/29