### PR TITLE
ci: do not push after release

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,13 @@
       "release": true
     },
     "npm": {
-      "skipChecks": true
+      "skipChecks": true,
+      "ignoreVersion": true
+    },
+    "git": {
+      "requireBranch": "main",
+      "push": false,
+      "commit": false
     }
   }
 }


### PR DESCRIPTION
Ok so we did a first successful release 🎉 

However some thing were not set up correctly to work with Hyperledger permissions and branch protection. Basically it comes down to that we cannot create a commit, so we can't update the version in package.json

To get around this I made the following changes:
- Do not push new commits to github (only releases, this is not protected)
- Do not create a commit
- Make the tag on the current commit instead of the version bump commit
- Take the current version from the latest tag that belongs to this branch instead of package.json (i.e. the tag must be on a commit that is in the history of this branch) 
- Keep the version in package.json to 0.0.0

I know this is 100% ideal, but without being able to push to the main branch it's quite complex to create a version commit. So I'm quite happy with this approach.