### PR TITLE
refactor: Move a transport protocol-related logic from the framework core

### DIFF
--- a/samples/mediator-ws.ts
+++ b/samples/mediator-ws.ts
@@ -3,10 +3,9 @@ import WebSocket from 'ws'
 import cors from 'cors'
 import { v4 as uuid } from 'uuid'
 import config from './config'
-import { Agent, InboundTransporter, WsOutboundTransporter } from '../src'
+import { Agent, InboundTransporter, WebSocketTransportSession, WsOutboundTransporter } from '../src'
 import { DidCommMimeType } from '../src/types'
 import { InMemoryMessageRepository } from '../src/storage/InMemoryMessageRepository'
-import { WebSocketTransport } from '../src/agent/TransportService'
 import testLogger from '../src/__tests__/logger'
 
 const logger = testLogger
@@ -40,8 +39,8 @@ class WsInboundTransporter implements InboundTransporter {
     socket.addEventListener('message', async (event: any) => {
       logger.debug('WebSocket message event received.', { url: event.target.url, data: event.data })
       // @ts-expect-error Property 'dispatchEvent' is missing in type WebSocket imported from 'ws' module but required in type 'WebSocket'.
-      const transport = new WebSocketTransport('', socket)
-      const outboundMessage = await agent.receiveMessage(JSON.parse(event.data), transport)
+      const session = new WebSocketTransportSession(socket)
+      const outboundMessage = await agent.receiveMessage(JSON.parse(event.data), session)
       if (outboundMessage) {
         socket.send(JSON.stringify(outboundMessage.payload))
       }

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -316,6 +316,14 @@ export async function issueCredential({
   }
 }
 
+/**
+ * Returns mock of function with correct type annotations according to original function `fn`.
+ * It can be used also for class methods.
+ *
+ * @param fn function you want to mock
+ * @returns mock function with type annotations
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function mockFunction<T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> {
   return fn as jest.MockedFunction<T>
 }

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -19,7 +19,7 @@ import { BasicMessagesModule } from '../modules/basic-messages/BasicMessagesModu
 import { LedgerModule } from '../modules/ledger/LedgerModule'
 import { InMemoryMessageRepository } from '../storage/InMemoryMessageRepository'
 import { Symbols } from '../symbols'
-import { Transport } from './TransportService'
+import { TransportSession } from './TransportService'
 import { EventEmitter } from './EventEmitter'
 import { AgentEventTypes, AgentMessageReceivedEvent } from './Events'
 
@@ -136,8 +136,8 @@ export class Agent {
     return this.agentConfig.mediatorUrl
   }
 
-  public async receiveMessage(inboundPackedMessage: unknown, transport?: Transport) {
-    return await this.messageReceiver.receiveMessage(inboundPackedMessage, transport)
+  public async receiveMessage(inboundPackedMessage: unknown, session?: TransportSession) {
+    return await this.messageReceiver.receiveMessage(inboundPackedMessage, session)
   }
 
   public async closeAndDeleteWallet() {

--- a/src/agent/MessageReceiver.ts
+++ b/src/agent/MessageReceiver.ts
@@ -11,7 +11,7 @@ import { AgentMessage } from './AgentMessage'
 import { JsonTransformer } from '../utils/JsonTransformer'
 import { Logger } from '../logger'
 import { replaceLegacyDidSovPrefixOnMessage } from '../utils/messageType'
-import { Transport, TransportService } from './TransportService'
+import { TransportSession, TransportService } from './TransportService'
 import { AriesFrameworkError } from '../error'
 
 @scoped(Lifecycle.ContainerScoped)
@@ -44,7 +44,7 @@ export class MessageReceiver {
    *
    * @param inboundPackedMessage the message to receive and handle
    */
-  public async receiveMessage(inboundPackedMessage: unknown, transport?: Transport) {
+  public async receiveMessage(inboundPackedMessage: unknown, session?: TransportSession) {
     if (typeof inboundPackedMessage !== 'object' || inboundPackedMessage == null) {
       throw new AriesFrameworkError('Invalid message received. Message should be object')
     }
@@ -70,8 +70,8 @@ export class MessageReceiver {
       }
     }
 
-    if (connection && transport) {
-      this.transportService.saveTransport(connection.id, transport)
+    if (connection && session) {
+      this.transportService.saveSession(connection.id, session)
     }
 
     this.logger.info(`Received message with type '${unpackedMessage.message['@type']}'`, unpackedMessage.message)

--- a/src/agent/MessageSender.ts
+++ b/src/agent/MessageSender.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { inject, Lifecycle, scoped } from 'tsyringe'
 
 import { OutboundMessage, OutboundPackage } from '../types'
@@ -39,7 +38,7 @@ export class MessageSender {
     const { verkey, theirKey } = connection
     const endpoint = this.transportService.findEndpoint(connection)
     const message = payload.toJSON()
-    this.logger.info('outboundMessage', { verkey, theirKey, message })
+    this.logger.debug('outboundMessage', { verkey, theirKey, message })
     const responseRequested = outboundMessage.payload.hasReturnRouting()
     const wireMessage = await this.envelopeService.packMessage(outboundMessage)
     return { connection, payload: wireMessage, endpoint, responseRequested }

--- a/src/agent/MessageSender.ts
+++ b/src/agent/MessageSender.ts
@@ -50,8 +50,7 @@ export class MessageSender {
       throw new AriesFrameworkError('Agent has no outbound transporter!')
     }
     const outboundPackage = await this.packMessage(outboundMessage)
-    const transport = this.transportService.findTransport(outboundMessage.connection.id)
-    outboundPackage.transport = transport
+    outboundPackage.session = this.transportService.findSession(outboundMessage.connection.id)
     await this.outboundTransporter.sendMessage(outboundPackage)
   }
 }

--- a/src/agent/MessageSender.ts
+++ b/src/agent/MessageSender.ts
@@ -1,20 +1,28 @@
-import { Lifecycle, scoped } from 'tsyringe'
+import { inject, Lifecycle, scoped } from 'tsyringe'
 
 import { OutboundMessage, OutboundPackage } from '../types'
 import { OutboundTransporter } from '../transport/OutboundTransporter'
 import { EnvelopeService } from './EnvelopeService'
 import { TransportService } from './TransportService'
 import { AriesFrameworkError } from '../error'
+import { Logger } from '../logger'
+import { Symbols } from '../symbols'
 
 @scoped(Lifecycle.ContainerScoped)
 export class MessageSender {
   private envelopeService: EnvelopeService
   private transportService: TransportService
+  private logger: Logger
   private _outboundTransporter?: OutboundTransporter
 
-  public constructor(envelopeService: EnvelopeService, transportService: TransportService) {
+  public constructor(
+    envelopeService: EnvelopeService,
+    transportService: TransportService,
+    @inject(Symbols.Logger) logger: Logger
+  ) {
     this.envelopeService = envelopeService
     this.transportService = transportService
+    this.logger = logger
   }
 
   public setOutboundTransporter(outboundTransporter: OutboundTransporter) {
@@ -26,14 +34,20 @@ export class MessageSender {
   }
 
   public async packMessage(outboundMessage: OutboundMessage): Promise<OutboundPackage> {
-    return this.envelopeService.packMessage(outboundMessage)
+    const { connection, payload, endpoint } = outboundMessage
+    const { verkey, theirKey } = connection
+    const message = payload.toJSON()
+    this.logger.info('outboundMessage', { verkey, theirKey, endpoint, message })
+    const responseRequested = outboundMessage.payload.hasReturnRouting()
+    const wireMessage = await this.envelopeService.packMessage(outboundMessage)
+    return { connection, payload: wireMessage, endpoint, responseRequested }
   }
 
   public async sendMessage(outboundMessage: OutboundMessage): Promise<void> {
     if (!this.outboundTransporter) {
       throw new AriesFrameworkError('Agent has no outbound transporter!')
     }
-    const outboundPackage = await this.envelopeService.packMessage(outboundMessage)
+    const outboundPackage = await this.packMessage(outboundMessage)
     const transport = this.transportService.resolveTransport(outboundMessage.connection)
     outboundPackage.transport = transport
     await this.outboundTransporter.sendMessage(outboundPackage)

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -10,23 +10,23 @@ export const DID_COMM_TRANSPORT_QUEUE = 'didcomm:transport/queue'
 
 @scoped(Lifecycle.ContainerScoped)
 export class TransportService {
-  private transportTable: TransportTable = {}
+  private transportSessionTable: TransportSessionTable = {}
   private logger: Logger
 
   public constructor(@inject(Symbols.Logger) logger: Logger) {
     this.logger = logger
   }
 
-  public saveTransport(connectionId: string, transport: Transport) {
-    this.transportTable[connectionId] = transport
+  public saveSession(connectionId: string, transport: TransportSession) {
+    this.transportSessionTable[connectionId] = transport
   }
 
   public hasInboundEndpoint(connection: ConnectionRecord) {
     return connection.didDoc.didCommServices.find((s) => s.serviceEndpoint !== DID_COMM_TRANSPORT_QUEUE)
   }
 
-  public findTransport(connectionId: string) {
-    return this.transportTable[connectionId]
+  public findSession(connectionId: string) {
+    return this.transportSessionTable[connectionId]
   }
 
   public findEndpoint(connection: ConnectionRecord) {
@@ -49,24 +49,10 @@ export class TransportService {
   }
 }
 
-interface TransportTable {
-  [connectionRecordId: string]: Transport
+interface TransportSessionTable {
+  [connectionRecordId: string]: TransportSession
 }
 
-type TransportType = 'websocket' | 'http' | 'queue'
-
-export interface Transport {
-  type: TransportType
-  endpoint: string
-}
-
-export class WebSocketTransport implements Transport {
-  public readonly type = 'websocket'
-  public endpoint: string
-  public socket?: WebSocket
-
-  public constructor(endpoint: string, socket?: WebSocket) {
-    this.endpoint = endpoint
-    this.socket = socket
-  }
+export interface TransportSession {
+  type: string
 }

--- a/src/agent/__tests__/MessageSender.test.ts
+++ b/src/agent/__tests__/MessageSender.test.ts
@@ -5,11 +5,10 @@ import { EnvelopeService as EnvelopeServiceImpl } from '../EnvelopeService'
 import { createOutboundMessage } from '../helpers'
 import { AgentMessage } from '../AgentMessage'
 import { OutboundTransporter } from '../../transport'
-import { OutboundPackage } from '../..'
-import { OutboundMessage } from '../../types'
+import { OutboundPackage } from '../../types'
 import { ConnectionRecord } from '../../modules/connections'
 import { ReturnRouteTypes } from '../../decorators/transport/TransportDecorator'
-import { getMockConnection } from '../../__tests__/helpers'
+import { getMockConnection, mockFunction } from '../../__tests__/helpers'
 
 jest.mock('../TransportService')
 jest.mock('../EnvelopeService')
@@ -47,10 +46,7 @@ describe('MessageSender', () => {
   }
 
   const enveloperService = new EnvelopeService()
-  const envelopeServicePackMessageMock = enveloperService.packMessage as jest.Mock<
-    Promise<JsonWebKey>,
-    [OutboundMessage]
-  >
+  const envelopeServicePackMessageMock = mockFunction(enveloperService.packMessage)
   envelopeServicePackMessageMock.mockReturnValue(Promise.resolve(wireMessage))
 
   const transportService = new TransportService()
@@ -130,15 +126,3 @@ describe('MessageSender', () => {
     })
   })
 })
-
-/**
- * Returns mock of function with correct type annotations according to original function `fn`.
- * It can be used also for class methods.
- *
- * @param fn function you want to mock
- * @returns mock function with type annotations
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function mockFunction<T extends (...args: any[]) => any>(fn: T): jest.MockedFunction<T> {
-  return fn as jest.MockedFunction<T>
-}

--- a/src/agent/__tests__/MessageSender.test.ts
+++ b/src/agent/__tests__/MessageSender.test.ts
@@ -1,0 +1,113 @@
+import testLogger from '../../__tests__/logger'
+import { MessageSender } from '../MessageSender'
+import { Transport, TransportService as TransportServiceImpl } from '../TransportService'
+import { EnvelopeService as EnvelopeServiceImpl } from '../EnvelopeService'
+import { createOutboundMessage } from '../helpers'
+import { AgentMessage } from '../AgentMessage'
+import { OutboundTransporter } from '../../transport'
+import { OutboundPackage } from '../..'
+import { OutboundMessage } from '../../types'
+import { ConnectionRecord } from '../../modules/connections'
+import { ReturnRouteTypes } from '../../decorators/transport/TransportDecorator'
+import { getMockConnection } from '../../__tests__/helpers'
+
+jest.mock('../TransportService')
+jest.mock('../EnvelopeService')
+
+const logger = testLogger
+
+class DummyOutboundTransporter implements OutboundTransporter {
+  public start(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public stop(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public supportedSchemes: string[] = []
+  public sendMessage(outboundPackage: OutboundPackage): Promise<any> {
+    return Promise.resolve()
+  }
+}
+
+class DummyTransport implements Transport {
+  public readonly type = 'websocket'
+  public endpoint = 'endpoint'
+}
+
+describe('MessageSender', () => {
+  describe('sendMessage', () => {
+    const TransportService = <jest.Mock<TransportServiceImpl>>(<unknown>TransportServiceImpl)
+    const EnvelopeService = <jest.Mock<EnvelopeServiceImpl>>(<unknown>EnvelopeServiceImpl)
+
+    const wireMessage = {
+      alg: 'EC',
+      crv: 'P-256',
+      x: 'MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4',
+      y: '4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM',
+      use: 'enc',
+      kid: '1',
+    }
+
+    const enveloperService = new EnvelopeService()
+    const envelopeServicePackMessageMock = enveloperService.packMessage as jest.Mock<
+      Promise<JsonWebKey>,
+      [OutboundMessage]
+    >
+    envelopeServicePackMessageMock.mockReturnValue(Promise.resolve(wireMessage))
+
+    const transport = new DummyTransport()
+    const transportService = new TransportService()
+    const transportServiceResolveTransportMock = transportService.resolveTransport as jest.Mock<
+      Transport,
+      [ConnectionRecord]
+    >
+    transportServiceResolveTransportMock.mockReturnValue(transport)
+
+    let messageSender: MessageSender
+    let outboundTransporter: OutboundTransporter
+    let connection: ConnectionRecord
+
+    beforeEach(() => {
+      outboundTransporter = new DummyOutboundTransporter()
+      messageSender = new MessageSender(enveloperService, transportService, logger)
+      connection = getMockConnection({ id: 'test-123' })
+    })
+
+    test('throws error when there is no outbound transport', async () => {
+      const message = new AgentMessage()
+      const outboundMessage = createOutboundMessage(connection, message)
+      await expect(messageSender.sendMessage(outboundMessage)).rejects.toThrow(`Agent has no outbound transporter!`)
+    })
+
+    test('calls transporter with connection, payload and endpoint', async () => {
+      const message = new AgentMessage()
+      const spy = jest.spyOn(outboundTransporter, 'sendMessage')
+      const outboundMessage = createOutboundMessage(connection, message)
+      messageSender.setOutboundTransporter(outboundTransporter)
+
+      await messageSender.sendMessage(outboundMessage)
+
+      const [[sendMessageCall]] = spy.mock.calls
+      expect(sendMessageCall).toEqual({
+        connection,
+        payload: wireMessage,
+        endpoint: outboundMessage.endpoint,
+        responseRequested: false,
+        transport,
+      })
+    })
+
+    test('when message has return route calls transporter with responseRequested', async () => {
+      const message = new AgentMessage()
+      const spy = jest.spyOn(outboundTransporter, 'sendMessage')
+      message.setReturnRouting(ReturnRouteTypes.all)
+      const outboundMessage = createOutboundMessage(connection, message)
+      messageSender.setOutboundTransporter(outboundTransporter)
+
+      await messageSender.sendMessage(outboundMessage)
+
+      const [[sendMessageCall]] = spy.mock.calls
+      expect(sendMessageCall.responseRequested).toEqual(true)
+    })
+  })
+})

--- a/src/agent/__tests__/MessageSender.test.ts
+++ b/src/agent/__tests__/MessageSender.test.ts
@@ -1,6 +1,6 @@
 import testLogger from '../../__tests__/logger'
 import { MessageSender } from '../MessageSender'
-import { Transport, TransportService as TransportServiceImpl } from '../TransportService'
+import { TransportSession, TransportService as TransportServiceImpl } from '../TransportService'
 import { EnvelopeService as EnvelopeServiceImpl } from '../EnvelopeService'
 import { createOutboundMessage } from '../helpers'
 import { AgentMessage } from '../AgentMessage'
@@ -29,9 +29,8 @@ class DummyOutboundTransporter implements OutboundTransporter {
   }
 }
 
-class DummyTransport implements Transport {
-  public readonly type = 'websocket'
-  public endpoint = 'endpoint'
+class DummyTransportSession implements TransportSession {
+  public readonly type = 'dummy'
 }
 
 describe('MessageSender', () => {
@@ -55,9 +54,9 @@ describe('MessageSender', () => {
   envelopeServicePackMessageMock.mockReturnValue(Promise.resolve(wireMessage))
 
   const transportService = new TransportService()
-  const transport = new DummyTransport()
-  const transportServiceFindTransportMock = mockFunction(transportService.findTransport)
-  transportServiceFindTransportMock.mockReturnValue(transport)
+  const session = new DummyTransportSession()
+  const transportServiceFindSessionMock = mockFunction(transportService.findSession)
+  transportServiceFindSessionMock.mockReturnValue(session)
 
   const endpoint = 'https://www.exampleEndpoint.com'
   const transportServiceFindEndpointMock = mockFunction(transportService.findEndpoint)
@@ -94,7 +93,7 @@ describe('MessageSender', () => {
         payload: wireMessage,
         endpoint,
         responseRequested: false,
-        transport,
+        session,
       })
     })
   })

--- a/src/agent/helpers.ts
+++ b/src/agent/helpers.ts
@@ -14,7 +14,6 @@ export function createOutboundMessage<T extends AgentMessage = AgentMessage>(
     // When invitation uses DID
     return {
       connection,
-      endpoint: invitation.serviceEndpoint,
       payload,
       recipientKeys: invitation.recipientKeys || [],
       routingKeys: invitation.routingKeys || [],
@@ -32,7 +31,6 @@ export function createOutboundMessage<T extends AgentMessage = AgentMessage>(
 
   return {
     connection,
-    endpoint: service.serviceEndpoint,
     payload,
     recipientKeys: service.recipientKeys,
     routingKeys: service.routingKeys ?? [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import type Indy from 'indy-sdk'
 import type { Did, WalletConfig, WalletCredentials, Verkey } from 'indy-sdk'
 import { ConnectionRecord } from './modules/connections'
 import { AgentMessage } from './agent/AgentMessage'
-import { Transport } from './agent/TransportService'
+import { TransportSession } from './agent/TransportService'
 import { Logger } from './logger'
 import { FileSystem } from './storage/fs/FileSystem'
 
@@ -62,7 +62,7 @@ export interface OutboundPackage {
   payload: WireMessage
   responseRequested?: boolean
   endpoint?: string
-  transport?: Transport
+  session?: TransportSession
 }
 
 export interface InboundConnection {


### PR DESCRIPTION
I did some refactorings to help me add support for multiple transports in the following PR:
* Add test to `MessageSender`
* Move up a logic from `EnvelopeService` to `MessageSender`
* Remove transport-related details from the `TransportService` and from the core of the framework.
* Rename `transport` to `session` which hopefully express the meaning better.

As a next step I'm considering:
* Rename transporters to transports
* Move up more logic from `MessageSender.packMessage` and pass `service` object to `packMessage`
* Then we could call `packMessage` and `sendMessage` for every available service. Eventually, we could remove the logic from `createOutboundMessage`.
* Improve validation of `outboundMessage` inside `OutboundTransporter` and error handling
* Add multiple transports

If you think it doesn't make sense to merge this without full functionality I can continue with adding changes. But I realized that it contains a good amount of changes already and it could be worth merging sooner.