### PR TITLE
fix: convert from buffer now also accepts uint8Array

### DIFF
--- a/src/utils/BufferEncoder.ts
+++ b/src/utils/BufferEncoder.ts
@@ -7,8 +7,8 @@ export class BufferEncoder {
    *
    * @param buffer the buffer to encode into base64 string
    */
-  public static toBase64(buffer: Buffer) {
-    return buffer.toString('base64')
+  public static toBase64(buffer: Buffer | Uint8Array) {
+    return Buffer.from(buffer).toString('base64')
   }
 
   /**

--- a/src/utils/JsonEncoder.ts
+++ b/src/utils/JsonEncoder.ts
@@ -61,7 +61,7 @@ export class JsonEncoder {
    *
    * @param buffer the buffer to decode into json
    */
-  public static fromBuffer(buffer: Buffer) {
-    return JsonEncoder.fromString(buffer.toString('utf-8'))
+  public static fromBuffer(buffer: Buffer | Uint8Array) {
+    return JsonEncoder.fromString(Buffer.from(buffer).toString('utf-8'))
   }
 }


### PR DESCRIPTION
Also decodes from uint8Array now instead of only a Buffer.

Necessary for anything that is not in NodeJs.

Signed-off-by: blu3beri <berend@animo.id>