### PR TITLE
fix: websocket and fetch fix for browser

### DIFF
--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -1,3 +1,7 @@
 export function isNodeJS() {
-  return typeof process !== 'undefined' && process.release.name === 'node'
+  return typeof process !== 'undefined' && process.release && process.release.name === 'node'
+}
+
+export function isReactNative() {
+  return typeof navigator != 'undefined' && navigator.product == 'ReactNative'
 }

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,12 +1,16 @@
 import { isNodeJS, isReactNative } from './environment'
 
-let fetch
+type Fetch = {
+  (input: RequestInfo, init?: RequestInit): Promise<Response>
+}
+
+let fetch: Fetch
 let Headers
 let Request
 let Response
 
 // NodeJS doesn't have fetch by default
-if (!fetch && isNodeJS()) {
+if (isNodeJS()) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const nodeFetch = require('node-fetch')
 
@@ -14,7 +18,7 @@ if (!fetch && isNodeJS()) {
   Headers = nodeFetch.Headers
   Request = nodeFetch.Request
   Response = nodeFetch.Response
-} else if (!fetch && isReactNative()) {
+} else if (isReactNative()) {
   fetch = global.fetch
   Headers = global.Headers
   Request = global.Request

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,10 +1,6 @@
 import { isNodeJS, isReactNative } from './environment'
 
-type Fetch = {
-  (input: RequestInfo, init?: RequestInit): Promise<Response>
-}
-
-let fetch: Fetch
+let fetch: typeof global.fetch
 let Headers
 let Request
 let Response

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,10 +1,9 @@
-import { isNodeJS } from './environment'
+import { isNodeJS, isReactNative } from './environment'
 
-// RN exposes global fetch
-let fetch = global.fetch
-let Headers = global.Headers
-let Request = global.Request
-let Response = global.Response
+let fetch
+let Headers
+let Request
+let Response
 
 // NodeJS doesn't have fetch by default
 if (!fetch && isNodeJS()) {
@@ -15,6 +14,16 @@ if (!fetch && isNodeJS()) {
   Headers = nodeFetch.Headers
   Request = nodeFetch.Request
   Response = nodeFetch.Response
+} else if (!fetch && isReactNative()) {
+  fetch = global.fetch
+  Headers = global.Headers
+  Request = global.Request
+  Response = global.Response
+} else {
+  fetch = window.fetch.bind(window)
+  Headers = window.Headers
+  Request = window.Request
+  Response = window.Response
 }
 
 export { fetch, Headers, Request, Response }

--- a/src/utils/ws.ts
+++ b/src/utils/ws.ts
@@ -1,15 +1,6 @@
 import { isNodeJS, isReactNative } from './environment'
 
-type WS = {
-  new (url: string, protocols?: string | string[] | undefined): WebSocket
-  prototype: WebSocket
-  readonly CLOSED: number
-  readonly CLOSING: number
-  readonly CONNECTING: number
-  readonly OPEN: number
-}
-
-let WebSocket: WS
+let WebSocket: typeof global.WebSocket
 
 // NodeJS doesn't have WebSocket by default
 if (isNodeJS()) {

--- a/src/utils/ws.ts
+++ b/src/utils/ws.ts
@@ -1,7 +1,6 @@
-import { isNodeJS } from './environment'
+import { isNodeJS, isReactNative } from './environment'
 
-// RN exposes global WebSocket
-let WebSocket = global.WebSocket
+let WebSocket
 
 // NodeJS doesn't have WebSocket by default
 if (!WebSocket && isNodeJS()) {
@@ -9,6 +8,10 @@ if (!WebSocket && isNodeJS()) {
   const nodeWebSocket = require('ws')
 
   WebSocket = nodeWebSocket
+} else if (!WebSocket && isReactNative()) {
+  WebSocket = global.WebSocket
+} else {
+  WebSocket = window.WebSocket.bind(window)
 }
 
 export { WebSocket }

--- a/src/utils/ws.ts
+++ b/src/utils/ws.ts
@@ -1,14 +1,23 @@
 import { isNodeJS, isReactNative } from './environment'
 
-let WebSocket
+type WS = {
+  new (url: string, protocols?: string | string[] | undefined): WebSocket
+  prototype: WebSocket
+  readonly CLOSED: number
+  readonly CLOSING: number
+  readonly CONNECTING: number
+  readonly OPEN: number
+}
+
+let WebSocket: WS
 
 // NodeJS doesn't have WebSocket by default
-if (!WebSocket && isNodeJS()) {
+if (isNodeJS()) {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   const nodeWebSocket = require('ws')
 
   WebSocket = nodeWebSocket
-} else if (!WebSocket && isReactNative()) {
+} else if (isReactNative()) {
   WebSocket = global.WebSocket
 } else {
   WebSocket = window.WebSocket.bind(window)


### PR DESCRIPTION
- fix: fetch & websocket browser support

This add support for fetch and websocket in the browser environment. Typings had to be added to prevent errors in the respective outboundtransport

(Not sure if these typings are the correct way)
