### PR TITLE
fix: check instance types of record properties

### DIFF
--- a/src/lib/modules/CredentialsModule.ts
+++ b/src/lib/modules/CredentialsModule.ts
@@ -38,10 +38,12 @@ export class CredentialsModule {
   public async acceptCredential(credential: CredentialRecord) {
     logger.log('acceptCredential credential', credential);
 
-    // FIXME: credential.offer is already CredentialOfferMessage type
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const offer = JsonTransformer.fromJSON(credential.offer, CredentialOfferMessage);
+    // FIXME: transformation should be handled by credential record
+    const offer =
+      credential.offer instanceof CredentialOfferMessage
+        ? credential.offer
+        : JsonTransformer.fromJSON(credential.offer, CredentialOfferMessage);
+
     const [offerAttachment] = offer.attachments;
 
     if (!offerAttachment.data.base64) {

--- a/src/lib/protocols/credentials/CredentialService.ts
+++ b/src/lib/protocols/credentials/CredentialService.ts
@@ -110,10 +110,11 @@ export class CredentialService extends EventEmitter {
 
     const proverDid = connection.did;
 
-    // FIXME: TypeScript thinks the type of credential.offer is already CredentialOfferMessage, but it still needs to be transformed
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const offer = JsonTransformer.fromJSON(credential.offer, CredentialOfferMessage);
+    // FIXME: transformation should be handled by credential record
+    const offer =
+      credential.offer instanceof CredentialOfferMessage
+        ? credential.offer
+        : JsonTransformer.fromJSON(credential.offer, CredentialOfferMessage);
     const [offerAttachment] = offer.attachments;
 
     if (!offerAttachment.data.base64) {
@@ -190,10 +191,11 @@ export class CredentialService extends EventEmitter {
 
     this.assertState(credential.state, CredentialState.RequestReceived);
 
-    // FIXME: credential.offer is already CredentialOfferMessage type
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    const offer = JsonTransformer.fromJSON(credential.offer, CredentialOfferMessage);
+    // FIXME: transformation should be handled by credential record
+    const offer =
+      credential.offer instanceof CredentialOfferMessage
+        ? credential.offer
+        : JsonTransformer.fromJSON(credential.offer, CredentialOfferMessage);
     const [offerAttachment] = offer.attachments;
 
     if (!offerAttachment.data.base64) {


### PR DESCRIPTION
This is a temprorary fix until we properly managing transformation of record properties from an to class instances. While using the framework in the app we noticed sometimes the properties are class instances, and sometimes not. This fixes it 'the dirty way' for now.


Note: I'm creating a lot of small pr's and extract some of the present proof work I'm doing to make reviewing easier


﻿Signed-off-by: Timo Glastra <timo@animo.id>
