### PR TITLE
add method to check encoding, improve encode

### DIFF
--- a/src/lib/protocols/credentials/CredentialUtils.ts
+++ b/src/lib/protocols/credentials/CredentialUtils.ts
@@ -25,11 +25,69 @@ export class CredentialUtils {
     }, {});
   }
 
-  private static encode(value: any) {
-    if (!isNaN(value)) {
+  /**
+   * Check whether the raw value matches the encoded version according to the encoding format described in Aries RFC 0037
+   * Use this method to ensure the received proof (over the encoded) value is the same as the raw value of the data.
+   *
+   * @param raw
+   * @param encoded
+   * @returns Whether raw and encoded value match
+   *
+   * @see https://github.com/hyperledger/aries-framework-dotnet/blob/a18bef91e5b9e4a1892818df7408e2383c642dfa/src/Hyperledger.Aries/Utils/CredentialUtils.cs#L78-L89
+   * @see https://github.com/hyperledger/aries-rfcs/blob/be4ad0a6fb2823bb1fc109364c96f077d5d8dffa/features/0037-present-proof/README.md#verifying-claims-of-indy-based-verifiable-credentials
+   */
+  public static checkValidEncoding(raw: any, encoded: string) {
+    return encoded === CredentialUtils.encode(raw);
+  }
+
+  /**
+   * Encode value according to the encoding format described in Aries RFC 0036/0037
+   *
+   * @param value
+   * @returns Encoded version of value
+   *
+   * @see https://github.com/hyperledger/aries-cloudagent-python/blob/0000f924a50b6ac5e6342bff90e64864672ee935/aries_cloudagent/messaging/util.py#L106-L136
+   * @see https://github.com/hyperledger/aries-rfcs/blob/be4ad0a6fb2823bb1fc109364c96f077d5d8dffa/features/0037-present-proof/README.md#verifying-claims-of-indy-based-verifiable-credentials
+   * @see https://github.com/hyperledger/aries-rfcs/blob/be4ad0a6fb2823bb1fc109364c96f077d5d8dffa/features/0036-issue-credential/README.md#encoding-claims-for-indy-based-verifiable-credentials
+   */
+  public static encode(value: any) {
+    const isString = typeof value === 'string';
+    const isEmpty = isString && value === '';
+    const isNumber = typeof value === 'number';
+    const isBoolean = typeof value === 'boolean';
+
+    // If bool return bool as number string
+    if (isBoolean) {
+      return Number(value).toString();
+    }
+
+    // If value is int32 return as number string
+    if (isNumber && this.isInt32(value)) {
       return value.toString();
     }
 
+    // If value is an int32 number string return as number string
+    if (isString && !isEmpty && !isNaN(Number(value)) && this.isInt32(Number(value))) {
+      return value;
+    }
+
+    if (isNumber) {
+      value = value.toString();
+    }
+
+    // If value is null we must use the string value 'None'
+    if (value === null || value === undefined) {
+      value = 'None';
+    }
+
     return new BigNumber(sha256.array(value)).toString();
+  }
+
+  private static isInt32(number: number) {
+    const minI32 = -2147483648;
+    const maxI32 = 2147483647;
+
+    // Check if number is integer and in range of int32
+    return Number.isInteger(number) && number >= minI32 && number <= maxI32;
   }
 }

--- a/src/lib/protocols/credentials/__tests__/CredentialUtils.test.ts
+++ b/src/lib/protocols/credentials/__tests__/CredentialUtils.test.ts
@@ -1,6 +1,93 @@
 import { CredentialUtils } from '../CredentialUtils';
 import { CredentialPreview, CredentialPreviewAttribute } from '../messages/CredentialOfferMessage';
 
+/**
+ * Sample test cases for encoding/decoding of verifiable credential claims - Aries RFCs 0036 and 0037
+ * @see https://gist.github.com/swcurran/78e5a9e8d11236f003f6a6263c6619a6
+ */
+const testEncodings: { [key: string]: { raw: any; encoded: string } } = {
+  address2: {
+    raw: '101 Wilson Lane',
+    encoded: '68086943237164982734333428280784300550565381723532936263016368251445461241953',
+  },
+  zip: {
+    raw: '87121',
+    encoded: '87121',
+  },
+  city: {
+    raw: 'SLC',
+    encoded: '101327353979588246869873249766058188995681113722618593621043638294296500696424',
+  },
+  address1: {
+    raw: '101 Tela Lane',
+    encoded: '63690509275174663089934667471948380740244018358024875547775652380902762701972',
+  },
+  state: {
+    raw: 'UT',
+    encoded: '93856629670657830351991220989031130499313559332549427637940645777813964461231',
+  },
+  Empty: {
+    raw: '',
+    encoded: '102987336249554097029535212322581322789799900648198034993379397001115665086549',
+  },
+  Null: {
+    raw: null,
+    encoded: '99769404535520360775991420569103450442789945655240760487761322098828903685777',
+  },
+  'bool True': {
+    raw: true,
+    encoded: '1',
+  },
+  'bool False': {
+    raw: false,
+    encoded: '0',
+  },
+  'str True': {
+    raw: 'True',
+    encoded: '27471875274925838976481193902417661171675582237244292940724984695988062543640',
+  },
+  'str False': {
+    raw: 'False',
+    encoded: '43710460381310391454089928988014746602980337898724813422905404670995938820350',
+  },
+  'max i32': {
+    raw: 2147483647,
+    encoded: '2147483647',
+  },
+  'max i32 + 1': {
+    raw: 2147483648,
+    encoded: '26221484005389514539852548961319751347124425277437769688639924217837557266135',
+  },
+  'min i32': {
+    raw: -2147483648,
+    encoded: '-2147483648',
+  },
+  'min i32 - 1': {
+    raw: -2147483649,
+    encoded: '68956915425095939579909400566452872085353864667122112803508671228696852865689',
+  },
+  'float 0.1': {
+    raw: 0.1,
+    encoded: '9382477430624249591204401974786823110077201914483282671737639310288175260432',
+  },
+  'str 0.1': {
+    raw: '0.1',
+    encoded: '9382477430624249591204401974786823110077201914483282671737639310288175260432',
+  },
+  'chr 0': {
+    raw: String.fromCharCode(0),
+    encoded: '49846369543417741186729467304575255505141344055555831574636310663216789168157',
+  },
+  'chr 1': {
+    raw: String.fromCharCode(1),
+    encoded: '34356466678672179216206944866734405838331831190171667647615530531663699592602',
+  },
+  'chr 2': {
+    raw: String.fromCharCode(2),
+    encoded: '99398763056634537812744552006896172984671876672520535998211840060697129507206',
+  },
+};
+
 describe('CredentialUtils', () => {
   describe('convertPreviewToValues', () => {
     test('returns object with raw and encoded attributes', () => {
@@ -26,6 +113,15 @@ describe('CredentialUtils', () => {
         },
         age: { raw: '1234', encoded: '1234' },
       });
+    });
+  });
+
+  describe('checkValidEncoding', () => {
+    // Formatted for test.each
+    const testEntries = Object.entries(testEncodings).map(([name, { raw, encoded }]) => [name, raw, encoded]);
+
+    test.each(testEntries)('returns true for valid encoding %s', (_, raw, encoded) => {
+      expect(CredentialUtils.checkValidEncoding(raw, encoded)).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
I'm working on the present proof protocol, and part of it is verifying the raw against the encoded values. As the PR is already quite big I thought this could be easily added as a separate PR.

The encoding method didn't properly encode all value types. I used the example test cases from the RFC as tests and updated the encode method