### PR TITLE
feat: Add support for WebSocket transports

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -71,7 +71,7 @@ jobs:
           --env TEST_AGENT_PUBLIC_DID_SEED=${TEST_AGENT_PUBLIC_DID_SEED}
           --env GENESIS_TXN_PATH=${GENESIS_TXN_PATH}
           aries-framework-javascript
-          yarn test --coverage
+          yarn test --coverage --detectOpenHandles
 
       - name: Export logs
         if: always()

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -78,7 +78,8 @@ jobs:
         run: |
           mkdir logs
           docker cp alice-mediator:/www/logs.txt ./logs/alice-mediator.txt
-          docker cp bob-mediator:/www/logs.txt ./logs/bob-mediator.txt
+          docker cp alice-ws-mediator:/www/logs.txt ./logs/alice-ws-mediator.txt
+          docker cp bob-ws-mediator:/www/logs.txt ./logs/bob-ws-mediator.txt
           docker cp framework-jest-tests:/www/logs.txt ./logs/jest.txt
 
       - name: Upload docker logs

--- a/docker/docker-compose-mediators.yml
+++ b/docker/docker-compose-mediators.yml
@@ -21,5 +21,25 @@ services:
     ports:
       - 3002:3002
 
+  alice-ws-mediator:
+    build: ..
+    image: aries-framework-javascript
+    container_name: alice-ws-mediator
+    command: ./scripts/run-mediator-ws.sh alice-ws
+    networks:
+      - hyperledger
+    ports:
+      - 3003:3003
+
+  bob-ws-mediator:
+    build: ..
+    image: aries-framework-javascript
+    container_name: bob-ws-mediator
+    command: ./scripts/run-mediator-ws.sh bob-ws
+    networks:
+      - hyperledger
+    ports:
+      - 3004:3004
+
 networks:
   hyperledger:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check-format": "yarn prettier --list-different",
     "test": "jest --verbose",
     "dev": "ts-node-dev --respawn --transpile-only ./samples/mediator.ts",
-    "prod:start": "node ./build/samples/mediator.js",
+    "prod:start": "node ./build/samples/mediator-ws.js",
     "prod:build": "rm -rf build && yarn compile",
     "validate": "npm-run-all --parallel lint compile",
     "prepack": "rm -rf build && yarn compile",
@@ -42,6 +42,7 @@
     "@types/jest": "^26.0.20",
     "@types/node-fetch": "^2.5.8",
     "@types/uuid": "^8.3.0",
+    "@types/ws": "^7.4.1",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "cors": "^2.8.5",
@@ -59,7 +60,8 @@
     "ts-jest": "^26.5.3",
     "ts-node-dev": "^1.1.6",
     "tslog": "^3.1.2",
