### PR TITLE
feat: Added attachment extension

### DIFF
--- a/src/agent/AgentMessage.ts
+++ b/src/agent/AgentMessage.ts
@@ -6,8 +6,16 @@ import { TimingDecorated } from '../decorators/timing/TimingDecoratorExtension'
 import { BaseMessage } from './BaseMessage'
 import { JsonTransformer } from '../utils/JsonTransformer'
 import { AckDecorated } from '../decorators/ack/AckDecoratorExtension'
+import { AttachmentDecorated } from '../decorators/attachment/AttachmentExtension'
 
-const DefaultDecorators = [ThreadDecorated, L10nDecorated, TransportDecorated, TimingDecorated, AckDecorated]
+const DefaultDecorators = [
+  ThreadDecorated,
+  L10nDecorated,
+  TransportDecorated,
+  TimingDecorated,
+  AckDecorated,
+  AttachmentDecorated,
+]
 
 export class AgentMessage extends Compose(BaseMessage, DefaultDecorators) {
   public toJSON(): Record<string, unknown> {

--- a/src/decorators/attachment/Attachment.test.ts
+++ b/src/decorators/attachment/Attachment.test.ts
@@ -1,0 +1,68 @@
+import { JsonTransformer } from '../..'
+import { Attachment } from './Attachment'
+
+const mockJson = {
+  '@id': 'ceffce22-6471-43e4-8945-b604091981c9',
+  description: 'A small picture of a cat',
+  filename: 'cat.png',
+  'mime-type': 'text/plain',
+  lastmod_time: new Date(),
+  byte_count: 9200,
+  data: {
+    json: {
+      hello: 'world!',
+    },
+    sha256: '00d7b2068a0b237f14a7979bbfc01ad62f60792e459467bfc4a7d3b9a6dbbe3e',
+  },
+}
+
+const id = 'ceffce22-6471-43e4-8945-b604091981c9'
+const description = 'A small picture of a cat'
+const filename = 'cat.png'
+const mimeType = 'text/plain'
+const lastmodTime = new Date()
+const byteCount = 9200
+const data = {
+  json: {
+    hello: 'world!',
+  },
+  sha256: '00d7b2068a0b237f14a7979bbfc01ad62f60792e459467bfc4a7d3b9a6dbbe3e',
+}
+
+describe('Decorators | Attachment', () => {
+  it('should correctly transform Json to Attachment class', () => {
+    const decorator = JsonTransformer.fromJSON(mockJson, Attachment)
+
+    expect(decorator.id).toBe(mockJson['@id'])
+    expect(decorator.description).toBe(mockJson.description)
+    expect(decorator.filename).toBe(mockJson.filename)
+    expect(decorator.lastmodTime).toEqual(mockJson.lastmod_time)
+    expect(decorator.byteCount).toEqual(mockJson.byte_count)
+    expect(decorator.data).toEqual(mockJson.data)
+  })
+
+  it('should correctly transform Attachment class to Json', () => {
+    const decorator = new Attachment({
+      id,
+      description,
+      filename,
+      mimeType,
+      lastmodTime,
+      byteCount,
+      data,
+    })
+
+    const json = JsonTransformer.toJSON(decorator)
+    const transformed = {
+      '@id': id,
+      description,
+      filename,
+      'mime-type': mimeType,
+      lastmod_time: lastmodTime,
+      byte_count: byteCount,
+      data,
+    }
+
+    expect(json).toEqual(transformed)
+  })
+})

--- a/src/decorators/attachment/Attachment.ts
+++ b/src/decorators/attachment/Attachment.ts
@@ -7,7 +7,7 @@ export interface AttachmentOptions {
   description?: string
   filename?: string
   mimeType?: string
-  lastmodTime?: number
+  lastmodTime?: Date
   byteCount?: number
   data: AttachmentData
 }
@@ -117,7 +117,7 @@ export class Attachment {
   @Type(() => Date)
   @IsOptional()
   @IsDate()
-  public lastmodTime?: number
+  public lastmodTime?: Date
 
   /**
    * Optional, and mostly relevant when content is included by reference instead of by value. Lets the receiver guess how expensive it will be, in time, bandwidth, and storage, to fully fetch the attachment.

--- a/src/decorators/attachment/AttachmentExtension.ts
+++ b/src/decorators/attachment/AttachmentExtension.ts
@@ -1,5 +1,5 @@
 import { Expose, Type } from 'class-transformer'
-import { IsArray, ValidateNested } from 'class-validator'
+import { IsArray, IsOptional, ValidateNested } from 'class-validator'
 
 import { BaseMessageConstructor } from '../../agent/BaseMessage'
 import { Attachment } from './Attachment'
@@ -13,6 +13,7 @@ export function AttachmentDecorated<T extends BaseMessageConstructor>(Base: T) {
     @Type(() => Attachment)
     @ValidateNested()
     @IsArray()
+    @IsOptional()
     public attachments?: Attachment[]
 
     public getAttachmentById(id: string): Attachment | undefined {

--- a/src/decorators/attachment/AttachmentExtension.ts
+++ b/src/decorators/attachment/AttachmentExtension.ts
@@ -17,7 +17,7 @@ export function AttachmentDecorated<T extends BaseMessageConstructor>(Base: T) {
     public attachments?: Attachment[]
 
     public getAttachmentById(id: string): Attachment | undefined {
-      return this.attachments?.find((attachment) => attachment.id === id.substring(0, 64))
+      return this.attachments?.find((attachment) => attachment.id === id)
     }
 
     public addAttachment(attachment: Attachment): void {

--- a/src/decorators/attachment/AttachmentExtension.ts
+++ b/src/decorators/attachment/AttachmentExtension.ts
@@ -1,0 +1,32 @@
+import { Expose, Type } from 'class-transformer'
+import { IsArray, ValidateNested } from 'class-validator'
+
+import { BaseMessageConstructor } from '../../agent/BaseMessage'
+import { Attachment } from './Attachment'
+
+export function AttachmentDecorated<T extends BaseMessageConstructor>(Base: T) {
+  class AttachmentDecoratorExtension extends Base {
+    /**
+     * The ~attach decorator is required for appending attachments to a credential
+     */
+    @Expose({ name: '~attach' })
+    @Type(() => Attachment)
+    @ValidateNested()
+    @IsArray()
+    public attachments?: Attachment[]
+
+    public getAttachmentById(id: string): Attachment | undefined {
+      return this.attachments?.find((attachment) => attachment.id === id.substring(0, 64))
+    }
+
+    public addAttachment(attachment: Attachment): void {
+      if (this.attachments) {
+        this.attachments?.push(attachment)
+      } else {
+        this.attachments = [attachment]
+      }
+    }
+  }
+
+  return AttachmentDecoratorExtension
+}

--- a/src/modules/credentials/__tests__/CredentialService.test.ts
+++ b/src/modules/credentials/__tests__/CredentialService.test.ts
@@ -112,7 +112,7 @@ const mockCredentialRecord = ({
     offerMessage: new OfferCredentialMessage({
       comment: 'some comment',
       credentialPreview: credentialPreview,
-      attachments: [offerAttachment],
+      offerAttachments: [offerAttachment],
     }),
     id,
     credentialAttributes: credentialAttributes || credentialPreview.attributes,
@@ -263,7 +263,7 @@ describe('CredentialService', () => {
       credentialOfferMessage = new OfferCredentialMessage({
         comment: 'some comment',
         credentialPreview: credentialPreview,
-        attachments: [offerAttachment],
+        offerAttachments: [offerAttachment],
       })
       messageContext = new InboundMessageContext(credentialOfferMessage, {
         connection,
@@ -405,7 +405,7 @@ describe('CredentialService', () => {
 
       const credentialRequest = new RequestCredentialMessage({
         comment: 'abcd',
-        attachments: [requestAttachment],
+        requestAttachments: [requestAttachment],
       })
       credentialRequest.setThread({ threadId: 'somethreadid' })
       messageContext = new InboundMessageContext(credentialRequest, {
@@ -477,7 +477,7 @@ describe('CredentialService', () => {
         state: CredentialState.RequestReceived,
         requestMessage: new RequestCredentialMessage({
           comment: 'abcd',
-          attachments: [requestAttachment],
+          requestAttachments: [requestAttachment],
         }),
         tags: { threadId },
       })
@@ -547,12 +547,8 @@ describe('CredentialService', () => {
       })
 
       // We're using instance of `StubWallet`. Value of `cred` should be as same as in the credential response message.
-      const [cred] = await indyIssuerService.createCredential({
-        credentialOffer: credOffer,
-        credentialRequest: credReq,
-        credentialValues: {},
-      })
-      const [responseAttachment] = credentialResponse.attachments
+      const [cred] = await wallet.createCredential(credOffer, credReq, {})
+      const [responseAttachment] = credentialResponse.credentialAttachments
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(JsonEncoder.fromBase64(responseAttachment.data.base64!)).toEqual(cred)
     })
@@ -582,7 +578,7 @@ describe('CredentialService', () => {
                 state,
                 tags: { threadId },
                 requestMessage: new RequestCredentialMessage({
-                  attachments: [requestAttachment],
+                  requestAttachments: [requestAttachment],
                 }),
               })
             )
@@ -600,14 +596,14 @@ describe('CredentialService', () => {
       credential = mockCredentialRecord({
         state: CredentialState.RequestSent,
         requestMessage: new RequestCredentialMessage({
-          attachments: [requestAttachment],
+          requestAttachments: [requestAttachment],
         }),
         metadata: { requestMetadata: { cred_req: 'meta-data' } },
       })
 
       const credentialResponse = new IssueCredentialMessage({
         comment: 'abcd',
-        attachments: [credentialAttachment],
+        credentialAttachments: [credentialAttachment],
       })
       credentialResponse.setThread({ threadId: 'somethreadid' })
       messageContext = new InboundMessageContext(credentialResponse, {

--- a/src/modules/credentials/__tests__/CredentialService.test.ts
+++ b/src/modules/credentials/__tests__/CredentialService.test.ts
@@ -547,7 +547,11 @@ describe('CredentialService', () => {
       })
 
       // We're using instance of `StubWallet`. Value of `cred` should be as same as in the credential response message.
-      const [cred] = await wallet.createCredential(credOffer, credReq, {})
+      const [cred] = await indyIssuerService.createCredential({
+        credentialOffer: credOffer,
+        credentialRequest: credReq,
+        credentialValues: {},
+      })
       const [responseAttachment] = credentialResponse.credentialAttachments
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       expect(JsonEncoder.fromBase64(responseAttachment.data.base64!)).toEqual(cred)

--- a/src/modules/credentials/messages/IssueCredentialMessage.ts
+++ b/src/modules/credentials/messages/IssueCredentialMessage.ts
@@ -12,7 +12,7 @@ export const INDY_CREDENTIAL_ATTACHMENT_ID = 'libindy-cred-0'
 interface IssueCredentialMessageOptions {
   id?: string
   comment?: string
-  attachments: Attachment[]
+  credentialAttachments: Attachment[]
 }
 
 export class IssueCredentialMessage extends AgentMessage {
@@ -22,7 +22,7 @@ export class IssueCredentialMessage extends AgentMessage {
     if (options) {
       this.id = options.id ?? this.generateId()
       this.comment = options.comment
-      this.attachments = options.attachments
+      this.credentialAttachments = options.credentialAttachments
     }
   }
 
@@ -39,10 +39,10 @@ export class IssueCredentialMessage extends AgentMessage {
   @ValidateNested({
     each: true,
   })
-  public attachments!: Attachment[]
+  public credentialAttachments!: Attachment[]
 
   public get indyCredential(): Cred | null {
-    const attachment = this.attachments.find((attachment) => attachment.id === INDY_CREDENTIAL_ATTACHMENT_ID)
+    const attachment = this.credentialAttachments.find((attachment) => attachment.id === INDY_CREDENTIAL_ATTACHMENT_ID)
 
     // Return null if attachment is not found
     if (!attachment?.data?.base64) {

--- a/src/modules/credentials/messages/OfferCredentialMessage.ts
+++ b/src/modules/credentials/messages/OfferCredentialMessage.ts
@@ -13,7 +13,7 @@ export const INDY_CREDENTIAL_OFFER_ATTACHMENT_ID = 'libindy-cred-offer-0'
 export interface OfferCredentialMessageOptions {
   id?: string
   comment?: string
-  attachments: Attachment[]
+  offerAttachments: Attachment[]
   credentialPreview: CredentialPreview
 }
 
@@ -30,7 +30,7 @@ export class OfferCredentialMessage extends AgentMessage {
       this.id = options.id || this.generateId()
       this.comment = options.comment
       this.credentialPreview = options.credentialPreview
-      this.attachments = options.attachments
+      this.offerAttachments = options.offerAttachments
     }
   }
 
@@ -52,10 +52,10 @@ export class OfferCredentialMessage extends AgentMessage {
   @ValidateNested({
     each: true,
   })
-  public attachments!: Attachment[]
+  public offerAttachments!: Attachment[]
 
   public get indyCredentialOffer(): CredOffer | null {
-    const attachment = this.attachments.find((attachment) => attachment.id === INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
+    const attachment = this.offerAttachments.find((attachment) => attachment.id === INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
 
     // Return null if attachment is not found
     if (!attachment?.data?.base64) {

--- a/src/modules/credentials/messages/RequestCredentialMessage.ts
+++ b/src/modules/credentials/messages/RequestCredentialMessage.ts
@@ -11,7 +11,7 @@ export const INDY_CREDENTIAL_REQUEST_ATTACHMENT_ID = 'libindy-cred-request-0'
 interface RequestCredentialMessageOptions {
   id?: string
   comment?: string
-  attachments: Attachment[]
+  requestAttachments: Attachment[]
 }
 
 export class RequestCredentialMessage extends AgentMessage {
@@ -21,7 +21,7 @@ export class RequestCredentialMessage extends AgentMessage {
     if (options) {
       this.id = options.id || this.generateId()
       this.comment = options.comment
-      this.attachments = options.attachments
+      this.requestAttachments = options.requestAttachments
     }
   }
 
@@ -38,10 +38,12 @@ export class RequestCredentialMessage extends AgentMessage {
   @ValidateNested({
     each: true,
   })
-  public attachments!: Attachment[]
+  public requestAttachments!: Attachment[]
 
   public get indyCredentialRequest(): CredReq | null {
-    const attachment = this.attachments.find((attachment) => attachment.id === INDY_CREDENTIAL_REQUEST_ATTACHMENT_ID)
+    const attachment = this.requestAttachments.find(
+      (attachment) => attachment.id === INDY_CREDENTIAL_REQUEST_ATTACHMENT_ID
+    )
 
     // Return null if attachment is not found
     if (!attachment?.data?.base64) {

--- a/src/modules/credentials/services/CredentialService.ts
+++ b/src/modules/credentials/services/CredentialService.ts
@@ -225,7 +225,7 @@ export class CredentialService extends EventEmitter {
     })
     const credentialOfferMessage = new OfferCredentialMessage({
       comment,
-      attachments: [attachment],
+      offerAttachments: [attachment],
       credentialPreview: preview,
     })
     credentialOfferMessage.setThread({
@@ -269,7 +269,7 @@ export class CredentialService extends EventEmitter {
     })
     const credentialOfferMessage = new OfferCredentialMessage({
       comment,
-      attachments: [attachment],
+      offerAttachments: [attachment],
       credentialPreview: preview,
     })
 
@@ -407,7 +407,7 @@ export class CredentialService extends EventEmitter {
     const { comment } = options
     const credentialRequest = new RequestCredentialMessage({
       comment,
-      attachments: [attachment],
+      requestAttachments: [attachment],
     })
     credentialRequest.setThread({ threadId: credentialRecord.tags.threadId })
 
@@ -526,7 +526,7 @@ export class CredentialService extends EventEmitter {
     const { comment } = options
     const issueCredentialMessage = new IssueCredentialMessage({
       comment,
-      attachments: [credentialAttachment],
+      credentialAttachments: [credentialAttachment],
     })
     issueCredentialMessage.setThread({
       threadId: credentialRecord.tags.threadId,

--- a/src/modules/proofs/messages/PresentationMessage.ts
+++ b/src/modules/proofs/messages/PresentationMessage.ts
@@ -12,7 +12,7 @@ export const INDY_PROOF_ATTACHMENT_ID = 'libindy-presentation-0'
 export interface PresentationOptions {
   id?: string
   comment?: string
-  attachments: Attachment[]
+  presentationAttachments: Attachment[]
 }
 
 /**
@@ -28,7 +28,7 @@ export class PresentationMessage extends AgentMessage {
     if (options) {
       this.id = options.id ?? this.generateId()
       this.comment = options.comment
-      this.attachments = options.attachments
+      this.presentationAttachments = options.presentationAttachments
     }
   }
 
@@ -52,10 +52,10 @@ export class PresentationMessage extends AgentMessage {
   @ValidateNested({
     each: true,
   })
-  public attachments!: Attachment[]
+  public presentationAttachments!: Attachment[]
 
   public get indyProof(): IndyProof | null {
-    const attachment = this.attachments.find((attachment) => attachment.id === INDY_PROOF_ATTACHMENT_ID)
+    const attachment = this.presentationAttachments.find((attachment) => attachment.id === INDY_PROOF_ATTACHMENT_ID)
 
     // Return null if attachment is not found
     if (!attachment?.data?.base64) {

--- a/src/modules/proofs/messages/RequestPresentationMessage.ts
+++ b/src/modules/proofs/messages/RequestPresentationMessage.ts
@@ -11,7 +11,7 @@ import { PresentProofMessageType } from './PresentProofMessageType'
 export interface RequestPresentationOptions {
   id?: string
   comment?: string
-  attachments: Attachment[]
+  requestPresentationAttachments: Attachment[]
 }
 
 export const INDY_PROOF_REQUEST_ATTACHMENT_ID = 'libindy-request-presentation-0'
@@ -28,7 +28,7 @@ export class RequestPresentationMessage extends AgentMessage {
     if (options) {
       this.id = options.id ?? this.generateId()
       this.comment = options.comment
-      this.attachments = options.attachments
+      this.requestPresentationAttachments = options.requestPresentationAttachments
     }
   }
 
@@ -52,10 +52,12 @@ export class RequestPresentationMessage extends AgentMessage {
   @ValidateNested({
     each: true,
   })
-  public attachments!: Attachment[]
+  public requestPresentationAttachments!: Attachment[]
 
   public get indyProofRequest(): ProofRequest | null {
-    const attachment = this.attachments.find((attachment) => attachment.id === INDY_PROOF_REQUEST_ATTACHMENT_ID)
+    const attachment = this.requestPresentationAttachments.find(
+      (attachment) => attachment.id === INDY_PROOF_REQUEST_ATTACHMENT_ID
+    )
 
     // Return null if attachment is not found
     if (!attachment?.data?.base64) {

--- a/src/modules/proofs/services/ProofService.ts
+++ b/src/modules/proofs/services/ProofService.ts
@@ -247,7 +247,7 @@ export class ProofService extends EventEmitter {
     })
     const requestPresentationMessage = new RequestPresentationMessage({
       comment: config?.comment,
-      attachments: [attachment],
+      requestPresentationAttachments: [attachment],
     })
     requestPresentationMessage.setThread({
       threadId: proofRecord.tags.threadId,
@@ -290,7 +290,7 @@ export class ProofService extends EventEmitter {
     })
     const requestPresentationMessage = new RequestPresentationMessage({
       comment: config?.comment,
-      attachments: [attachment],
+      requestPresentationAttachments: [attachment],
     })
 
     // Create record
@@ -411,7 +411,7 @@ export class ProofService extends EventEmitter {
     })
     const presentationMessage = new PresentationMessage({
       comment: config?.comment,
-      attachments: [attachment],
+      presentationAttachments: [attachment],
     })
     presentationMessage.setThread({ threadId: proofRecord.tags.threadId })
 


### PR DESCRIPTION
Added the extension to the attachment decorator and renamed the attachment property on the issue and verify messages to avoid confliction.

Has been added for the support of linking credentials to attachments.

Signed-off-by: Berend Sliedrecht <berend@animo.id>