### PR TITLE
refactor: Move indy dependency from proof service to wallet

### DIFF
--- a/src/lib/modules/credentials/__tests__/StubWallet.ts
+++ b/src/lib/modules/credentials/__tests__/StubWallet.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import type {
+import {
   IndyProofRequest,
   IndyRequestedCredentials,
   Schemas,
@@ -24,6 +24,8 @@ import type {
   WalletRecord,
   WalletQuery,
   LedgerRequest,
+  IndyCredential,
+  RevRegsDefs,
 } from 'indy-sdk';
 import { Wallet } from '../../../wallet/Wallet';
 import { UnpackedMessageContext } from '../../../types';
@@ -48,6 +50,22 @@ export class StubWallet implements Wallet {
     credentialDefs: CredentialDefs,
     revStates: RevStates
   ): Promise<IndyProof> {
+    throw new Error('Method not implemented.');
+  }
+  public getCredentialsForProofRequest(
+    proofRequest: IndyProofRequest,
+    attributeReferent: string
+  ): Promise<IndyCredential[]> {
+    throw new Error('Method not implemented.');
+  }
+  public verifyProof(
+    proofRequest: IndyProofRequest,
+    proof: IndyProof,
+    schemas: Schemas,
+    credentialDefs: CredentialDefs,
+    revRegsDefs: RevRegsDefs,
+    revRegs: RevStates
+  ): Promise<boolean> {
     throw new Error('Method not implemented.');
   }
   public searchCredentialsForProofRequest(proofRequest: IndyProofRequest): Promise<number> {

--- a/src/lib/wallet/Wallet.ts
+++ b/src/lib/wallet/Wallet.ts
@@ -26,6 +26,8 @@ import type {
   WalletQuery,
   WalletSearchOptions,
   LedgerRequest,
+  IndyCredential,
+  RevRegsDefs,
 } from 'indy-sdk';
 import { UnpackedMessageContext } from '../types';
 
@@ -58,6 +60,16 @@ export interface Wallet {
     credentialDefs: CredentialDefs,
     revStates: RevStates
   ): Promise<IndyProof>;
+  getCredentialsForProofRequest(proofRequest: IndyProofRequest, attributeReferent: string): Promise<IndyCredential[]>;
+  // TODO Method `verifyProof` does not have a dependency on `wallet`, we could eventually move it outside to another class.
+  verifyProof(
+    proofRequest: IndyProofRequest,
+    proof: IndyProof,
+    schemas: Schemas,
+    credentialDefs: CredentialDefs,
+    revRegsDefs: RevRegsDefs,
+    revRegs: RevStates
+  ): Promise<boolean>;
   storeCredential(
     credentialId: CredentialId,
     credReqMetadata: CredReqMetadata,
@@ -76,7 +88,6 @@ export interface Wallet {
   getWalletRecord(type: string, id: string, options: WalletRecordOptions): Promise<WalletRecord>;
   search(type: string, query: WalletQuery, options: WalletSearchOptions): Promise<AsyncIterable<WalletRecord>>;
   signRequest(myDid: Did, request: LedgerRequest): Promise<LedgerRequest>;
-  searchCredentialsForProofRequest(proofRequest: IndyProofRequest): Promise<number>;
   generateNonce(): Promise<string>;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,11 +565,6 @@
   dependencies:
     "@types/express" "*"
 
-"@types/debug@^4.1.5":
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.5.tgz#b14efa8852b7768d898906613c23f688713e02cd"
-  integrity sha512-Q1y515GcOdTHgagaVFhHnIFQ38ygs/kmxdNpvpou+raI9UO3YZcHDngBSYKQklcKlvA7iuQlmIKbzvmxcOE9CQ==
-
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"


### PR DESCRIPTION
Implements point 7 from #192. Although it's still not ideal to have everything in the wallet I think it's a good step forward. I can imagine we'll have another class like `CredentialsCrypto` with dependency to `Wallet` which could eventually replace dependency from `ProofService` to `Wallet.