### PR TITLE
fix: legacy did:sov prefix on invitation

### DIFF
--- a/src/agent/MessageReceiver.ts
+++ b/src/agent/MessageReceiver.ts
@@ -8,7 +8,7 @@ import { ConnectionService } from '../modules/connections';
 import { AgentMessage } from './AgentMessage';
 import { JsonTransformer } from '../utils/JsonTransformer';
 import { Logger } from '../logger';
-import { replaceLegacyDidSovPrefix } from '../utils/messageType';
+import { replaceLegacyDidSovPrefixOnMessage } from '../utils/messageType';
 
 class MessageReceiver {
   private config: AgentConfig;
@@ -133,7 +133,7 @@ class MessageReceiver {
    */
   private async transformMessage(unpackedMessage: UnpackedMessageContext): Promise<AgentMessage> {
     // replace did:sov:BzCbsNYhMrjHiqZDTUASHg;spec prefix for message type with https://didcomm.org
-    replaceLegacyDidSovPrefix(unpackedMessage.message);
+    replaceLegacyDidSovPrefixOnMessage(unpackedMessage.message);
 
     const messageType = unpackedMessage.message['@type'];
     const MessageClass = this.dispatcher.getMessageClassForType(messageType);

--- a/src/modules/connections/__tests__/ConnectionInvitationMessage.test.ts
+++ b/src/modules/connections/__tests__/ConnectionInvitationMessage.test.ts
@@ -25,4 +25,21 @@ describe('ConnectionInvitationMessage', () => {
     const invitation = JsonTransformer.fromJSON(json, ConnectionInvitationMessage);
     await expect(validateOrReject(invitation)).rejects.not.toBeNull();
   });
+
+  it('should replace legacy did:sov:BzCbsNYhMrjHiqZDTUASHg;spec prefix with https://didcomm.org in message type', async () => {
+    const json = {
+      '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation',
+      '@id': '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+      recipientKeys: ['recipientKeyOne', 'recipientKeyTwo'],
+      serviceEndpoint: 'https://example.com',
+      label: 'test',
+    };
+    const invitation = JsonTransformer.fromJSON(json, ConnectionInvitationMessage);
+
+    // Assert type
+    expect(invitation.type).toBe('https://didcomm.org/connections/1.0/invitation');
+
+    // Assert validation also works with the transformation
+    await expect(validateOrReject(invitation)).resolves.toBeUndefined();
+  });
 });

--- a/src/modules/connections/messages/ConnectionInvitationMessage.ts
+++ b/src/modules/connections/messages/ConnectionInvitationMessage.ts
@@ -1,7 +1,9 @@
+import { Transform } from 'class-transformer';
 import { Equals, IsString, ValidateIf, IsArray, IsOptional } from 'class-validator';
 
 import { AgentMessage } from '../../../agent/AgentMessage';
 import { decodeInvitationFromUrl, encodeInvitationToUrl } from '../../../helpers';
+import { replaceLegacyDidSovPrefix } from '../../../utils/messageType';
 import { ConnectionMessageType } from './ConnectionMessageType';
 
 // TODO: improve typing of `DIDInvitationData` and `InlineInvitationData` so properties can't be mixed
@@ -49,6 +51,7 @@ export class ConnectionInvitationMessage extends AgentMessage {
   }
 
   @Equals(ConnectionInvitationMessage.type)
+  @Transform(({ value }) => replaceLegacyDidSovPrefix(value), { toClassOnly: true })
   public readonly type = ConnectionInvitationMessage.type;
   public static readonly type = ConnectionMessageType.ConnectionInvitation;
 

--- a/src/utils/__tests__/messageType.test.ts
+++ b/src/utils/__tests__/messageType.test.ts
@@ -1,27 +1,49 @@
-import { replaceLegacyDidSovPrefix } from '../messageType';
+import { replaceLegacyDidSovPrefix, replaceLegacyDidSovPrefixOnMessage } from '../messageType';
 
-describe('replaceLegacyDidSovPrefix()', () => {
-  it('should replace the message type prefix with https://didcomm.org if it starts with did:sov:BzCbsNYhMrjHiqZDTUASHg;spec', () => {
-    const message = {
-      '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message',
-    };
+describe('messageType', () => {
+  describe('replaceLegacyDidSovPrefixOnMessage()', () => {
+    it('should replace the message type prefix with https://didcomm.org if it starts with did:sov:BzCbsNYhMrjHiqZDTUASHg;spec', () => {
+      const message = {
+        '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message',
+      };
 
-    replaceLegacyDidSovPrefix(message);
+      replaceLegacyDidSovPrefixOnMessage(message);
 
-    expect(message['@type']).toBe('https://didcomm.org/basicmessage/1.0/message');
+      expect(message['@type']).toBe('https://didcomm.org/basicmessage/1.0/message');
+    });
+
+    it("should not replace the message type prefix with https://didcomm.org if it doesn't start with did:sov:BzCbsNYhMrjHiqZDTUASHg;spec", () => {
+      const messageOtherDidSov = {
+        '@type': 'did:sov:another_did;spec/basicmessage/1.0/message',
+      };
+      replaceLegacyDidSovPrefixOnMessage(messageOtherDidSov);
+      expect(messageOtherDidSov['@type']).toBe('did:sov:another_did;spec/basicmessage/1.0/message');
+
+      const messageDidComm = {
+        '@type': 'https://didcomm.org/basicmessage/1.0/message',
+      };
+      replaceLegacyDidSovPrefixOnMessage(messageDidComm);
+      expect(messageDidComm['@type']).toBe('https://didcomm.org/basicmessage/1.0/message');
+    });
   });
 
-  it("should not replace the message type prefix with https://didcomm.org if it doesn't start with did:sov:BzCbsNYhMrjHiqZDTUASHg;spec", () => {
-    const messageOtherDidSov = {
-      '@type': 'did:sov:another_did;spec/basicmessage/1.0/message',
-    };
-    replaceLegacyDidSovPrefix(messageOtherDidSov);
-    expect(messageOtherDidSov['@type']).toBe('did:sov:another_did;spec/basicmessage/1.0/message');
+  describe('replaceLegacyDidSovPrefix()', () => {
+    it('should replace the message type prefix with https://didcomm.org if it starts with did:sov:BzCbsNYhMrjHiqZDTUASHg;spec', () => {
+      const type = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/basicmessage/1.0/message';
 
-    const messageDidComm = {
-      '@type': 'https://didcomm.org/basicmessage/1.0/message',
-    };
-    replaceLegacyDidSovPrefix(messageDidComm);
-    expect(messageDidComm['@type']).toBe('https://didcomm.org/basicmessage/1.0/message');
+      expect(replaceLegacyDidSovPrefix(type)).toBe('https://didcomm.org/basicmessage/1.0/message');
+    });
+
+    it("should not replace the message type prefix with https://didcomm.org if it doesn't start with did:sov:BzCbsNYhMrjHiqZDTUASHg;spec", () => {
+      const messageTypeOtherDidSov = 'did:sov:another_did;spec/basicmessage/1.0/message';
+
+      expect(replaceLegacyDidSovPrefix(messageTypeOtherDidSov)).toBe(
+        'did:sov:another_did;spec/basicmessage/1.0/message'
+      );
+
+      const messageTypeDidComm = 'https://didcomm.org/basicmessage/1.0/message';
+
+      expect(replaceLegacyDidSovPrefix(messageTypeDidComm)).toBe('https://didcomm.org/basicmessage/1.0/message');
+    });
   });
 });

--- a/src/utils/messageType.ts
+++ b/src/utils/messageType.ts
@@ -1,11 +1,16 @@
 import { UnpackedMessage } from '../types';
 
-export function replaceLegacyDidSovPrefix(message: UnpackedMessage) {
+export function replaceLegacyDidSovPrefixOnMessage(message: UnpackedMessage) {
+  message['@type'] = replaceLegacyDidSovPrefix(message['@type']);
+}
+
+export function replaceLegacyDidSovPrefix(messageType: string) {
   const didSovPrefix = 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec';
   const didCommPrefix = 'https://didcomm.org';
-  const messageType = message['@type'];
 
   if (messageType.startsWith(didSovPrefix)) {
-    message['@type'] = messageType.replace(didSovPrefix, didCommPrefix);
+    return messageType.replace(didSovPrefix, didCommPrefix);
   }
+
+  return messageType;
 }


### PR DESCRIPTION
Invitations do not go trough the message receiver which means the prefix was not replaced and validation failed because it expected the https://didcomm.org prefix.

This add an `@Transform` to the type of the invitation message so it is replaced with the didcomm prefix. As it is the only out-of-band message, this seemed like the best approach