### PR TITLE
refactor: extract inbound transporter from agent constructor

### DIFF
--- a/samples/__tests__/e2e.test.ts
+++ b/samples/__tests__/e2e.test.ts
@@ -44,14 +44,13 @@ describe('with mediator', () => {
   })
 
   test('Alice and Bob make a connection with mediator', async () => {
-    const aliceAgentReceiver = new PollingInboundTransporter()
-    const bobAgentReceiver = new PollingInboundTransporter()
-
-    aliceAgent = new Agent(aliceConfig, aliceAgentReceiver)
+    aliceAgent = new Agent(aliceConfig)
+    aliceAgent.setInboundTransporter(new PollingInboundTransporter())
     aliceAgent.setOutboundTransporter(new HttpOutboundTransporter(aliceAgent))
     await aliceAgent.init()
 
-    bobAgent = new Agent(bobConfig, bobAgentReceiver)
+    bobAgent = new Agent(bobConfig)
+    bobAgent.setInboundTransporter(new PollingInboundTransporter())
     bobAgent.setOutboundTransporter(new HttpOutboundTransporter(bobAgent))
     await bobAgent.init()
 

--- a/samples/mediator.ts
+++ b/samples/mediator.ts
@@ -14,7 +14,7 @@ class HttpInboundTransporter implements InboundTransporter {
     this.app = app
   }
 
-  public start(agent: Agent) {
+  public async start(agent: Agent) {
     this.app.post('/msg', async (req, res) => {
       const message = req.body
       const packedMessage = JSON.parse(message)
@@ -67,7 +67,8 @@ app.set('json spaces', 2)
 const messageRepository = new InMemoryMessageRepository()
 const messageSender = new StorageOutboundTransporter(messageRepository)
 const messageReceiver = new HttpInboundTransporter(app)
-const agent = new Agent(config, messageReceiver, messageRepository)
+const agent = new Agent(config, messageRepository)
+agent.setInboundTransporter(messageReceiver)
 agent.setOutboundTransporter(messageSender)
 
 app.get('/', async (req, res) => {

--- a/src/__tests__/agents.test.ts
+++ b/src/__tests__/agents.test.ts
@@ -46,14 +46,13 @@ describe('agents', () => {
     const aliceMessages = new Subject()
     const bobMessages = new Subject()
 
-    const aliceAgentInbound = new SubjectInboundTransporter(aliceMessages, bobMessages)
-    const bobAgentInbound = new SubjectInboundTransporter(bobMessages, aliceMessages)
-
-    aliceAgent = new Agent(aliceConfig, aliceAgentInbound)
+    aliceAgent = new Agent(aliceConfig)
+    aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages, bobMessages))
     aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(bobMessages))
     await aliceAgent.init()
 
-    bobAgent = new Agent(bobConfig, bobAgentInbound)
+    bobAgent = new Agent(bobConfig)
+    bobAgent.setInboundTransporter(new SubjectInboundTransporter(bobMessages, aliceMessages))
     bobAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages))
     await bobAgent.init()
 

--- a/src/__tests__/credentials.test.ts
+++ b/src/__tests__/credentials.test.ts
@@ -74,14 +74,14 @@ describe('credentials', () => {
     const faberMessages = new Subject()
     const aliceMessages = new Subject()
 
-    const faberAgentInbound = new SubjectInboundTransporter(faberMessages, aliceMessages)
-    const aliceAgentInbound = new SubjectInboundTransporter(aliceMessages, faberMessages)
-
-    faberAgent = new Agent(faberConfig, faberAgentInbound)
-    aliceAgent = new Agent(aliceConfig, aliceAgentInbound)
+    faberAgent = new Agent(faberConfig)
+    faberAgent.setInboundTransporter(new SubjectInboundTransporter(faberMessages, aliceMessages))
     faberAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages))
-    aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages))
     await faberAgent.init()
+
+    aliceAgent = new Agent(aliceConfig)
+    aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages, faberMessages))
+    aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages))
     await aliceAgent.init()
 
     const schemaTemplate = {

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -129,7 +129,7 @@ export class SubjectInboundTransporter implements InboundTransporter {
     this.theirSubject = theirSubject
   }
 
-  public start(agent: Agent) {
+  public async start(agent: Agent) {
     this.subscribe(agent)
   }
 

--- a/src/__tests__/ledger.test.ts
+++ b/src/__tests__/ledger.test.ts
@@ -22,7 +22,7 @@ describe('ledger', () => {
   let schemaId: SchemaId
 
   beforeAll(async () => {
-    faberAgent = new Agent(faberConfig, new DummyInboundTransporter())
+    faberAgent = new Agent(faberConfig)
     await faberAgent.init()
   })
 
@@ -134,9 +134,3 @@ describe('ledger', () => {
     )
   })
 })
-
-class DummyInboundTransporter implements InboundTransporter {
-  public start() {
-    testLogger.test('Starting agent...')
-  }
-}

--- a/src/__tests__/proofs.test.ts
+++ b/src/__tests__/proofs.test.ts
@@ -79,14 +79,14 @@ describe('Present Proof', () => {
     const faberMessages = new Subject()
     const aliceMessages = new Subject()
 
-    const faberAgentInbound = new SubjectInboundTransporter(faberMessages, aliceMessages)
-    const aliceAgentInbound = new SubjectInboundTransporter(aliceMessages, faberMessages)
-
-    faberAgent = new Agent(faberConfig, faberAgentInbound)
-    aliceAgent = new Agent(aliceConfig, aliceAgentInbound)
+    faberAgent = new Agent(faberConfig)
+    faberAgent.setInboundTransporter(new SubjectInboundTransporter(faberMessages, aliceMessages))
     faberAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages))
-    aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages))
     await faberAgent.init()
+
+    aliceAgent = new Agent(aliceConfig)
+    aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages, faberMessages))
+    aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages))
     await aliceAgent.init()
 
     const schemaTemplate = {

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -40,7 +40,7 @@ export class Agent {
   protected messageReceiver: MessageReceiver
   protected dispatcher: Dispatcher
   protected messageSender: MessageSender
-  public inboundTransporter?: InboundTransporter
+  public readonly inboundTransporter?: InboundTransporter
 
   protected connectionService: ConnectionService
   protected proofService: ProofService

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -40,7 +40,7 @@ export class Agent {
   protected messageReceiver: MessageReceiver
   protected dispatcher: Dispatcher
   protected messageSender: MessageSender
-  public readonly inboundTransporter?: InboundTransporter
+  public inboundTransporter?: InboundTransporter
 
   protected connectionService: ConnectionService
   protected proofService: ProofService

--- a/src/transport/InboundTransporter.ts
+++ b/src/transport/InboundTransporter.ts
@@ -1,5 +1,5 @@
 import { Agent } from '../agent/Agent'
 
 export interface InboundTransporter {
-  start(agent: Agent): void
+  start(agent: Agent): Promise<void>
 }


### PR DESCRIPTION
It aligns API with the setting of the outbound transporter. It's also better for the cases when a developer wants to pass messages into the agent by themself.

BREAKING CHANGE

Signed-off-by: Jakub Koci <jakub.koci@gmail.com>