### PR TITLE
ci: skip npm check, doesn't work with NPM_TOKEN

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,9 @@
   "release-it": {
     "github": {
       "release": true
+    },
+    "npm": {
+      "skipChecks": true
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

As the title suggests, the npm checks don't work with NPM_TOKEN, only when you do npm login. We only have a token, and the checks are not required

I did a dry run locally but not with NPM_TOKEN, I now tested it with NPM_TOKEN locally.

Third time's the charm, @jakubkoci could you do the honours?