### PR TITLE
make events property instead of method

### DIFF
--- a/src/lib/modules/BasicMessagesModule.ts
+++ b/src/lib/modules/BasicMessagesModule.ts
@@ -12,6 +12,16 @@ export class BasicMessagesModule {
     this.messageSender = messageSender;
   }
 
+  /**
+   * Get the event emitter for the basic message service. Will emit state changed events
+   * when the basic messages are received.
+   *
+   * @returns event emitter for basic message actions
+   */
+  public get events(): EventEmitter {
+    return this.basicMessageService;
+  }
+
   public async sendMessage(connection: ConnectionRecord, message: string) {
     const outboundMessage = await this.basicMessageService.send(message, connection);
     await this.messageSender.sendMessage(outboundMessage);
@@ -19,9 +29,5 @@ export class BasicMessagesModule {
 
   public async findAllByQuery(query: WalletQuery) {
     return this.basicMessageService.findAllByQuery(query);
-  }
-
-  public events(): EventEmitter {
-    return this.basicMessageService;
   }
 }

--- a/src/lib/modules/ConnectionsModule.ts
+++ b/src/lib/modules/ConnectionsModule.ts
@@ -28,6 +28,16 @@ export class ConnectionsModule {
     this.messageSender = messageSender;
   }
 
+  /**
+   * Get the event emitter for the connection service. Will emit state changed events
+   * when the state of connections records changes.
+   *
+   * @returns event emitter for connection related actions
+   */
+  public get events(): EventEmitter {
+    return this.connectionService;
+  }
+
   public async createConnection(config?: { autoAcceptConnection?: boolean; alias?: string }) {
     const connection = await this.connectionService.createConnectionWithInvitation({
       autoAcceptConnection: config?.autoAcceptConnection,
@@ -139,12 +149,12 @@ export class ConnectionsModule {
     return new Promise(resolve => {
       const listener = ({ connection }: ConnectionStateChangedEvent) => {
         if (isConnected(connection)) {
-          this.events().off(ConnectionEventType.StateChanged, listener);
+          this.events.off(ConnectionEventType.StateChanged, listener);
           resolve(connection);
         }
       };
 
-      this.events().on(ConnectionEventType.StateChanged, listener);
+      this.events.on(ConnectionEventType.StateChanged, listener);
     });
   }
 
@@ -162,9 +172,5 @@ export class ConnectionsModule {
 
   public async findConnectionByTheirKey(verkey: Verkey): Promise<ConnectionRecord | null> {
     return this.connectionService.findByTheirKey(verkey);
-  }
-
-  public events(): EventEmitter {
-    return this.connectionService;
   }
 }

--- a/src/lib/modules/CredentialsModule.ts
+++ b/src/lib/modules/CredentialsModule.ts
@@ -29,6 +29,16 @@ export class CredentialsModule {
     this.messageSender = messageSender;
   }
 
+  /**
+   * Get the event emitter for the credential service. Will emit state changed events
+   * when the state of credential records changes.
+   *
+   * @returns event emitter for proof related actions
+   */
+  public get events(): EventEmitter {
+    return this.credentialService;
+  }
+
   public async issueCredential(connection: ConnectionRecord, credentialTemplate: CredentialOfferTemplate) {
     const credentialOfferMessage = await this.credentialService.createOffer(connection, credentialTemplate);
     const outboundMessage = createOutboundMessage(connection, credentialOfferMessage);
@@ -73,9 +83,5 @@ export class CredentialsModule {
 
   public async find(id: string) {
     return this.credentialService.find(id);
-  }
-
-  public events(): EventEmitter {
-    return this.credentialService;
   }
 }


### PR DESCRIPTION
Same as with other property changes. More natural usage when it is a property IMO

﻿Signed-off-by: Timo Glastra <timo@animo.id>
