### PR TITLE
refactor: Hide wallet handle inside a Wallet class

### DIFF
--- a/src/lib/decorators/signature/SignatureDecoratorUtils.test.ts
+++ b/src/lib/decorators/signature/SignatureDecoratorUtils.test.ts
@@ -53,7 +53,7 @@ describe('Decorators | Signature | SignatureDecoratorUtils', () => {
 
   test('signData signs json object and returns SignatureDecorator', async () => {
     const seed1 = '00000000000000000000000000000My1';
-    const verkey = await indy.createKey(wallet.walletHandle as number, { seed: seed1 });
+    const [, verkey] = await wallet.createDid({ seed: seed1 });
 
     const result = await signData(data, wallet, verkey);
 

--- a/src/lib/decorators/signature/SignatureDecoratorUtils.ts
+++ b/src/lib/decorators/signature/SignatureDecoratorUtils.ts
@@ -37,9 +37,8 @@ export async function unpackAndVerifySignatureDecorator(
  * Sign data supplied and return a signature decorator.
  *
  * @param data the data to sign
- * @param walletHandle the handle of the wallet to use for signing
- * @param signerKey Signers verkey
- * @param indy Indy instance
+ * @param wallet the wallet contianing a key to use for signing
+ * @param signerKey signers verkey
  *
  * @returns Resulting signature decorator.
  */

--- a/src/lib/wallet/IndyWallet.ts
+++ b/src/lib/wallet/IndyWallet.ts
@@ -18,7 +18,7 @@ export class IndyWallet implements Wallet {
     this.indy = indy;
   }
 
-  public get walletHandle() {
+  private get walletHandle() {
     if (!this._walletHandle) {
       throw new Error('Wallet has not been initialized yet');
     }


### PR DESCRIPTION
I recently complained in some PR that we have `walletHandle` attribute publicly accessible. I got an idea to use `createDid` wallet method in the test. What do you think?

Signed-off-by: Jakub Koci <jakub.koci@gmail.com>