### PR TITLE
Added default mediator alias + support to specify mediator alias

### DIFF
--- a/src/lib/modules/RoutingModule.ts
+++ b/src/lib/modules/RoutingModule.ts
@@ -39,10 +39,10 @@ export class RoutingModule {
 
     if (!provisioningRecord) {
       logger.log('There is no provisioning. Creating connection with mediator...');
-      const { verkey, invitationUrl } = mediatorConfiguration;
+      const { verkey, invitationUrl, alias = 'Mediator' } = mediatorConfiguration;
       const mediatorInvitation = await decodeInvitationFromUrl(invitationUrl);
 
-      const connection = await this.connectionService.processInvitation(mediatorInvitation);
+      const connection = await this.connectionService.processInvitation(mediatorInvitation, { alias });
       const connectionRequest = await this.connectionService.createRequest(connection.id);
       const connectionResponse = await this.messageSender.sendAndReceiveMessage(
         connectionRequest,
@@ -105,4 +105,5 @@ export class RoutingModule {
 interface MediatorConfiguration {
   verkey: Verkey;
   invitationUrl: string;
+  alias?: string;
 }

--- a/src/lib/protocols/connections/ConnectionService.test.ts
+++ b/src/lib/protocols/connections/ConnectionService.test.ts
@@ -162,7 +162,7 @@ describe('ConnectionService', () => {
 
   describe('processInvitation', () => {
     it('returns a connection record containing the information from the connection invitation', async () => {
-      expect.assertions(7);
+      expect.assertions(9);
 
       const recipientKey = 'key-1';
       const invitation = new ConnectionInvitationMessage({
@@ -172,6 +172,7 @@ describe('ConnectionService', () => {
       });
 
       const connection = await connectionService.processInvitation(invitation);
+      const connectionAlias = await connectionService.processInvitation(invitation, { alias: 'test-alias' });
 
       expect(connection.role).toBe(ConnectionRole.Invitee);
       expect(connection.state).toBe(ConnectionState.Invited);
@@ -185,6 +186,8 @@ describe('ConnectionService', () => {
         })
       );
       expect(connection.invitation).toMatchObject(invitation);
+      expect(connection.alias).toBeUndefined();
+      expect(connectionAlias.alias).toBe('test-alias');
     });
 
     it('returns a connection record with the autoAcceptConnection parameter from the config', async () => {


### PR DESCRIPTION
**Concern:** Unable to set `alias` for Mediator

**Cause:** `processInvitation` does have support to set `alias` however, no `alias` was being passed from `RoutingModule.provision()`

**Correction:**
- Added default `alias` within `RoutingModule.provision()`
- Added `alias` to `MediatorConfiguration`

(Updated tests as well)