### PR TITLE
ci: remove docker cache

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Checkout aries-framework-javascript
         uses: actions/checkout@v2
 
-      - name: Get docker cache
-        uses: satackey/action-docker-layer-caching@v0.0.11
-
       - name: Start indy pool
         run: |
           docker build -f network/indy-pool.dockerfile -t indy-pool .


### PR DESCRIPTION
This is not related to the release PRs so I thought it'd be better to make it a separate PR. 

turns out it actually takes longer to get the cache than to build the docker images themselves.

Signed-off-by: Timo Glastra <timo@animo.id>