### PR TITLE
Default to sending https didcomm message prefix

### DIFF
--- a/src/lib/__tests__/credentials.test.ts
+++ b/src/lib/__tests__/credentials.test.ts
@@ -145,10 +145,10 @@ describe('credentials', () => {
       id: expect.any(String),
       offerMessage: {
         '@id': expect.any(String),
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/offer-credential',
+        '@type': 'https://didcomm.org/issue-credential/1.0/offer-credential',
         comment: 'some comment about credential',
         credential_preview: {
-          '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview',
+          '@type': 'https://didcomm.org/issue-credential/1.0/credential-preview',
           attributes: [
             {
               name: 'name',
@@ -248,10 +248,10 @@ describe('credentials', () => {
       id: expect.any(String),
       offerMessage: {
         '@id': expect.any(String),
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/offer-credential',
+        '@type': 'https://didcomm.org/issue-credential/1.0/offer-credential',
         comment: 'some comment about credential',
         credential_preview: {
-          '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview',
+          '@type': 'https://didcomm.org/issue-credential/1.0/credential-preview',
           attributes: [
             {
               name: 'name',

--- a/src/lib/agent/MessageReceiver.ts
+++ b/src/lib/agent/MessageReceiver.ts
@@ -8,6 +8,7 @@ import { ConnectionService } from '../modules/connections';
 import { AgentMessage } from './AgentMessage';
 import { JsonTransformer } from '../utils/JsonTransformer';
 import { Logger } from '../logger';
+import { replaceLegacyDidSovPrefix } from '../utils/messageType';
 
 class MessageReceiver {
   private config: AgentConfig;
@@ -131,6 +132,9 @@ class MessageReceiver {
    * @param unpackedMessage the unpacked message for which to transform the message in to a class instance
    */
   private async transformMessage(unpackedMessage: UnpackedMessageContext): Promise<AgentMessage> {
+    // replace did:sov:BzCbsNYhMrjHiqZDTUASHg;spec prefix for message type with https://didcomm.org
+    replaceLegacyDidSovPrefix(unpackedMessage.message);
+
     const messageType = unpackedMessage.message['@type'];
     const MessageClass = this.dispatcher.getMessageClassForType(messageType);
 

--- a/src/lib/decorators/signature/SignatureDecoratorUtils.test.ts
+++ b/src/lib/decorators/signature/SignatureDecoratorUtils.test.ts
@@ -33,7 +33,7 @@ describe('Decorators | Signature | SignatureDecoratorUtils', () => {
   };
 
   const signedData = new SignatureDecorator({
-    signatureType: 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
+    signatureType: 'https://didcomm.org/signature/1.0/ed25519Sha512_single',
     signature: 'zOSmKNCHKqOJGDJ6OlfUXTPJiirEAXrFn1kPiFDZfvG5hNTBKhsSzqAvlg44apgWBu7O57vGWZsXBF2BWZ5JAw',
     signatureData:
       'AAAAAAAAAAB7ImRpZCI6ImRpZCIsImRpZF9kb2MiOnsiQGNvbnRleHQiOiJodHRwczovL3czaWQub3JnL2RpZC92MSIsInNlcnZpY2UiOlt7ImlkIjoiZGlkOmV4YW1wbGU6MTIzNDU2Nzg5YWJjZGVmZ2hpI2RpZC1jb21tdW5pY2F0aW9uIiwidHlwZSI6ImRpZC1jb21tdW5pY2F0aW9uIiwicHJpb3JpdHkiOjAsInJlY2lwaWVudEtleXMiOlsic29tZVZlcmtleSJdLCJyb3V0aW5nS2V5cyI6W10sInNlcnZpY2VFbmRwb2ludCI6Imh0dHBzOi8vYWdlbnQuZXhhbXBsZS5jb20vIn1dfX0',

--- a/src/lib/decorators/signature/SignatureDecoratorUtils.ts
+++ b/src/lib/decorators/signature/SignatureDecoratorUtils.ts
@@ -49,7 +49,7 @@ export async function signData(data: unknown, wallet: Wallet, signerKey: Verkey)
   const signatureBuffer = await wallet.sign(dataBuffer, signerKey);
 
   const signatureDecorator = new SignatureDecorator({
-    signatureType: 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/signature/1.0/ed25519Sha512_single',
+    signatureType: 'https://didcomm.org/signature/1.0/ed25519Sha512_single',
     signature: BufferEncoder.toBase64URL(signatureBuffer),
     signatureData: BufferEncoder.toBase64URL(dataBuffer),
     signer: signerKey,

--- a/src/lib/modules/basic-messages/messages/BasicMessageMessageType.ts
+++ b/src/lib/modules/basic-messages/messages/BasicMessageMessageType.ts
@@ -1,3 +1,3 @@
 export enum MessageType {
-  BasicMessage = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message',
+  BasicMessage = 'https://didcomm.org/basicmessage/1.0/message',
 }

--- a/src/lib/modules/common/messages/CommonMessageType.ts
+++ b/src/lib/modules/common/messages/CommonMessageType.ts
@@ -1,3 +1,3 @@
 export enum CommonMessageType {
-  Ack = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/notification/1.0/ack',
+  Ack = 'https://didcomm.org/notification/1.0/ack',
 }

--- a/src/lib/modules/connections/messages/ConnectionMessageType.ts
+++ b/src/lib/modules/connections/messages/ConnectionMessageType.ts
@@ -1,7 +1,7 @@
 export enum ConnectionMessageType {
-  ConnectionInvitation = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation',
-  ConnectionRequest = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/request',
-  ConnectionResponse = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/response',
-  TrustPingMessage = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping',
-  TrustPingResponseMessage = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/trust_ping/1.0/ping_response',
+  ConnectionInvitation = 'https://didcomm.org/connections/1.0/invitation',
+  ConnectionRequest = 'https://didcomm.org/connections/1.0/request',
+  ConnectionResponse = 'https://didcomm.org/connections/1.0/response',
+  TrustPingMessage = 'https://didcomm.org/trust_ping/1.0/ping',
+  TrustPingResponseMessage = 'https://didcomm.org/trust_ping/1.0/ping_response',
 }

--- a/src/lib/modules/credentials/__tests__/CredentialService.test.ts
+++ b/src/lib/modules/credentials/__tests__/CredentialService.test.ts
@@ -214,10 +214,10 @@ describe('CredentialService', () => {
 
       expect(credentialOffer.toJSON()).toMatchObject({
         '@id': expect.any(String),
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/offer-credential',
+        '@type': 'https://didcomm.org/issue-credential/1.0/offer-credential',
         comment: 'some comment',
         credential_preview: {
-          '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview',
+          '@type': 'https://didcomm.org/issue-credential/1.0/credential-preview',
           attributes: [
             {
               name: 'name',
@@ -353,7 +353,7 @@ describe('CredentialService', () => {
       // then
       expect(credentialRequest.toJSON()).toMatchObject({
         '@id': expect.any(String),
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/request-credential',
+        '@type': 'https://didcomm.org/issue-credential/1.0/request-credential',
         '~thread': {
           thid: 'fd9c5ddb-ec11-4acd-bc32-540736249746',
         },
@@ -511,7 +511,7 @@ describe('CredentialService', () => {
       // then
       expect(credentialResponse.toJSON()).toMatchObject({
         '@id': expect.any(String),
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/issue-credential',
+        '@type': 'https://didcomm.org/issue-credential/1.0/issue-credential',
         '~thread': {
           thid: 'fd9c5ddb-ec11-4acd-bc32-540736249746',
         },
@@ -735,7 +735,7 @@ describe('CredentialService', () => {
       // then
       expect(ackMessage.toJSON()).toMatchObject({
         '@id': expect.any(String),
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/ack',
+        '@type': 'https://didcomm.org/issue-credential/1.0/ack',
         '~thread': {
           thid: 'fd9c5ddb-ec11-4acd-bc32-540736249746',
         },

--- a/src/lib/modules/credentials/messages/IssueCredentialMessageType.ts
+++ b/src/lib/modules/credentials/messages/IssueCredentialMessageType.ts
@@ -1,8 +1,8 @@
 export enum IssueCredentialMessageType {
-  ProposeCredential = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/propose-credential',
-  OfferCredential = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/offer-credential',
-  CredentialPreview = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/credential-preview',
-  RequestCredential = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/request-credential',
-  IssueCredential = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/issue-credential',
-  CredentialAck = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/issue-credential/1.0/ack',
+  ProposeCredential = 'https://didcomm.org/issue-credential/1.0/propose-credential',
+  OfferCredential = 'https://didcomm.org/issue-credential/1.0/offer-credential',
+  CredentialPreview = 'https://didcomm.org/issue-credential/1.0/credential-preview',
+  RequestCredential = 'https://didcomm.org/issue-credential/1.0/request-credential',
+  IssueCredential = 'https://didcomm.org/issue-credential/1.0/issue-credential',
+  CredentialAck = 'https://didcomm.org/issue-credential/1.0/ack',
 }

--- a/src/lib/modules/proofs/messages/PresentProofMessageType.ts
+++ b/src/lib/modules/proofs/messages/PresentProofMessageType.ts
@@ -1,7 +1,7 @@
 export enum PresentProofMessageType {
-  ProposePresentation = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/propose-presentation',
-  RequestPresentation = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/request-presentation',
-  Presentation = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/presentation',
-  PresentationPreview = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/presentation-preview',
-  PresentationAck = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/present-proof/1.0/ack',
+  ProposePresentation = 'https://didcomm.org/present-proof/1.0/propose-presentation',
+  RequestPresentation = 'https://didcomm.org/present-proof/1.0/request-presentation',
+  Presentation = 'https://didcomm.org/present-proof/1.0/presentation',
+  PresentationPreview = 'https://didcomm.org/present-proof/1.0/presentation-preview',
+  PresentationAck = 'https://didcomm.org/present-proof/1.0/ack',
 }

--- a/src/lib/modules/routing/messages/RoutingMessageType.ts
+++ b/src/lib/modules/routing/messages/RoutingMessageType.ts
@@ -3,5 +3,5 @@ export enum RoutingMessageType {
   KeylistUpdate = 'https://didcomm.org/coordinatemediation/1.0/keylist_update',
   BatchPickup = 'https://didcomm.org/messagepickup/1.0/batch-pickup',
   Batch = 'https://didcomm.org/messagepickup/1.0/batch',
-  ForwardMessage = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/routing/1.0/forward',
+  ForwardMessage = 'https://didcomm.org/routing/1.0/forward',
 }

--- a/src/lib/utils/__tests__/JsonTransformer.test.ts
+++ b/src/lib/utils/__tests__/JsonTransformer.test.ts
@@ -11,7 +11,7 @@ describe('JsonTransformer', () => {
       });
 
       const json = {
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation',
+        '@type': 'https://didcomm.org/connections/1.0/invitation',
         '@id': 'afe2867e-58c3-4a8d-85b2-23370dd9c9f0',
         label: 'test-label',
         did: 'did:sov:test1234',
@@ -24,7 +24,7 @@ describe('JsonTransformer', () => {
   describe('fromJSON', () => {
     it('transforms JSON object to class instance', () => {
       const json = {
-        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation',
+        '@type': 'https://didcomm.org/connections/1.0/invitation',
         '@id': 'afe2867e-58c3-4a8d-85b2-23370dd9c9f0',
         label: 'test-label',
         did: 'did:sov:test1234',
@@ -49,7 +49,7 @@ describe('JsonTransformer', () => {
       });
 
       const jsonString =
-        '{"@type":"did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation","@id":"afe2867e-58c3-4a8d-85b2-23370dd9c9f0","label":"test-label","did":"did:sov:test1234"}';
+        '{"@type":"https://didcomm.org/connections/1.0/invitation","@id":"afe2867e-58c3-4a8d-85b2-23370dd9c9f0","label":"test-label","did":"did:sov:test1234"}';
 
       expect(JsonTransformer.serialize(invitation)).toEqual(jsonString);
     });
@@ -58,7 +58,7 @@ describe('JsonTransformer', () => {
   describe('deserialize', () => {
     it('transforms JSON string to class instance', () => {
       const jsonString =
-        '{"@type":"did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation","@id":"afe2867e-58c3-4a8d-85b2-23370dd9c9f0","label":"test-label","did":"did:sov:test1234"}';
+        '{"@type":"https://didcomm.org/connections/1.0/invitation","@id":"afe2867e-58c3-4a8d-85b2-23370dd9c9f0","label":"test-label","did":"did:sov:test1234"}';
 
       const invitation = new ConnectionInvitationMessage({
         did: 'did:sov:test1234',

--- a/src/lib/utils/__tests__/messageType.test.ts
+++ b/src/lib/utils/__tests__/messageType.test.ts
@@ -1,0 +1,27 @@
+import { replaceLegacyDidSovPrefix } from '../messageType';
+
+describe('replaceLegacyDidSovPrefix()', () => {
+  it('should replace the message type prefix with https://didcomm.org if it starts with did:sov:BzCbsNYhMrjHiqZDTUASHg;spec', () => {
+    const message = {
+      '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message',
+    };
+
+    replaceLegacyDidSovPrefix(message);
+
+    expect(message['@type']).toBe('https://didcomm.org/basicmessage/1.0/message');
+  });
+
+  it("should not replace the message type prefix with https://didcomm.org if it doesn't start with did:sov:BzCbsNYhMrjHiqZDTUASHg;spec", () => {
+    const messageOtherDidSov = {
+      '@type': 'did:sov:another_did;spec/basicmessage/1.0/message',
+    };
+    replaceLegacyDidSovPrefix(messageOtherDidSov);
+    expect(messageOtherDidSov['@type']).toBe('did:sov:another_did;spec/basicmessage/1.0/message');
+
+    const messageDidComm = {
+      '@type': 'https://didcomm.org/basicmessage/1.0/message',
+    };
+    replaceLegacyDidSovPrefix(messageDidComm);
+    expect(messageDidComm['@type']).toBe('https://didcomm.org/basicmessage/1.0/message');
+  });
+});

--- a/src/lib/utils/messageType.ts
+++ b/src/lib/utils/messageType.ts
@@ -1,0 +1,11 @@
+import { UnpackedMessage } from '../types';
+
+export function replaceLegacyDidSovPrefix(message: UnpackedMessage) {
+  const didSovPrefix = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec';
+  const didCommPrefix = 'https://didcomm.org';
+  const messageType = message['@type'];
+
+  if (messageType.startsWith(didSovPrefix)) {
+    message['@type'] = messageType.replace(didSovPrefix, didCommPrefix);
+  }
+}


### PR DESCRIPTION
Still supports receiving the old "did:sov:BzCbsNYhMrjHiqZDTUASHg;spec" prefix

https://github.com/hyperledger/aries-rfcs/blob/master/features/0348-transition-msg-type-to-https/README.md

Fixes #121



Signed-off-by: Timo Glastra <timo@animo.id>