### PR TITLE
chore: use latest tag for npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     },
     "npm": {
       "skipChecks": true,
-      "ignoreVersion": true
+      "ignoreVersion": true,
+      "tag": "latest"
     },
     "git": {
       "requireBranch": "main",


### PR DESCRIPTION
as we only have unstable releases, if we do not set the latest tag you can not just install aries-framework

Signed-off-by: Timo Glastra <timo@animo.id>