### PR TITLE
ci: do not run concurrent release jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,6 +16,11 @@ env:
   TEST_AGENT_PUBLIC_DID_SEED: 000000000000000000000000Trustee9
   GENESIS_TXN_PATH: network/genesis/local-genesis.txn
 
+# Make sure we're not running multiple release steps at the same time as this can give issues with determining the next npm version to release.
+# Ideally we only add this to the 'release' job so it doesn't limit PR, but github can't guarantee the job order in that case:
+# "When concurrency is specified at the job level, order is not guaranteed for jobs or runs that queue within 5 minutes of each other."
+concurrency: aries-framework-${{ github.ref }}-${{ github.repository }}-${{ github.even_name }}
+
 jobs:
   validate:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This should fix the issues with the release. Github added a `concurrency` key a few weeks ago that allows us to prevent concurrent jobs from running. See the comment in the action file for more context


https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency

