### PR TITLE
add ssi-agent-wire type to mediator

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
-    "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "eslint": "^7.7.0",

--- a/src/samples/mediator.ts
+++ b/src/samples/mediator.ts
@@ -1,6 +1,5 @@
 import express, { Express } from 'express';
 import cors from 'cors';
-import bodyParser from 'body-parser';
 import config from './config';
 import logger from '../lib/logger';
 import { Agent, InboundTransporter, OutboundTransporter, encodeInvitationToUrl } from '../lib';
@@ -59,7 +58,11 @@ const PORT = config.port;
 const app = express();
 
 app.use(cors());
-app.use(bodyParser.text());
+app.use(
+  express.text({
+    type: ['application/ssi-agent-wire', 'text/plain'],
+  })
+);
 app.set('json spaces', 2);
 
 const messageRepository = new InMemoryMessageRepository();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1099,7 +1099,7 @@ bn.js@^5.1.3:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.1.3.tgz#beca005408f642ebebea80b042b4d18d2ac0ee6b"
   integrity sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==
 
-body-parser@1.19.0, body-parser@^1.19.0:
+body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==


### PR DESCRIPTION
ACA-Py sends outbound messages with the `application/ssi-agent-wire` Content-Type header, which the mediator didn't recognise.