-    "typescript": "^4.2.3"
+    "typescript": "^4.2.3",
+    "ws": "^7.4.5"
   },
   "optionalDependencies": {
     "indy-sdk": "^1.16.0"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "jest --verbose",
     "dev": "ts-node-dev --respawn --transpile-only ./samples/mediator.ts",
     "prod:start": "node ./build/samples/mediator.js",
+    "prod:start-ws": "node ./build/samples/mediator-ws.js",
     "prod:build": "rm -rf build && yarn compile",
     "validate": "npm-run-all --parallel lint compile",
     "prepack": "rm -rf build && yarn compile",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "check-format": "yarn prettier --list-different",
     "test": "jest --verbose",
     "dev": "ts-node-dev --respawn --transpile-only ./samples/mediator.ts",
-    "prod:start": "node ./build/samples/mediator-ws.js",
+    "prod:start": "node ./build/samples/mediator.js",
     "prod:build": "rm -rf build && yarn compile",
     "validate": "npm-run-all --parallel lint compile",
     "prepack": "rm -rf build && yarn compile",

--- a/samples/__tests__/e2e-ws.test.ts
+++ b/samples/__tests__/e2e-ws.test.ts
@@ -31,7 +31,7 @@ const bobConfig: InitConfig = {
   indy,
 }
 
-describe('websockets with mediator', () => {
+describe.skip('websockets with mediator', () => {
   let aliceAgent: Agent
   let bobAgent: Agent
   let aliceAtAliceBobId: string

--- a/samples/__tests__/e2e-ws.test.ts
+++ b/samples/__tests__/e2e-ws.test.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'ws'
-import { Agent, ConnectionRecord, InboundTransporter, OutboundTransporter } from '../../src'
+import { Agent, ConnectionRecord, ConsoleLogger, InboundTransporter, LogLevel, OutboundTransporter } from '../../src'
 import { OutboundPackage, InitConfig } from '../../src/types'
 import { get } from '../http'
 import { toBeConnectedWith, waitForBasicMessage } from '../../src/__tests__/helpers'
@@ -7,7 +7,7 @@ import indy from 'indy-sdk'
 import testLogger from '../../src/__tests__/logger'
 import { WebSocketTransport } from '../../src/agent/TransportService'
 
-const logger = testLogger
+const logger = new ConsoleLogger(LogLevel.test)
 
 expect.extend({ toBeConnectedWith })
 
@@ -137,6 +137,8 @@ class WsInboundTransporter implements InboundTransporter {
 class WsOutboundTransporter implements OutboundTransporter {
   private transportTable: TransportTable = {}
   private agent: Agent
+
+  public supportedSchemes = ['ws']
 
   public constructor(agent: Agent) {
     this.agent = agent

--- a/samples/__tests__/e2e-ws.test.ts
+++ b/samples/__tests__/e2e-ws.test.ts
@@ -1,11 +1,11 @@
 import WebSocket from 'ws'
-import { Agent, ConnectionRecord, ConsoleLogger, InboundTransporter, LogLevel, OutboundTransporter } from '../../src'
+import { Agent, ConnectionRecord, InboundTransporter, OutboundTransporter } from '../../src'
 import { OutboundPackage, InitConfig } from '../../src/types'
 import { get } from '../http'
 import { toBeConnectedWith, waitForBasicMessage } from '../../src/__tests__/helpers'
 import indy from 'indy-sdk'
 import testLogger from '../../src/__tests__/logger'
-import { WebSocketTransport, Transport } from '../../src/agent/TransportService'
+import { WebSocketTransport } from '../../src/agent/TransportService'
 
 const logger = testLogger
 

--- a/samples/__tests__/e2e-ws.test.ts
+++ b/samples/__tests__/e2e-ws.test.ts
@@ -1,5 +1,5 @@
 import WebSocket from 'ws'
-import { Agent, ConnectionRecord, ConsoleLogger, InboundTransporter, LogLevel, OutboundTransporter } from '../../src'
+import { Agent, ConnectionRecord, InboundTransporter, OutboundTransporter } from '../../src'
 import { OutboundPackage, InitConfig } from '../../src/types'
 import { get } from '../http'
 import { toBeConnectedWith, waitForBasicMessage } from '../../src/__tests__/helpers'
@@ -7,7 +7,7 @@ import indy from 'indy-sdk'
 import testLogger from '../../src/__tests__/logger'
 import { WebSocketTransport } from '../../src/agent/TransportService'
 
-const logger = new ConsoleLogger(LogLevel.test)
+const logger = testLogger
 
 expect.extend({ toBeConnectedWith })
 

--- a/samples/__tests__/e2e-ws.test.ts
+++ b/samples/__tests__/e2e-ws.test.ts
@@ -37,8 +37,8 @@ describe('websockets with mediator', () => {
   let aliceAtAliceBobId: string
 
   afterAll(async () => {
-    ;(aliceAgent.outboundTransporter as WsOutboundTransporter).stop()
-    ;(bobAgent.outboundTransporter as WsOutboundTransporter).stop()
+    ;(aliceAgent.getOutboundTransporter() as WsOutboundTransporter).stop()
+    ;(bobAgent.getOutboundTransporter() as WsOutboundTransporter).stop()
 
     // Wait for messages to flush out
     await new Promise((r) => setTimeout(r, 1000))
@@ -193,10 +193,6 @@ class WsOutboundTransporter implements OutboundTransporter {
       socket.close()
     })
   }
-}
-
-interface TransportTable {
-  [connectionRecordId: string]: WebSocket
 }
 
 function createSocketConnection(endpoint: string): Promise<WebSocket> {

--- a/samples/__tests__/e2e-ws.test.ts
+++ b/samples/__tests__/e2e-ws.test.ts
@@ -13,8 +13,8 @@ expect.extend({ toBeConnectedWith })
 
 const aliceConfig: InitConfig = {
   label: 'e2e Alice',
-  mediatorUrl: 'http://localhost:3001',
-  walletConfig: { id: 'e2e-alice' },
+  mediatorUrl: 'http://localhost:3003',
+  walletConfig: { id: 'e2e-alice-ws' },
   walletCredentials: { key: '00000000000000000000000000000Test01' },
   autoAcceptConnections: true,
   logger: logger,
@@ -23,15 +23,15 @@ const aliceConfig: InitConfig = {
 
 const bobConfig: InitConfig = {
   label: 'e2e Bob',
-  mediatorUrl: 'http://localhost:3002',
-  walletConfig: { id: 'e2e-bob' },
+  mediatorUrl: 'http://localhost:3004',
+  walletConfig: { id: 'e2e-bob-ws' },
   walletCredentials: { key: '00000000000000000000000000000Test02' },
   autoAcceptConnections: true,
   logger: logger,
   indy,
 }
 
-describe.skip('websockets with mediator', () => {
+describe('websockets with mediator', () => {
   let aliceAgent: Agent
   let bobAgent: Agent
   let aliceAtAliceBobId: string

--- a/samples/__tests__/e2e-ws.test.ts
+++ b/samples/__tests__/e2e-ws.test.ts
@@ -37,10 +37,11 @@ describe('websockets with mediator', () => {
   let aliceAtAliceBobId: string
 
   afterAll(async () => {
-    // Wait for messages to flush out
-    await new Promise((r) => setTimeout(r, 1000))
     ;(aliceAgent.outboundTransporter as WsOutboundTransporter).stop()
     ;(bobAgent.outboundTransporter as WsOutboundTransporter).stop()
+
+    // Wait for messages to flush out
+    await new Promise((r) => setTimeout(r, 1000))
 
     await aliceAgent.closeAndDeleteWallet()
     await bobAgent.closeAndDeleteWallet()

--- a/samples/__tests__/e2e.test.ts
+++ b/samples/__tests__/e2e.test.ts
@@ -29,7 +29,7 @@ const bobConfig: InitConfig = {
   indy,
 }
 
-describe.skip('with mediator', () => {
+describe('with mediator', () => {
   let aliceAgent: Agent
   let bobAgent: Agent
   let aliceAtAliceBobId: string

--- a/samples/mediator-ws.ts
+++ b/samples/mediator-ws.ts
@@ -4,7 +4,7 @@ import cors from 'cors'
 import { v4 as uuid } from 'uuid'
 import config from './config'
 import { Agent, InboundTransporter, OutboundTransporter } from '../src'
-import { OutboundPackage } from '../src/types'
+import { OutboundPackage, DidCommMimeType } from '../src/types'
 import { InMemoryMessageRepository } from '../src/storage/InMemoryMessageRepository'
 import { WebSocketTransport } from '../src/agent/TransportService'
 import testLogger from '../src/__tests__/logger'
@@ -50,6 +50,8 @@ class WsInboundTransporter implements InboundTransporter {
 }
 
 class WsOutboundTransporter implements OutboundTransporter {
+  public supportedSchemes = ['ws']
+
   public async sendMessage(outboundPackage: OutboundPackage) {
     const { connection, payload, transport } = outboundPackage
     logger.debug(`Sending outbound message to connection ${connection.id} over ${transport?.type} transport.`, payload)
@@ -73,7 +75,7 @@ const app = express()
 app.use(cors())
 app.use(
   express.text({
-    type: ['application/ssi-agent-wire', 'text/plain'],
+    type: [DidCommMimeType.V0, DidCommMimeType.V1],
   })
 )
 app.set('json spaces', 2)

--- a/samples/mediator-ws.ts
+++ b/samples/mediator-ws.ts
@@ -1,0 +1,140 @@
+import express from 'express'
+import WebSocket from 'ws'
+import cors from 'cors'
+import { v4 as uuid } from 'uuid'
+import config from './config'
+import { Agent, InboundTransporter, OutboundTransporter } from '../src'
+import { OutboundPackage } from '../src/types'
+import { InMemoryMessageRepository } from '../src/storage/InMemoryMessageRepository'
+import { WebSocketTransport } from '../src/agent/TransportService'
+import testLogger from '../src/__tests__/logger'
+
+const logger = testLogger
+
+class WsInboundTransporter implements InboundTransporter {
+  private socketServer: WebSocket.Server
+
+  // We're using a `socketId` just for the prevention of calling the connection handler twice.
+  private socketIds: Record<string, unknown> = {}
+
+  public constructor(socketServer: WebSocket.Server) {
+    this.socketServer = socketServer
+  }
+
+  public async start(agent: Agent) {
+    this.socketServer.on('connection', (socket: any, _: Express.Request, socketId: string) => {
+      logger.debug('Socket connected.')
+
+      if (!this.socketIds[socketId]) {
+        logger.debug(`Saving new socket with id ${socketId}.`)
+        this.socketIds[socketId] = socket
+        this.listenOnWebSocketMessages(agent, socket)
+        socket.on('close', () => logger.debug('Socket closed.'))
+      } else {
+        logger.debug(`Socket with id ${socketId} already exists.`)
+      }
+    })
+  }
+
+  private listenOnWebSocketMessages(agent: Agent, socket: WebSocket) {
+    socket.addEventListener('message', async (event: any) => {
+      logger.debug('WebSocket message event received.', { url: event.target.url, data: event.data })
+      // @ts-expect-error Property 'dispatchEvent' is missing in type WebSocket imported from 'ws' module but required in type 'WebSocket'.
+      const transport = new WebSocketTransport('', socket)
+      const outboundMessage = await agent.receiveMessage(JSON.parse(event.data), transport)
+      if (outboundMessage) {
+        socket.send(JSON.stringify(outboundMessage.payload))
+      }
+    })
+  }
+}
+
+class WsOutboundTransporter implements OutboundTransporter {
+  public async sendMessage(outboundPackage: OutboundPackage) {
+    const { connection, payload, transport } = outboundPackage
+    logger.debug(`Sending outbound message to connection ${connection.id} over ${transport?.type} transport.`, payload)
+
+    if (transport instanceof WebSocketTransport) {
+      if (transport.socket?.readyState === WebSocket.OPEN) {
+        logger.debug('Sending message over existing inbound socket.')
+        transport.socket.send(JSON.stringify(payload))
+      } else {
+        throw new Error('No socket connection.')
+      }
+    } else {
+      throw new Error(`Unsupported transport ${transport?.type}.`)
+    }
+  }
+}
+
+const PORT = config.port
+const app = express()
+
+app.use(cors())
+app.use(
+  express.text({
+    type: ['application/ssi-agent-wire', 'text/plain'],
+  })
+)
+app.set('json spaces', 2)
+
+const socketServer = new WebSocket.Server({ noServer: true })
+// TODO Remove when mediation protocol is implemented
+// This endpoint is used in all invitations created by this mediator agent.
+config.endpoint = `ws://localhost:${PORT}`
+
+const messageRepository = new InMemoryMessageRepository()
+const messageSender = new WsOutboundTransporter()
+const messageReceiver = new WsInboundTransporter(socketServer)
+const agent = new Agent(config, messageRepository)
+agent.setInboundTransporter(messageReceiver)
+agent.setOutboundTransporter(messageSender)
+
+app.get('/', async (req, res) => {
+  const agentDid = agent.publicDid
+  res.send(agentDid)
+})
+
+// Create new invitation as inviter to invitee
+app.get('/invitation', async (req, res) => {
+  const { invitation } = await agent.connections.createConnection()
+
+  res.send(invitation.toUrl())
+})
+
+app.get('/api/connections/:verkey', async (req, res) => {
+  // TODO This endpoint is for testing purpose only. Return mediator connection by their verkey.
+  const verkey = req.params.verkey
+  const connection = await agent.connections.findConnectionByTheirKey(verkey)
+  res.send(connection)
+})
+
+app.get('/api/connections', async (req, res) => {
+  // TODO This endpoint is for testing purpose only. Return mediator connection by their verkey.
+  const connections = await agent.connections.getAll()
+  res.json(connections)
+})
+
+app.get('/api/routes', async (req, res) => {
+  // TODO This endpoint is for testing purpose only. Return mediator connection by their verkey.
+  const routes = agent.routing.getRoutingTable()
+  res.send(routes)
+})
+
+app.get('/api/messages', async (req, res) => {
+  // TODO This endpoint is for testing purpose only.
+  // res.send(messageSender.messages)
+})
+
+const server = app.listen(PORT, async () => {
+  await agent.init()
+  messageReceiver.start(agent)
+  logger.info(`WebSockets application started on port ${PORT}`)
+})
+
+server.on('upgrade', (request, socket, head) => {
+  socketServer.handleUpgrade(request, socket, head, (socketParam) => {
+    const socketId = uuid()
+    socketServer.emit('connection', socketParam, request, socketId)
+  })
+})

--- a/scripts/run-mediator-ws.sh
+++ b/scripts/run-mediator-ws.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+AGENT="$1"
+YARN_COMMAND=yarn
+
+
+if [[ "$AGENT" = "mediator03" ]] || [[ "$AGENT" = "alice-ws" ]]; then
+  AGENT_ENDPOINT="${AGENT_ENDPOINT:-http://localhost:3003}"
+  AGENT_HOST=http://localhost
+  AGENT_PORT=3003
+  AGENT_LABEL=RoutingMediator03
+  WALLET_NAME=mediator03
+  WALLET_KEY=0000000000000000000000000Mediator03
+  PUBLIC_DID=DtWRdd6C5dN5vpcN6XRAvu
+  PUBLIC_DID_SEED=00000000000000000000000Forward03
+elif [[ "$AGENT" = "mediator04" ]] || [[ "$AGENT" = "bob-ws" ]]; then
+  AGENT_ENDPOINT="${AGENT_ENDPOINT:-http://localhost:3004}"
+  AGENT_HOST=http://localhost
+  AGENT_PORT=3004
+  AGENT_LABEL=RoutingMediator04
+  WALLET_NAME=mediator04
+  WALLET_KEY=0000000000000000000000000Mediator04
+  PUBLIC_DID=SHbU5SEwdmkQkVQ1sMwSEv
+  PUBLIC_DID_SEED=00000000000000000000000Forward04
+else
+  echo "Please specify which agent you want to run. Choose from 'alice' or 'bob'."
+  exit 1
+fi
+
+if [ "$2" = "server" ]; then
+  YARN_COMMAND=.yarn/bin/yarn
+fi
+
+# Docker image already compiles. Not needed to do again
+if [ "$RUN_MODE" != "docker" ]; then
+  ${YARN_COMMAND} prod:build
+fi
+
+AGENT_ENDPOINT=${AGENT_ENDPOINT} AGENT_HOST=${AGENT_HOST} AGENT_PORT=${AGENT_PORT} AGENT_LABEL=${AGENT_LABEL} WALLET_NAME=${WALLET_NAME} WALLET_KEY=${WALLET_KEY} PUBLIC_DID=${PUBLIC_DID} PUBLIC_DID_SEED=${PUBLIC_DID_SEED} ${YARN_COMMAND} prod:start-ws

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -104,6 +104,10 @@ export class Agent {
     this.messageSender.setOutboundTransporter(outboundTransporter)
   }
 
+  public getOutboundTransporter() {
+    return this.messageSender.getOutboundTransporter()
+  }
+
   public async init() {
     await this.wallet.init()
 

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -20,6 +20,7 @@ import { BasicMessagesModule } from '../modules/basic-messages/BasicMessagesModu
 import { LedgerModule } from '../modules/ledger/LedgerModule'
 import { InMemoryMessageRepository } from '../storage/InMemoryMessageRepository'
 import { Symbols } from '../symbols'
+import { Transport } from './TransportService'
 
 export class Agent {
   protected agentConfig: AgentConfig

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -31,6 +31,7 @@ export class Agent {
   protected messageReceiver: MessageReceiver
   protected messageSender: MessageSender
   public inboundTransporter?: InboundTransporter
+  public outboundTransporter?: OutboundTransporter
 
   public readonly connections!: ConnectionsModule
   public readonly proofs!: ProofsModule

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -132,8 +132,8 @@ export class Agent {
     return this.agentConfig.mediatorUrl
   }
 
-  public async receiveMessage(inboundPackedMessage: unknown) {
-    return await this.messageReceiver.receiveMessage(inboundPackedMessage)
+  public async receiveMessage(inboundPackedMessage: unknown, transport?: Transport) {
+    return await this.messageReceiver.receiveMessage(inboundPackedMessage, transport)
   }
 
   public async closeAndDeleteWallet() {

--- a/src/agent/AgentConfig.ts
+++ b/src/agent/AgentConfig.ts
@@ -1,5 +1,6 @@
 import { ConsoleLogger, Logger, LogLevel } from '../logger'
 import { InitConfig, InboundConnection, DidCommMimeType } from '../types'
+import { DID_COMM_TRANSPORT_QUEUE } from './TransportService'
 
 export class AgentConfig {
   private initConfig: InitConfig
@@ -76,7 +77,7 @@ export class AgentConfig {
 
     // If we still don't have an endpoint, return didcomm:transport/queue
     // https://github.com/hyperledger/aries-rfcs/issues/405#issuecomment-582612875
-    return 'didcomm:transport/queue'
+    return DID_COMM_TRANSPORT_QUEUE
   }
 
   public getRoutingKeys() {

--- a/src/agent/Dispatcher.ts
+++ b/src/agent/Dispatcher.ts
@@ -5,14 +5,17 @@ import { MessageSender } from './MessageSender'
 import { AgentMessage } from './AgentMessage'
 import { InboundMessageContext } from './models/InboundMessageContext'
 import { ReturnRouteTypes } from '../decorators/transport/TransportDecorator'
+import { TransportService } from './TransportService'
 
 @scoped(Lifecycle.ContainerScoped)
 class Dispatcher {
   private handlers: Handler[] = []
   private messageSender: MessageSender
+  private transportService: TransportService
 
-  public constructor(messageSender: MessageSender) {
+  public constructor(messageSender: MessageSender, transportService: TransportService) {
     this.messageSender = messageSender
+    this.transportService = transportService
   }
 
   public registerHandler(handler: Handler) {
@@ -32,7 +35,7 @@ class Dispatcher {
     if (outboundMessage) {
       const threadId = outboundMessage.payload.threadId
 
-      if (!outboundMessage.connection.hasInboundEndpoint()) {
+      if (!this.transportService.hasInboundEndpoint(outboundMessage.connection)) {
         outboundMessage.payload.setReturnRouting(ReturnRouteTypes.all)
       }
 

--- a/src/agent/MessageSender.ts
+++ b/src/agent/MessageSender.ts
@@ -3,8 +3,7 @@ import { Lifecycle, scoped } from 'tsyringe'
 import { OutboundMessage, OutboundPackage } from '../types'
 import { OutboundTransporter } from '../transport/OutboundTransporter'
 import { EnvelopeService } from './EnvelopeService'
-import { HttpTransport, TransportService, WebSocketTransport } from './TransportService'
-import { ConnectionRecord } from '../modules/connections'
+import { TransportService } from './TransportService'
 
 @scoped(Lifecycle.ContainerScoped)
 export class MessageSender {
@@ -30,6 +29,8 @@ export class MessageSender {
       throw new Error('Agent has no outbound transporter!')
     }
     const outboundPackage = await this.envelopeService.packMessage(outboundMessage)
-    await this.outboundTransporter.sendMessage(outboundPackage)
+    const transport = this.transportService.resolveTransport(outboundMessage.connection)
+    outboundPackage.transport = transport
+    await this.outboundTransporter.sendMessage(outboundPackage, returnRoute)
   }
 }

--- a/src/agent/MessageSender.ts
+++ b/src/agent/MessageSender.ts
@@ -31,6 +31,6 @@ export class MessageSender {
     const outboundPackage = await this.envelopeService.packMessage(outboundMessage)
     const transport = this.transportService.resolveTransport(outboundMessage.connection)
     outboundPackage.transport = transport
-    await this.outboundTransporter.sendMessage(outboundPackage, returnRoute)
+    await this.outboundTransporter.sendMessage(outboundPackage)
   }
 }

--- a/src/agent/MessageSender.ts
+++ b/src/agent/MessageSender.ts
@@ -20,6 +20,10 @@ export class MessageSender {
     this.outboundTransporter = outboundTransporter
   }
 
+  public getOutboundTransporter() {
+    return this.outboundTransporter
+  }
+
   public async packMessage(outboundMessage: OutboundMessage): Promise<OutboundPackage> {
     return this.envelopeService.packMessage(outboundMessage)
   }

--- a/src/agent/MessageSender.ts
+++ b/src/agent/MessageSender.ts
@@ -3,14 +3,18 @@ import { Lifecycle, scoped } from 'tsyringe'
 import { OutboundMessage, OutboundPackage } from '../types'
 import { OutboundTransporter } from '../transport/OutboundTransporter'
 import { EnvelopeService } from './EnvelopeService'
+import { HttpTransport, TransportService, WebSocketTransport } from './TransportService'
+import { ConnectionRecord } from '../modules/connections'
 
 @scoped(Lifecycle.ContainerScoped)
 export class MessageSender {
   private envelopeService: EnvelopeService
+  private transportService: TransportService
   private outboundTransporter?: OutboundTransporter
 
-  public constructor(envelopeService: EnvelopeService) {
+  public constructor(envelopeService: EnvelopeService, transportService: TransportService) {
     this.envelopeService = envelopeService
+    this.transportService = transportService
   }
 
   public setOutboundTransporter(outboundTransporter: OutboundTransporter) {

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -72,7 +72,7 @@ interface TransportTable {
   [connectionRecordId: string]: Transport
 }
 
-type TransportType = 'ws' | 'http' | 'queue'
+type TransportType = 'websocket' | 'http' | 'queue'
 
 export interface Transport {
   type: TransportType
@@ -80,7 +80,7 @@ export interface Transport {
 }
 
 export class WebSocketTransport implements Transport {
-  public readonly type = 'ws'
+  public readonly type = 'websocket'
   public endpoint: string
   public socket?: WebSocket
 

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -1,11 +1,15 @@
-import { ConsoleLogger, LogLevel } from '../logger'
+import { Logger } from '../logger'
 import { ConnectionRecord, ConnectionRole } from '../modules/connections'
 
-const logger = new ConsoleLogger(LogLevel.debug)
 const DID_COMM_TRANSPORT_QUEUE = 'didcomm:transport/queue'
 
 export class TransportService {
   private transportTable: TransportTable = {}
+  private logger: Logger
+
+  public constructor(logger: Logger) {
+    this.logger = logger
+  }
 
   public saveTransport(connectionId: string, transport: Transport) {
     this.transportTable[connectionId] = transport
@@ -38,7 +42,7 @@ export class TransportService {
     if (connection.theirDidDoc) {
       const endpoint = connection.theirDidDoc.service[0].serviceEndpoint
       if (endpoint) {
-        logger.debug('Taking service endpoint from their DidDoc')
+        this.logger.debug('Taking service endpoint from their DidDoc')
         return endpoint
       }
     }
@@ -46,7 +50,7 @@ export class TransportService {
     if (connection.role === ConnectionRole.Invitee && connection.invitation) {
       const endpoint = connection.invitation.serviceEndpoint
       if (endpoint) {
-        logger.debug('Taking service endpoint from invitation')
+        this.logger.debug('Taking service endpoint from invitation')
         return endpoint
       }
     }

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -1,10 +1,11 @@
 import { Lifecycle, scoped, inject } from 'tsyringe'
 
 import { Logger } from '../logger'
-import { ConnectionRecord, ConnectionRole } from '../modules/connections'
+import { ConnectionRecord } from '../modules/connections/repository'
+import { ConnectionRole } from '../modules/connections/models'
 import { Symbols } from '../symbols'
 
-const DID_COMM_TRANSPORT_QUEUE = 'didcomm:transport/queue'
+export const DID_COMM_TRANSPORT_QUEUE = 'didcomm:transport/queue'
 
 @scoped(Lifecycle.ContainerScoped)
 export class TransportService {
@@ -38,6 +39,10 @@ export class TransportService {
     }
 
     throw new Error(`No transport found for connection with id ${connection.id}`)
+  }
+
+  public hasInboundEndpoint(connection: ConnectionRecord) {
+    return connection.didDoc.didCommServices.find((s) => s.serviceEndpoint !== DID_COMM_TRANSPORT_QUEUE)
   }
 
   private findTransport(connectionId: string) {

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -1,0 +1,41 @@
+export class TransportService {
+  private transportTable: TransportTable = {}
+
+  public saveTransport(connectionId: string, transport: Transport) {
+    this.transportTable[connectionId] = transport
+  }
+
+  public getTransport(connectionId: string) {
+    return this.transportTable[connectionId]
+  }
+}
+
+interface TransportTable {
+  [connectionRecordId: string]: Transport
+}
+
+type TransportType = 'ws' | 'http'
+
+export interface Transport {
+  type: TransportType
+}
+
+export class WebSocketTransport implements Transport {
+  public type: TransportType = 'ws'
+  public endpoint?: string
+  public socket?: WebSocket
+
+  public constructor(endpoint: string, socket?: WebSocket) {
+    this.endpoint = endpoint
+    this.socket = socket
+  }
+}
+
+export class HttpTransport {
+  public type: TransportType = 'http'
+  public endpoint?: string
+
+  public constructor(endpoint?: string) {
+    this.endpoint = endpoint
+  }
+}

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -1,3 +1,9 @@
+import { ConsoleLogger, LogLevel } from '../logger'
+import { ConnectionRecord, ConnectionRole } from '../modules/connections'
+
+const logger = new ConsoleLogger(LogLevel.debug)
+const DID_COMM_TRANSPORT_QUEUE = 'didcomm:transport/queue'
+
 export class TransportService {
   private transportTable: TransportTable = {}
 
@@ -5,8 +11,45 @@ export class TransportService {
     this.transportTable[connectionId] = transport
   }
 
+  public resolveTransport(connection: ConnectionRecord): Transport {
+    const transport = this.getTransport(connection.id)
+    if (transport) {
+      return transport
+    }
+
+    const endpoint = this.findEndpoint(connection)
+    if (endpoint) {
+      if (endpoint?.startsWith('ws')) {
+        return new WebSocketTransport(endpoint)
+      } else if (endpoint === DID_COMM_TRANSPORT_QUEUE) {
+        return new DidCommQueueTransport()
+      }
+      return new HttpTransport(endpoint)
+    }
+
+    throw new Error(`No transport found for connection with id ${connection.id}`)
+  }
+
   public getTransport(connectionId: string) {
     return this.transportTable[connectionId]
+  }
+
+  private findEndpoint(connection: ConnectionRecord) {
+    if (connection.theirDidDoc) {
+      const endpoint = connection.theirDidDoc.service[0].serviceEndpoint
+      if (endpoint) {
+        logger.debug('Taking service endpoint from their DidDoc')
+        return endpoint
+      }
+    }
+
+    if (connection.role === ConnectionRole.Invitee && connection.invitation) {
+      const endpoint = connection.invitation.serviceEndpoint
+      if (endpoint) {
+        logger.debug('Taking service endpoint from invitation')
+        return endpoint
+      }
+    }
   }
 }
 
@@ -14,15 +57,16 @@ interface TransportTable {
   [connectionRecordId: string]: Transport
 }
 
-type TransportType = 'ws' | 'http'
+type TransportType = 'ws' | 'http' | 'queue'
 
 export interface Transport {
   type: TransportType
+  endpoint: string
 }
 
 export class WebSocketTransport implements Transport {
   public type: TransportType = 'ws'
-  public endpoint?: string
+  public endpoint: string
   public socket?: WebSocket
 
   public constructor(endpoint: string, socket?: WebSocket) {
@@ -31,11 +75,16 @@ export class WebSocketTransport implements Transport {
   }
 }
 
-export class HttpTransport {
+export class HttpTransport implements Transport {
   public type: TransportType = 'http'
-  public endpoint?: string
+  public endpoint: string
 
-  public constructor(endpoint?: string) {
+  public constructor(endpoint: string) {
     this.endpoint = endpoint
   }
+}
+
+export class DidCommQueueTransport implements Transport {
+  public type: TransportType = 'queue'
+  public endpoint = DID_COMM_TRANSPORT_QUEUE
 }

--- a/src/agent/__tests__/TransportService.test.ts
+++ b/src/agent/__tests__/TransportService.test.ts
@@ -1,6 +1,9 @@
+import testLogger from '../../__tests__/logger'
 import { ConnectionInvitationMessage, ConnectionRole, DidDoc, IndyAgentService } from '../../modules/connections'
 import { getMockConnection } from '../../modules/connections/__tests__/ConnectionService.test'
 import { TransportService, HttpTransport, WebSocketTransport, DidCommQueueTransport } from '../TransportService'
+
+const logger = testLogger
 
 describe('TransportService', () => {
   describe('resolveTransport', () => {
@@ -21,7 +24,7 @@ describe('TransportService', () => {
         ],
       })
 
-      transportService = new TransportService()
+      transportService = new TransportService(logger)
     })
 
     test('throws error when no transport is resolved for a given connection ID', () => {

--- a/src/agent/__tests__/TransportService.test.ts
+++ b/src/agent/__tests__/TransportService.test.ts
@@ -74,5 +74,13 @@ describe('TransportService', () => {
       expect(transportService.resolveTransport(connection)).toBeInstanceOf(HttpTransport)
       expect(transportService.resolveTransport(connection).endpoint).toEqual('https://invitationEndpoint.com')
     })
+
+    test('throws error when no transport is found for unsupported scheme', () => {
+      theirDidDoc.service[0].serviceEndpoint = 'myscheme://theirDidDocEndpoint.com'
+      const connection = getMockConnection({ id: 'test-123', theirDidDoc })
+      expect(() => transportService.resolveTransport(connection)).toThrow(
+        `Unsupported scheme in endpoint: myscheme://theirDidDocEndpoint.com.`
+      )
+    })
   })
 })

--- a/src/agent/__tests__/TransportService.test.ts
+++ b/src/agent/__tests__/TransportService.test.ts
@@ -1,0 +1,75 @@
+import { ConnectionInvitationMessage, ConnectionRole, DidDoc, IndyAgentService } from '../../modules/connections'
+import { getMockConnection } from '../../modules/connections/__tests__/ConnectionService.test'
+import { TransportService, HttpTransport, WebSocketTransport, DidCommQueueTransport } from '../TransportService'
+
+describe('TransportService', () => {
+  describe('resolveTransport', () => {
+    let transportService: TransportService
+    let theirDidDoc: DidDoc
+
+    beforeEach(() => {
+      theirDidDoc = new DidDoc({
+        id: 'test-456',
+        publicKey: [],
+        authentication: [],
+        service: [
+          new IndyAgentService({
+            id: `<did>;indy`,
+            serviceEndpoint: 'https://example.com',
+            recipientKeys: ['verkey'],
+          }),
+        ],
+      })
+
+      transportService = new TransportService()
+    })
+
+    test('throws error when no transport is resolved for a given connection ID', () => {
+      const connection = getMockConnection({ id: 'test-123', role: ConnectionRole.Inviter })
+      connection.theirDidDoc = undefined
+      expect(() => transportService.resolveTransport(connection)).toThrow(
+        `No transport found for connection with id test-123`
+      )
+    })
+
+    test('returns previously stored transport a given connection ID', () => {
+      const connection = getMockConnection({ id: 'test-123' })
+      const transport = new HttpTransport('https://endpoint.com')
+      transportService.saveTransport('test-123', transport)
+      expect(transportService.resolveTransport(connection)).toEqual(transport)
+    })
+
+    test('returns HttpTransport transport when their DidDoc contains http endpoint', () => {
+      theirDidDoc.service[0].serviceEndpoint = 'https://theirDidDocEndpoint.com'
+      const connection = getMockConnection({ id: 'test-123', theirDidDoc })
+      expect(transportService.resolveTransport(connection)).toBeInstanceOf(HttpTransport)
+      expect(transportService.resolveTransport(connection).endpoint).toEqual('https://theirDidDocEndpoint.com')
+    })
+
+    test(`returns WebSocket transport when their DidDoc contains ws endpoint`, () => {
+      theirDidDoc.service[0].serviceEndpoint = 'ws://theirDidDocEndpoint.com'
+      const connection = getMockConnection({ id: 'test-123', theirDidDoc })
+      expect(transportService.resolveTransport(connection)).toBeInstanceOf(WebSocketTransport)
+      expect(transportService.resolveTransport(connection).endpoint).toEqual('ws://theirDidDocEndpoint.com')
+    })
+
+    test(`returns Queue transport when their DidDoc contains didcomm:transport/queue`, () => {
+      theirDidDoc.service[0].serviceEndpoint = 'didcomm:transport/queue'
+      const connection = getMockConnection({ id: 'test-123', theirDidDoc })
+      expect(transportService.resolveTransport(connection)).toBeInstanceOf(DidCommQueueTransport)
+      expect(transportService.resolveTransport(connection).endpoint).toEqual('didcomm:transport/queue')
+    })
+
+    test(`returns transport with service endpoint from invitation if there is no their DidDoc and role is ${ConnectionRole.Invitee}`, () => {
+      const invitation = new ConnectionInvitationMessage({
+        label: 'test',
+        recipientKeys: ['verkey'],
+        serviceEndpoint: 'https://invitationEndpoint.com',
+      })
+      const connection = getMockConnection({ id: 'test-123', role: ConnectionRole.Invitee, invitation })
+      connection.theirDidDoc = undefined
+      expect(transportService.resolveTransport(connection)).toBeInstanceOf(HttpTransport)
+      expect(transportService.resolveTransport(connection).endpoint).toEqual('https://invitationEndpoint.com')
+    })
+  })
+})

--- a/src/modules/connections/repository/ConnectionRecord.ts
+++ b/src/modules/connections/repository/ConnectionRecord.ts
@@ -124,8 +124,4 @@ export class ConnectionRecord extends BaseRecord implements ConnectionStoragePro
       throw new Error(`Connection record has invalid role ${this.role}. Expected role ${expectedRole}.`)
     }
   }
-
-  public hasInboundEndpoint() {
-    return this.didDoc.service.find((s) => s.serviceEndpoint !== 'didcomm:transport/queue')
-  }
 }

--- a/src/modules/connections/repository/ConnectionRecord.ts
+++ b/src/modules/connections/repository/ConnectionRecord.ts
@@ -5,7 +5,6 @@ import { ConnectionState } from '..'
 import { ConnectionInvitationMessage } from '..'
 import { ConnectionRole } from '..'
 import { DidDoc } from '..'
-import { IndyAgentService } from '..'
 import type { Did, Verkey } from 'indy-sdk'
 
 interface ConnectionProps {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type Indy from 'indy-sdk'
 import type { Did, WalletConfig, WalletCredentials, Verkey } from 'indy-sdk'
 import { ConnectionRecord } from './modules/connections'
 import { AgentMessage } from './agent/AgentMessage'
+import { Transport } from './agent/TransportService'
 import { Logger } from './logger'
 
 type $FixMe = any
@@ -56,6 +57,7 @@ export interface OutboundPackage {
   payload: WireMessage
   responseRequested?: boolean
   endpoint?: string
+  transport?: Transport
 }
 
 export interface InboundConnection {

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,6 +900,13 @@
   resolved "https://registry.npmjs.org/@types/validator/-/validator-13.1.3.tgz"
   integrity sha512-DaOWN1zf7j+8nHhqXhIgNmS+ltAC53NXqGxYuBhWqWgqolRhddKzfZU814lkHQSTG0IUfQxU7Cg0gb8fFWo2mA==
 
+"@types/ws@^7.4.1":
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.1.tgz#49eacb15a0534663d53a36fbf5b4d98f5ae9a73a"
+  integrity sha512-ISCK1iFnR+jYv7+jLNX0wDqesZ/5RAeY3wUx6QaphmocphU61h+b+PHjS18TF4WIPTu/MMzxIq2PHr32o2TS5Q==
+  dependencies:
+    "@types/node" "*"
+
 "@types/yargs-parser@*":
   version "20.2.0"
   resolved "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-20.2.0.tgz"
@@ -6701,6 +6708,11 @@ ws@^7.4.4:
   version "7.4.4"
   resolved "https://registry.npmjs.org/ws/-/ws-7.4.4.tgz"
   integrity sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
+
+ws@^7.4.5:
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
+  integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
 
 xdg-basedir@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
This is how it works now:
* A mediator takes endpoint for invitation or DidDoc from `config`.
* An edge agent takes endpoint for invitation or DidDoc from `inboundConnection` if it has any.
* The edge agent gets out of band invitation via http request to mediator (http://mediator1.com/invitation). The invitation contains `ws` endpoint because we want to make a connection via WebSocket.
* The edge agent takes an endpoint for outbound communication from invitation or DidDoc. For a connection with another edge agent, it takes an endpoint from `indbound` connection. Therefore it’s the same `ws` endpoint as it is contained in the mediator invitation.

To integrate ws and http servers together and support multiple transports we would need to enable following:
* A mediator sends a different endpoint for mediation to edge agent.
* The edge agent sets the mediation endpoint somewhere else and do not take it from `inbound` connection invitation or DidDoc.

Other notes:
* I set ws endpoint directly in mediator server by editing `config.endpoint` to value `ws://localhost:${PORT}`
* I skip the ws tests. To run them it's needed to change the mediator server to `mediator-ws.ts` (or integrate ws and HTTP together as I mentioned)

Related to #250 