### PR TITLE
ci: do no run release script in forks

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -97,9 +97,9 @@ jobs:
   release:
     runs-on: ubuntu-20.04
     name: Release
-    needs: [integration-test]
+    needs: [integration-test, validate]
     # Only run on push or workflow dispatch to main branch
-    if: (github.ref == 'refs/heads/main') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: (github.ref == 'refs/heads/main' && github.repository == 'hyperledger/aries-framework-javascript') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     steps:
       - name: Checkout aries-framework-javascript
         uses: actions/checkout@v2


### PR DESCRIPTION
Currently when we push to main in our fork of the repo, the release script will run (and fail). This does a check so it will only run in the hyperledger repo