### PR TITLE
Added support to set an alias for a Connection

### DIFF
--- a/src/lib/modules/ConnectionsModule.ts
+++ b/src/lib/modules/ConnectionsModule.ts
@@ -28,9 +28,10 @@ export class ConnectionsModule {
     this.messageSender = messageSender;
   }
 
-  public async createConnection(config?: { autoAcceptConnection?: boolean }) {
+  public async createConnection(config?: { autoAcceptConnection?: boolean; alias?: string }) {
     const connection = await this.connectionService.createConnectionWithInvitation({
       autoAcceptConnection: config?.autoAcceptConnection,
+      alias: config?.alias,
     });
 
     if (!connection.invitation) {
@@ -59,12 +60,14 @@ export class ConnectionsModule {
     invitationJson: Record<string, unknown>,
     config?: {
       autoAcceptConnection?: boolean;
+      alias?: string;
     }
   ): Promise<ConnectionRecord> {
     const invitationMessage = JsonTransformer.fromJSON(invitationJson, ConnectionInvitationMessage);
 
     let connection = await this.connectionService.processInvitation(invitationMessage, {
       autoAcceptConnection: config?.autoAcceptConnection,
+      alias: config?.alias,
     });
 
     // if auto accept is enabled (either on the record or the global agent config)

--- a/src/lib/protocols/connections/ConnectionService.test.ts
+++ b/src/lib/protocols/connections/ConnectionService.test.ts
@@ -148,6 +148,16 @@ describe('ConnectionService', () => {
       expect(connectionFalse.autoAcceptConnection).toBe(false);
       expect(connectionUndefined.autoAcceptConnection).toBeUndefined();
     });
+
+    it('returns a connection record with the alias parameter from the config', async () => {
+      expect.assertions(3);
+
+      const aliasDefined = await connectionService.createConnectionWithInvitation({ alias: 'test-alias' });
+      const aliasUndefined = await connectionService.createConnectionWithInvitation();
+
+      expect(aliasDefined.alias).toBe('test-alias');
+      expect(aliasUndefined.alias).toBeUndefined();
+    });
   });
 
   describe('processInvitation', () => {
@@ -194,6 +204,21 @@ describe('ConnectionService', () => {
       expect(connectionTrue.autoAcceptConnection).toBe(true);
       expect(connectionFalse.autoAcceptConnection).toBe(false);
       expect(connectionUndefined.autoAcceptConnection).toBeUndefined();
+    });
+
+    it('returns a connection record with the alias parameter from the config', async () => {
+      expect.assertions(3);
+
+      const invitation = new ConnectionInvitationMessage({
+        did: 'did:sov:test',
+        label: 'test label',
+      });
+
+      const aliasDefined = await connectionService.processInvitation(invitation, { alias: 'test-alias' });
+      const aliasUndefined = await connectionService.processInvitation(invitation);
+
+      expect(aliasDefined.alias).toBe('test-alias');
+      expect(aliasUndefined.alias).toBeUndefined();
     });
   });
 

--- a/src/lib/protocols/connections/ConnectionService.test.ts
+++ b/src/lib/protocols/connections/ConnectionService.test.ts
@@ -150,7 +150,7 @@ describe('ConnectionService', () => {
     });
 
     it('returns a connection record with the alias parameter from the config', async () => {
-      expect.assertions(3);
+      expect.assertions(2);
 
       const aliasDefined = await connectionService.createConnectionWithInvitation({ alias: 'test-alias' });
       const aliasUndefined = await connectionService.createConnectionWithInvitation();
@@ -207,7 +207,7 @@ describe('ConnectionService', () => {
     });
 
     it('returns a connection record with the alias parameter from the config', async () => {
-      expect.assertions(3);
+      expect.assertions(2);
 
       const invitation = new ConnectionInvitationMessage({
         did: 'did:sov:test',

--- a/src/lib/protocols/connections/ConnectionService.ts
+++ b/src/lib/protocols/connections/ConnectionService.ts
@@ -47,11 +47,15 @@ class ConnectionService extends EventEmitter {
    * @param config config for creation of connection and invitation
    * @returns new connection record
    */
-  public async createConnectionWithInvitation(config?: { autoAcceptConnection?: boolean }): Promise<ConnectionRecord> {
+  public async createConnectionWithInvitation(config?: {
+    autoAcceptConnection?: boolean;
+    alias?: string;
+  }): Promise<ConnectionRecord> {
     // TODO: public did, multi use
     const connectionRecord = await this.createConnection({
       role: ConnectionRole.Inviter,
       state: ConnectionState.Invited,
+      alias: config?.alias,
       autoAcceptConnection: config?.autoAcceptConnection,
     });
 
@@ -82,11 +86,13 @@ class ConnectionService extends EventEmitter {
     invitation: ConnectionInvitationMessage,
     config?: {
       autoAcceptConnection?: boolean;
+      alias?: string;
     }
   ): Promise<ConnectionRecord> {
     const connectionRecord = await this.createConnection({
       role: ConnectionRole.Invitee,
       state: ConnectionState.Invited,
+      alias: config?.alias,
       autoAcceptConnection: config?.autoAcceptConnection,
       invitation,
       tags: {
@@ -306,6 +312,7 @@ class ConnectionService extends EventEmitter {
     role: ConnectionRole;
     state: ConnectionState;
     invitation?: ConnectionInvitationMessage;
+    alias?: string;
     autoAcceptConnection?: boolean;
     tags?: ConnectionTags;
   }): Promise<ConnectionRecord> {
@@ -333,6 +340,7 @@ class ConnectionService extends EventEmitter {
         ...options.tags,
       },
       invitation: options.invitation,
+      alias: options.alias,
       autoAcceptConnection: options.autoAcceptConnection,
     });
 


### PR DESCRIPTION
**Concern:** Unable to set `alias` when creating or accepting a connection invitation

**Cause:** `ConnectionRecord` contains `alias` however, no support was present to specify it.

**Correction:** 
Added support for `alias` along with `autoAcceptConnection` to the following files: 
- `modules/ConnectionsModule.ts`
- `protocols/connections/ConnectionService.ts`

Fixes #140 
