### PR TITLE
fix: test failing because of moved import

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -52,24 +52,6 @@ export function getBaseConfig(name: string, extraConfig: Partial<InitConfig> = {
   return config
 }
 
-// Custom matchers which can be used to extend Jest matchers via extend, e. g. `expect.extend({ toBeConnectedWith })`.
-export function toBeConnectedWith(received: ConnectionRecord, connection: ConnectionRecord) {
-  const pass = received.theirDid === connection.did && received.theirKey === connection.verkey
-  if (pass) {
-    return {
-      message: () =>
-        `expected connection ${received.did}, ${received.verkey} not to be connected to with ${connection.did}, ${connection.verkey}`,
-      pass: true,
-    }
-  } else {
-    return {
-      message: () =>
-        `expected connection ${received.did}, ${received.verkey} to be connected to with ${connection.did}, ${connection.verkey}`,
-      pass: false,
-    }
-  }
-}
-
 export async function waitForProofRecord(
   agent: Agent,
   {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,4 +1,22 @@
 import 'reflect-metadata'
-import { toBeConnectedWith } from './helpers'
+import { ConnectionRecord } from '../modules/connections/repository/ConnectionRecord'
 
 expect.extend({ toBeConnectedWith })
+
+// Custom matchers which can be used to extend Jest matchers via extend, e. g. `expect.extend({ toBeConnectedWith })`.
+function toBeConnectedWith(received: ConnectionRecord, connection: ConnectionRecord) {
+  const pass = received.theirDid === connection.did && received.theirKey === connection.verkey
+  if (pass) {
+    return {
+      message: () =>
+        `expected connection ${received.did}, ${received.verkey} not to be connected to with ${connection.did}, ${connection.verkey}`,
+      pass: true,
+    }
+  } else {
+    return {
+      message: () =>
+        `expected connection ${received.did}, ${received.verkey} to be connected to with ${connection.did}, ${connection.verkey}`,
+      pass: false,
+    }
+  }
+}


### PR DESCRIPTION
This should fix the failing CI.

The CI jobs are now required so it won't be possible to get bad commits into main


The problem was because I moved `toBeConnected` with to setup so each test file doesn't have to do it anymore. However this caused (i think?) some cyclic dependencies