### PR TITLE
changes based on pr feedback

### DIFF
--- a/src/lib/__tests__/proofs.test.ts
+++ b/src/lib/__tests__/proofs.test.ts
@@ -193,23 +193,19 @@ describe('Present Proof', () => {
   test('Faber starts with proof requests to Alice', async () => {
     logger.log('Faber sends presentation request to Alice');
 
-    const attributes = new Map();
-    attributes.set(
-      'name',
-      new ProofAttributeInfo({
+    const attributes = {
+      name: new ProofAttributeInfo({
         name: 'name',
         restrictions: [
           new AttributeFilter({
             credentialDefinitionId: credDefId,
           }),
         ],
-      })
-    );
+      }),
+    };
 
-    const predicates = new Map();
-    predicates.set(
-      'age',
-      new ProofPredicateInfo({
+    const predicates = {
+      age: new ProofPredicateInfo({
         name: 'age',
         predicateType: PredicateType.GreaterThanOrEqualTo,
         predicateValue: 50,
@@ -218,8 +214,8 @@ describe('Present Proof', () => {
             credentialDefinitionId: credDefId,
           }),
         ],
-      })
-    );
+      }),
+    };
 
     let faberProofRecord = await faberAgent.proof.requestProof(faberConnection.id, {
       name: 'test-proof-request',

--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -216,11 +216,6 @@ export class Agent {
     this.basicMessages = new BasicMessagesModule(this.basicMessageService, this.messageSender);
     this.ledger = new LedgerModule(this.wallet, this.ledgerService);
 
-    this.credentials = new CredentialsModule(
-      this.connectionService,
-      this.credentialService,
-      this.ledgerService,
-      this.messageSender
-    );
+    this.credentials = new CredentialsModule(this.connectionService, this.credentialService, this.messageSender);
   }
 }

--- a/src/lib/agent/Agent.ts
+++ b/src/lib/agent/Agent.ts
@@ -202,7 +202,7 @@ export class Agent {
       this.messageSender
     );
 
-    this.proof = new ProofsModule(this.proofService, this.connectionService, this.messageSender, this.indy);
+    this.proof = new ProofsModule(this.proofService, this.connectionService, this.messageSender);
 
     this.routing = new RoutingModule(
       this.agentConfig,

--- a/src/lib/modules/ConnectionsModule.ts
+++ b/src/lib/modules/ConnectionsModule.ts
@@ -58,7 +58,7 @@ export class ConnectionsModule {
   }
 
   /**
-   * Receive connection invitation and create connection. If auto accepting is enabled
+   * Receive connection invitation as invitee and create connection. If auto accepting is enabled
    * via either the config passed in the function or the global agent config, a connection
    * request message will be send.
    *
@@ -88,7 +88,7 @@ export class ConnectionsModule {
   }
 
   /**
-   * Receive connection invitation encoded as url and create connection. If auto accepting is enabled
+   * Receive connection invitation as invitee encoded as url and create connection. If auto accepting is enabled
    * via either the config passed in the function or the global agent config, a connection
    * request message will be send.
    *
@@ -108,7 +108,7 @@ export class ConnectionsModule {
   }
 
   /**
-   * Accept a connection invitation (by sending a connection request message) for the connection with the specified connection id.
+   * Accept a connection invitation as invitee (by sending a connection request message) for the connection with the specified connection id.
    * This is not needed when auto accepting of connections is enabled.
    *
    * @param connectionId the id of the connection for which to accept the invitation
@@ -130,7 +130,7 @@ export class ConnectionsModule {
   }
 
   /**
-   * Accept a connection request (by sending a connection response message) for the connection with the specified connection id.
+   * Accept a connection request as inviter (by sending a connection response message) for the connection with the specified connection id.
    * This is not needed when auto accepting of connection is enabled.
    *
    * @param connectionId the id of the connection for which to accept the request
@@ -146,7 +146,7 @@ export class ConnectionsModule {
   }
 
   /**
-   * Accept a connection response (by sending a trust ping message) for the connection with the specified connection id.
+   * Accept a connection response as invitee (by sending a trust ping message) for the connection with the specified connection id.
    * This is not needed when auto accepting of connection is enabled.
    *
    * @param connectionId the id of the connection for which to accept the response

--- a/src/lib/modules/CredentialsModule.ts
+++ b/src/lib/modules/CredentialsModule.ts
@@ -2,7 +2,6 @@ import { CredentialRecord } from '../storage/CredentialRecord';
 import { createOutboundMessage } from '../protocols/helpers';
 import { MessageSender } from '../agent/MessageSender';
 import { ConnectionService } from '../protocols/connections/ConnectionService';
-import { LedgerService } from '../agent/LedgerService';
 import { EventEmitter } from 'events';
 import {
   ProposeCredentialMessage,
@@ -16,18 +15,15 @@ import { JsonTransformer } from '../utils/JsonTransformer';
 export class CredentialsModule {
   private connectionService: ConnectionService;
   private credentialService: CredentialService;
-  private ledgerService: LedgerService;
   private messageSender: MessageSender;
 
   public constructor(
     connectionService: ConnectionService,
     credentialService: CredentialService,
-    ledgerService: LedgerService,
     messageSender: MessageSender
   ) {
     this.connectionService = connectionService;
     this.credentialService = credentialService;
-    this.ledgerService = ledgerService;
     this.messageSender = messageSender;
   }
 

--- a/src/lib/modules/CredentialsModule.ts
+++ b/src/lib/modules/CredentialsModule.ts
@@ -42,7 +42,7 @@ export class CredentialsModule {
   }
 
   /**
-   * Initiate a new credential exchange by sending a credential proposal message
+   * Initiate a new credential exchange as holder by sending a credential proposal message
    * to the connection with the specified connection id.
    *
    * @param connectionId The connection to send the credential proposal to
@@ -61,7 +61,7 @@ export class CredentialsModule {
   }
 
   /**
-   * Accept a credential proposal (by sending a credential offer message) to the connection
+   * Accept a credential proposal as issuer (by sending a credential offer message) to the connection
    * associated with the credential record.
    *
    * @param credentialRecordId The id of the credential record for which to accept the proposal
@@ -111,7 +111,7 @@ export class CredentialsModule {
   }
 
   /**
-   * Initiate a new credential exchange by sending a credential offer message
+   * Initiate a new credential exchange as issuer by sending a credential offer message
    * to the connection with the specified connection id.
    *
    * @param connectionId The connection to send the credential offer to
@@ -133,7 +133,7 @@ export class CredentialsModule {
   }
 
   /**
-   * Accept a credential offer (by sending a credential request message) to the connection
+   * Accept a credential offer as holder (by sending a credential request message) to the connection
    * associated with the credential record.
    *
    * @param credentialRecordId The id of the credential record for which to accept the offer
@@ -154,7 +154,7 @@ export class CredentialsModule {
   }
 
   /**
-   * Accept a credential request (by sending a credential message) to the connection
+   * Accept a credential request as issuer (by sending a credential message) to the connection
    * associated with the credential record.
    *
    * @param credentialRecordId The id of the credential record for which to accept the request
@@ -174,7 +174,7 @@ export class CredentialsModule {
   }
 
   /**
-   * Accept a credential (by sending a credential acknowledgement message) to the connection
+   * Accept a credential as holder (by sending a credential acknowledgement message) to the connection
    * associated with the credential record.
    *
    * @param credentialRecordId The id of the credential record for which to accept the credential

--- a/src/lib/modules/ProofsModule.ts
+++ b/src/lib/modules/ProofsModule.ts
@@ -30,7 +30,7 @@ export class ProofsModule {
   }
 
   /**
-   * Initiate a new presentation exchange by sending a presentation proposal message
+   * Initiate a new presentation exchange as prover by sending a presentation proposal message
    * to the connection with the specified connection id.
    *
    * @param connectionId The connection to send the proof proposal to
@@ -57,7 +57,7 @@ export class ProofsModule {
   }
 
   /**
-   * Accept a presentation proposal (by sending a presentation request message) to the connection
+   * Accept a presentation proposal as verifier (by sending a presentation request message) to the connection
    * associated with the proof record.
    *
    * @param proofRecordId The id of the proof record for which to accept the proposal
@@ -104,7 +104,7 @@ export class ProofsModule {
   }
 
   /**
-   * Initiate a new presentation exchange by sending a presentation request message
+   * Initiate a new presentation exchange as verifier by sending a presentation request message
    * to the connection with the specified connection id
    *
    * @param connectionId The connection to send the proof request to
@@ -141,7 +141,7 @@ export class ProofsModule {
   }
 
   /**
-   * Accept a presentation request (by sending a presentation message) to the connection
+   * Accept a presentation request as prover (by sending a presentation message) to the connection
    * associated with the proof record.
    *
    * @param proofRecordId The id of the proof record for which to accept the request
@@ -169,7 +169,7 @@ export class ProofsModule {
   }
 
   /**
-   * Accept a presentation (by sending a presentation acknowledgement message) to the connection
+   * Accept a presentation as prover (by sending a presentation acknowledgement message) to the connection
    * associated with the proof record.
    *
    * @param proofRecordId The id of the proof record for which to accept the presentation
@@ -187,6 +187,18 @@ export class ProofsModule {
     return proofRecord;
   }
 
+  /**
+   * Create a RequestedCredentials object. Given input proof request and presentation proposal,
+   * use credentials in the wallet to build indy requested credentials object for input to proof creation.
+   * If restrictions allow, self attested attributes will be used.
+   *
+   * Use the return value of this method as input to {@link ProofService.createPresentation} to automatically
+   * accept a received presentation request.
+   *
+   * @param proofRequest The proof request to build the requested credentials object from
+   * @param presentationProposal Optional presentation proposal to improve credential selection algorithm
+   * @returns Requested credentials object for use in proof creation
+   */
   public async getRequestedCredentialsForProofRequest(
     proofRequest: ProofRequest,
     presentationProposal: PresentationPreview

--- a/src/lib/modules/ProofsModule.ts
+++ b/src/lib/modules/ProofsModule.ts
@@ -1,4 +1,3 @@
-import type Indy from 'indy-sdk';
 import { createOutboundMessage } from '../protocols/helpers';
 import { MessageSender } from '../agent/MessageSender';
 import { ProofService } from '../protocols/present-proof/ProofService';
@@ -13,18 +12,11 @@ export class ProofsModule {
   private proofService: ProofService;
   private connectionService: ConnectionService;
   private messageSender: MessageSender;
-  private indy: typeof Indy;
 
-  public constructor(
-    proofService: ProofService,
-    connectionService: ConnectionService,
-    messageSender: MessageSender,
-    indy: typeof Indy
-  ) {
+  public constructor(proofService: ProofService, connectionService: ConnectionService, messageSender: MessageSender) {
     this.proofService = proofService;
     this.connectionService = connectionService;
     this.messageSender = messageSender;
-    this.indy = indy;
   }
 
   /**
@@ -130,10 +122,12 @@ export class ProofsModule {
   ): Promise<ProofRecord> {
     const connection = await this.connectionService.getById(connectionId);
 
+    const nonce = proofRequestOptions.nonce ?? (await this.proofService.generateProofRequestNonce());
+
     const proofRequest = new ProofRequest({
       name: proofRequestOptions.name ?? 'proof-request',
       version: proofRequestOptions.name ?? '1.0',
-      nonce: proofRequestOptions.nonce ?? (await this.indy.generateNonce()),
+      nonce,
       requestedAttributes: proofRequestOptions.requestedAttributes,
       requestedPredicates: proofRequestOptions.requestedPredicates,
     });

--- a/src/lib/protocols/issue-credential/__tests__/StubWallet.ts
+++ b/src/lib/protocols/issue-credential/__tests__/StubWallet.ts
@@ -156,4 +156,8 @@ export class StubWallet implements Wallet {
   public signRequest(myDid: string, request: LedgerRequest): Promise<LedgerRequest> {
     throw new Error('Method not implemented.');
   }
+
+  public async generateNonce(): Promise<string> {
+    throw new Error('Method not implemented');
+  }
 }

--- a/src/lib/protocols/issue-credential/models/CredentialInfo.ts
+++ b/src/lib/protocols/issue-credential/models/CredentialInfo.ts
@@ -24,7 +24,7 @@ export class CredentialInfo {
 
   @Expose({ name: 'attrs' })
   @IsString({ each: true })
-  public attributes!: Map<string, string>;
+  public attributes!: Record<string, string>;
 
   @Expose({ name: 'schema_id' })
   @IsString()

--- a/src/lib/protocols/present-proof/ProofService.ts
+++ b/src/lib/protocols/present-proof/ProofService.ts
@@ -516,6 +516,10 @@ export class ProofService extends EventEmitter {
     return proofRecord;
   }
 
+  public async generateProofRequestNonce() {
+    return this.wallet.generateNonce();
+  }
+
   /**
    * Create a {@link ProofRequest} from a presentation proposal. This method can be used to create the
    * proof request from a received proposal for use in {@link ProofService#createRequestAsResponse}
@@ -529,10 +533,12 @@ export class ProofService extends EventEmitter {
     presentationProposal: PresentationPreview,
     config: { name: string; version: string; nonce?: string }
   ): Promise<ProofRequest> {
+    const nonce = config.nonce ?? (await this.generateProofRequestNonce());
+
     const proofRequest = new ProofRequest({
       name: config.name,
       version: config.version,
-      nonce: config.nonce ?? (await this.indy.generateNonce()),
+      nonce,
     });
 
     /**

--- a/src/lib/protocols/present-proof/ProofService.ts
+++ b/src/lib/protocols/present-proof/ProofService.ts
@@ -768,8 +768,8 @@ export class ProofService extends EventEmitter {
     // I'm not 100% sure how much indy does. Also if it checks whether the proof requests matches the proof
     // @see https://github.com/hyperledger/aries-cloudagent-python/blob/master/aries_cloudagent/indy/sdk/verifier.py#L79-L164
 
-    const schemas = await this.buildSchemas(new Set(proof.identifiers.map(i => i.schemaId)));
-    const credentialDefinitions = await this.buildCredentialDefinitions(
+    const schemas = await this.getSchemas(new Set(proof.identifiers.map(i => i.schemaId)));
+    const credentialDefinitions = await this.getCredentialDefinitions(
       new Set(proof.identifiers.map(i => i.credentialDefinitionId))
     );
 
@@ -845,8 +845,8 @@ export class ProofService extends EventEmitter {
       credentialObjects.push(credentialInfo);
     }
 
-    const schemas = await this.buildSchemas(new Set(credentialObjects.map(c => c.schemaId)));
-    const credentialDefinitions = await this.buildCredentialDefinitions(
+    const schemas = await this.getSchemas(new Set(credentialObjects.map(c => c.schemaId)));
+    const credentialDefinitions = await this.getCredentialDefinitions(
       new Set(credentialObjects.map(c => c.credentialDefinitionId))
     );
 
@@ -887,11 +887,11 @@ export class ProofService extends EventEmitter {
    *
    * Creates object with `{ schemaId: Schema }` mapping
    *
-   * @param schemaIds List of schema id
+   * @param schemaIds List of schema ids
    * @returns Object containing schemas for specified schema ids
    *
    */
-  private async buildSchemas(schemaIds: Set<string>) {
+  private async getSchemas(schemaIds: Set<string>) {
     const schemas: { [key: string]: Schema } = {};
 
     for (const schemaId of schemaIds) {
@@ -905,13 +905,13 @@ export class ProofService extends EventEmitter {
   /**
    * Build credential definitions object needed to create and verify proof objects.
    *
-   * Creates object with `{ schemaId: Schema }` mapping
+   * Creates object with `{ credentialDefinitionId: CredentialDefinition }` mapping
    *
-   * @param schemaIds List of schema id
+   * @param credentialDefinitionIds List of credential definition ids
    * @returns Object containing credential definitions for specified credential definition ids
    *
    */
-  private async buildCredentialDefinitions(credentialDefinitionIds: Set<string>) {
+  private async getCredentialDefinitions(credentialDefinitionIds: Set<string>) {
     const credentialDefinitions: { [key: string]: CredDef } = {};
 
     for (const credDefId of credentialDefinitionIds) {

--- a/src/lib/protocols/present-proof/models/ProofRequest.ts
+++ b/src/lib/protocols/present-proof/models/ProofRequest.ts
@@ -8,6 +8,7 @@ import { ProofPredicateInfo } from './ProofPredicateInfo';
 
 import { JsonTransformer } from '../../../utils/JsonTransformer';
 import { Optional } from '../../../utils/type';
+import { RecordTransformer } from '../../../utils/transformers';
 
 /**
  * Proof Request for Indy based proof format
@@ -20,9 +21,8 @@ export class ProofRequest {
       this.name = options.name;
       this.version = options.version;
       this.nonce = options.nonce;
-      // TODO: use object instead of map OR make it easier to construct
-      this.requestedAttributes = options.requestedAttributes ?? new Map();
-      this.requestedPredicates = options.requestedPredicates ?? new Map();
+      this.requestedAttributes = options.requestedAttributes ?? {};
+      this.requestedPredicates = options.requestedPredicates ?? {};
       this.nonRevoked = options.nonRevoked;
       this.ver = options.ver;
     }
@@ -39,13 +39,13 @@ export class ProofRequest {
 
   @Expose({ name: 'requested_attributes' })
   @ValidateNested({ each: true })
-  @Type(() => ProofAttributeInfo)
-  public requestedAttributes!: Map<string, ProofAttributeInfo>;
+  @RecordTransformer(ProofAttributeInfo)
+  public requestedAttributes!: Record<string, ProofAttributeInfo>;
 
   @Expose({ name: 'requested_predicates' })
   @ValidateNested({ each: true })
-  @Type(() => ProofPredicateInfo)
-  public requestedPredicates!: Map<string, ProofPredicateInfo>;
+  @RecordTransformer(ProofPredicateInfo)
+  public requestedPredicates!: Record<string, ProofPredicateInfo>;
 
   @Expose({ name: 'non_revoked' })
   @ValidateNested()

--- a/src/lib/protocols/present-proof/models/RequestedCredentials.ts
+++ b/src/lib/protocols/present-proof/models/RequestedCredentials.ts
@@ -1,15 +1,16 @@
 import type { IndyRequestedCredentials } from 'indy-sdk';
-import { IsString, ValidateNested } from 'class-validator';
+import { ValidateNested } from 'class-validator';
 import { Expose, Type } from 'class-transformer';
 
 import { RequestedAttribute } from './RequestedAttribute';
 import { RequestedPredicate } from './RequestedPredicate';
 import { JsonTransformer } from '../../../utils/JsonTransformer';
+import { RecordTransformer } from '../../../utils/transformers';
 
 interface RequestedCredentialsOptions {
-  requestedAttributes?: Map<string, RequestedAttribute>;
-  requestedPredicates?: Map<string, RequestedPredicate>;
-  selfAttestedAttributes?: Map<string, string>;
+  requestedAttributes?: Record<string, RequestedAttribute>;
+  requestedPredicates?: Record<string, RequestedPredicate>;
+  selfAttestedAttributes?: Record<string, string>;
 }
 
 /**
@@ -20,25 +21,25 @@ interface RequestedCredentialsOptions {
 export class RequestedCredentials {
   public constructor(options: RequestedCredentialsOptions) {
     if (options) {
-      this.requestedAttributes = options.requestedAttributes ?? new Map();
-      this.requestedPredicates = options.requestedPredicates ?? new Map();
-      this.selfAttestedAttributes = options.selfAttestedAttributes ?? new Map();
+      this.requestedAttributes = options.requestedAttributes ?? {};
+      this.requestedPredicates = options.requestedPredicates ?? {};
+      this.selfAttestedAttributes = options.selfAttestedAttributes ?? {};
     }
   }
 
   @Expose({ name: 'requested_attributes' })
   @ValidateNested({ each: true })
-  @Type(() => RequestedAttribute)
-  public requestedAttributes!: Map<string, RequestedAttribute>;
+  @RecordTransformer(RequestedAttribute)
+  public requestedAttributes!: Record<string, RequestedAttribute>;
 
   @Expose({ name: 'requested_predicates' })
   @ValidateNested({ each: true })
   @Type(() => RequestedPredicate)
-  public requestedPredicates!: Map<string, RequestedPredicate>;
+  @RecordTransformer(RequestedPredicate)
+  public requestedPredicates!: Record<string, RequestedPredicate>;
 
   @Expose({ name: 'self_attested_attributes' })
-  @IsString({ each: true })
-  public selfAttestedAttributes!: Map<string, string>;
+  public selfAttestedAttributes!: Record<string, string>;
 
   public toJSON() {
     // IndyRequestedCredentials is indy-sdk json type
@@ -48,11 +49,11 @@ export class RequestedCredentials {
   public getCredentialIdentifiers(): string[] {
     const credIds = new Set<string>();
 
-    this.requestedAttributes.forEach(attr => {
+    Object.values(this.requestedAttributes).forEach(attr => {
       credIds.add(attr.credentialId);
     });
 
-    this.requestedPredicates.forEach(pred => {
+    Object.values(this.requestedPredicates).forEach(pred => {
       credIds.add(pred.credentialId);
     });
 

--- a/src/lib/utils/transformers.ts
+++ b/src/lib/utils/transformers.ts
@@ -1,0 +1,32 @@
+import { Transform, TransformationType } from 'class-transformer';
+import { JsonTransformer } from './JsonTransformer';
+
+/**
+ * Decorator that transforms json to and from corresponding record.
+ *
+ * @example
+ * class Example {
+ *   RecordTransformer(Service)
+ *   private services: Record<string, Service>;
+ * }
+ */
+export function RecordTransformer<T>(Class: { new (...args: any[]): T }) {
+  return Transform(({ value, type }) => {
+    switch (type) {
+      case TransformationType.CLASS_TO_PLAIN:
+        return Object.entries(value).reduce(
+          (accumulator, [key, attribute]) => ({ ...accumulator, [key]: JsonTransformer.toJSON(attribute) }),
+          {}
+        );
+
+      case TransformationType.PLAIN_TO_CLASS:
+        return Object.entries(value).reduce(
+          (accumulator, [key, attribute]) => ({ ...accumulator, [key]: JsonTransformer.fromJSON(attribute, Class) }),
+          {}
+        );
+
+      default:
+        return value;
+    }
+  });
+}

--- a/src/lib/wallet/IndyWallet.ts
+++ b/src/lib/wallet/IndyWallet.ts
@@ -285,7 +285,7 @@ export class IndyWallet implements Wallet {
     return this.indy.signRequest(this.walletHandle, myDid, request);
   }
 
-  private keyForLocalDid(did: Did) {
-    return this.indy.keyForLocalDid(this.walletHandle, did);
+  public async generateNonce() {
+    return this.indy.generateNonce();
   }
 }

--- a/src/lib/wallet/Wallet.ts
+++ b/src/lib/wallet/Wallet.ts
@@ -76,6 +76,7 @@ export interface Wallet {
   search(type: string, query: WalletQuery, options: WalletSearchOptions): Promise<AsyncIterable<WalletRecord>>;
   signRequest(myDid: Did, request: LedgerRequest): Promise<LedgerRequest>;
   searchCredentialsForProofRequest(proofRequest: IndyProofRequest): Promise<number>;
+  generateNonce(): Promise<string>;
 }
 
 export interface DidInfo {


### PR DESCRIPTION
- remove indy from proofs module
- add role names to module methods
- rename `buildSchemas`, `buildCredentialDefinitions` to `getSchemas`, `getCredentialDefinitions` (not abstracted yet. That's a bigger change and will get a separate PR)
- Use records (json objects) instead of Maps to make API usage easier