### PR TITLE
fix: use both thread id and connection id

### DIFF
--- a/src/__tests__/credentials.test.ts
+++ b/src/__tests__/credentials.test.ts
@@ -149,7 +149,10 @@ describe('credentials', () => {
 
     // below values are not in json object
     expect(aliceCredentialRecord.id).not.toBeNull()
-    expect(aliceCredentialRecord.tags).toEqual({ threadId: faberCredentialRecord.tags.threadId })
+    expect(aliceCredentialRecord.tags).toEqual({
+      threadId: faberCredentialRecord.tags.threadId,
+      connectionId: aliceCredentialRecord.tags.connectionId,
+    })
     expect(aliceCredentialRecord.type).toBe(CredentialRecord.name)
 
     testLogger.test('Alice sends credential request to Faber')
@@ -185,6 +188,7 @@ describe('credentials', () => {
       createdAt: expect.any(Date),
       tags: {
         threadId: expect.any(String),
+        connectionId: expect.any(String),
       },
       offerMessage: expect.any(Object),
       requestMessage: expect.any(Object),
@@ -203,6 +207,7 @@ describe('credentials', () => {
       createdAt: expect.any(Date),
       tags: {
         threadId: expect.any(String),
+        connectionId: expect.any(String),
       },
       metadata: {
         schemaId,
@@ -256,7 +261,10 @@ describe('credentials', () => {
 
     // below values are not in json object
     expect(aliceCredentialRecord.id).not.toBeNull()
-    expect(aliceCredentialRecord.tags).toEqual({ threadId: faberCredentialRecord.tags.threadId })
+    expect(aliceCredentialRecord.tags).toEqual({
+      threadId: faberCredentialRecord.tags.threadId,
+      connectionId: aliceConnection.id,
+    })
     expect(aliceCredentialRecord.type).toBe(CredentialRecord.name)
 
     testLogger.test('Alice sends credential request to Faber')
@@ -292,6 +300,7 @@ describe('credentials', () => {
       createdAt: expect.any(Date),
       tags: {
         threadId: expect.any(String),
+        connectionId: expect.any(String),
       },
       offerMessage: expect.any(Object),
       requestMessage: expect.any(Object),
@@ -306,6 +315,7 @@ describe('credentials', () => {
       createdAt: expect.any(Date),
       tags: {
         threadId: expect.any(String),
+        connectionId: expect.any(String),
       },
       offerMessage: expect.any(Object),
       requestMessage: expect.any(Object),

--- a/src/modules/credentials/CredentialsModule.ts
+++ b/src/modules/credentials/CredentialsModule.ts
@@ -215,15 +215,16 @@ export class CredentialsModule {
   }
 
   /**
-   * Retrieve a credential record by thread id
+   * Retrieve a credential record by connection id and thread id
    *
+   * @param connectionId The connection id
    * @param threadId The thread id
    * @throws {RecordNotFoundError} If no record is found
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The credential record
    */
-  public getByThreadId(threadId: string): Promise<CredentialRecord> {
-    return this.credentialService.getByThreadId(threadId)
+  public getByConnectionAndThreadId(connectionId: string, threadId: string): Promise<CredentialRecord> {
+    return this.credentialService.getByConnectionAndThreadId(connectionId, threadId)
   }
 
   private registerHandlers(dispatcher: Dispatcher) {

--- a/src/modules/credentials/__tests__/CredentialRecord.test.ts
+++ b/src/modules/credentials/__tests__/CredentialRecord.test.ts
@@ -18,6 +18,10 @@ describe('CredentialRecord', () => {
           credentialDefinitionId: 'Th7MpTaRZVRYnPiabds81Y:3:CL:17:TAG',
           schemaId: 'TL1EaPFCZ8Si5aUrqScBDt:2:test-schema-1599055118161:1.0',
         },
+        tags: {
+          threadId: 'threadId',
+          connectionId: '28790bfe-1345-4c64-b21a-7d98982b3894',
+        },
       })
 
       const credentialInfo = credentialRecord.getCredentialInfo()

--- a/src/modules/credentials/__tests__/CredentialService.test.ts
+++ b/src/modules/credentials/__tests__/CredentialService.test.ts
@@ -107,21 +107,27 @@ const mockCredentialRecord = ({
   tags?: CredentialRecordTags
   id?: string
   credentialAttributes?: CredentialPreviewAttribute[]
-} = {}) =>
-  new CredentialRecord({
-    offerMessage: new OfferCredentialMessage({
-      comment: 'some comment',
-      credentialPreview: credentialPreview,
-      offerAttachments: [offerAttachment],
-    }),
+} = {}) => {
+  const offerMessage = new OfferCredentialMessage({
+    comment: 'some comment',
+    credentialPreview: credentialPreview,
+    offerAttachments: [offerAttachment],
+  })
+
+  return new CredentialRecord({
+    offerMessage,
     id,
     credentialAttributes: credentialAttributes || credentialPreview.attributes,
     requestMessage,
     metadata,
     state: state || CredentialState.OfferSent,
-    tags: tags || {},
+    tags: tags ?? {
+      threadId: offerMessage.id,
+      connectionId: '123',
+    },
     connectionId: '123',
   })
+}
 
 describe('CredentialService', () => {
   let credentialRepository: CredentialRepository
@@ -177,7 +183,7 @@ describe('CredentialService', () => {
         id: expect.any(String),
         createdAt: expect.any(Date),
         offerMessage: credentialOffer,
-        tags: { threadId: createdCredentialRecord.offerMessage?.id },
+        tags: { threadId: createdCredentialRecord.offerMessage?.id, connectionId: connection.id },
         state: CredentialState.OfferSent,
       })
     })
@@ -262,7 +268,7 @@ describe('CredentialService', () => {
         id: expect.any(String),
         createdAt: expect.any(Date),
         offerMessage: credentialOfferMessage,
-        tags: { threadId: credentialOfferMessage.id },
+        tags: { threadId: credentialOfferMessage.id, connectionId: connection.id },
         state: CredentialState.OfferReceived,
       }
       expect(repositorySaveSpy).toHaveBeenCalledTimes(1)
@@ -297,7 +303,10 @@ describe('CredentialService', () => {
     beforeEach(() => {
       credentialRecord = mockCredentialRecord({
         state: CredentialState.OfferReceived,
-        tags: { threadId: 'fd9c5ddb-ec11-4acd-bc32-540736249746' },
+        tags: {
+          threadId: 'fd9c5ddb-ec11-4acd-bc32-540736249746',
+          connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190',
+        },
       })
     })
 
@@ -404,7 +413,10 @@ describe('CredentialService', () => {
       const returnedCredentialRecord = await credentialService.processRequest(messageContext)
 
       // then
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, { threadId: 'somethreadid' })
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+        threadId: 'somethreadid',
+        connectionId: connection.id,
+      })
 
       const expectedCredentialRecord = {
         state: CredentialState.RequestReceived,
@@ -460,7 +472,7 @@ describe('CredentialService', () => {
           comment: 'abcd',
           requestAttachments: [requestAttachment],
         }),
-        tags: { threadId },
+        tags: { threadId, connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190' },
       })
     })
 
@@ -545,7 +557,7 @@ describe('CredentialService', () => {
         credentialService.createCredential(
           mockCredentialRecord({
             state: CredentialState.RequestReceived,
-            tags: { threadId },
+            tags: { threadId, connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190' },
           })
         )
       ).rejects.toThrowError(
@@ -562,7 +574,7 @@ describe('CredentialService', () => {
             credentialService.createCredential(
               mockCredentialRecord({
                 state,
-                tags: { threadId },
+                tags: { threadId, connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190' },
                 requestMessage: new RequestCredentialMessage({
                   requestAttachments: [requestAttachment],
                 }),
@@ -610,7 +622,10 @@ describe('CredentialService', () => {
       await credentialService.processCredential(messageContext)
 
       // then
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, { threadId: 'somethreadid' })
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+        threadId: 'somethreadid',
+        connectionId: connection.id,
+      })
 
       expect(storeCredentialMock).toHaveBeenNthCalledWith(1, {
         credentialId: expect.any(String),
@@ -722,7 +737,7 @@ describe('CredentialService', () => {
     beforeEach(() => {
       credential = mockCredentialRecord({
         state: CredentialState.CredentialReceived,
-        tags: { threadId },
+        tags: { threadId, connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190' },
       })
     })
 
@@ -783,7 +798,9 @@ describe('CredentialService', () => {
       await Promise.all(
         invalidCredentialStates.map(async (state) => {
           await expect(
-            credentialService.createAck(mockCredentialRecord({ state, tags: { threadId } }))
+            credentialService.createAck(
+              mockCredentialRecord({ state, tags: { threadId, connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190' } })
+            )
           ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
@@ -821,7 +838,10 @@ describe('CredentialService', () => {
       const expectedCredentialRecord = {
         state: CredentialState.Done,
       }
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, { threadId: 'somethreadid' })
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+        threadId: 'somethreadid',
+        connectionId: connection.id,
+      })
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
       const [[updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
       expect(updatedCredentialRecord).toMatchObject(expectedCredentialRecord)
@@ -889,8 +909,11 @@ describe('CredentialService', () => {
     it('getById should return value from credentialRepository.getSingleByQuery', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.getByThreadId('threadId')
-      expect(credentialRepository.getSingleByQuery).toBeCalledWith({ threadId: 'threadId' })
+      const result = await credentialService.getByConnectionAndThreadId('connectionId', 'threadId')
+      expect(credentialRepository.getSingleByQuery).toBeCalledWith({
+        threadId: 'threadId',
+        connectionId: 'connectionId',
+      })
 
       expect(result).toBe(expected)
     })

--- a/src/modules/credentials/repository/CredentialRecord.ts
+++ b/src/modules/credentials/repository/CredentialRecord.ts
@@ -26,7 +26,7 @@ export interface CredentialStorageProps {
 
   credentialId?: string
   metadata?: CredentialRecordMetadata
-  tags?: CredentialRecordTags
+  tags: CredentialRecordTags
   proposalMessage?: ProposeCredentialMessage
   offerMessage?: OfferCredentialMessage
   requestMessage?: RequestCredentialMessage
@@ -35,7 +35,8 @@ export interface CredentialStorageProps {
 }
 
 export interface CredentialRecordTags extends Tags {
-  threadId?: string
+  threadId: string
+  connectionId: string
 }
 
 export class CredentialRecord extends BaseRecord implements CredentialStorageProps {
@@ -71,7 +72,7 @@ export class CredentialRecord extends BaseRecord implements CredentialStoragePro
       this.connectionId = props.connectionId
       this.metadata = props.metadata ?? {}
       this.credentialId = props.credentialId
-      this.tags = (props.tags as { [keys: string]: string }) ?? {}
+      this.tags = props.tags
 
       this.proposalMessage = props.proposalMessage
       this.offerMessage = props.offerMessage

--- a/src/modules/credentials/services/CredentialService.ts
+++ b/src/modules/credentials/services/CredentialService.ts
@@ -86,7 +86,7 @@ export class CredentialService {
       state: CredentialState.ProposalSent,
       proposalMessage,
       credentialAttributes: proposalMessage.credentialProposal?.attributes,
-      tags: { threadId: proposalMessage.threadId },
+      tags: { threadId: proposalMessage.threadId, connectionId: connectionRecord.id },
     })
     await this.credentialRepository.save(credentialRecord)
     this.eventEmitter.emit<CredentialStateChangedEvent>({
@@ -154,11 +154,10 @@ export class CredentialService {
 
     try {
       // Credential record already exists
-      credentialRecord = await this.getByThreadId(proposalMessage.threadId)
+      credentialRecord = await this.getByConnectionAndThreadId(connection.id, proposalMessage.threadId)
 
       // Assert
       credentialRecord.assertState(CredentialState.OfferSent)
-      credentialRecord.assertConnection(connection.id)
 
       // Update record
       credentialRecord.proposalMessage = proposalMessage
@@ -171,7 +170,7 @@ export class CredentialService {
         proposalMessage,
         credentialAttributes: proposalMessage.credentialProposal?.attributes,
         state: CredentialState.ProposalReceived,
-        tags: { threadId: proposalMessage.threadId },
+        tags: { threadId: proposalMessage.threadId, connectionId: connection.id },
       })
 
       // Save record
@@ -274,7 +273,7 @@ export class CredentialService {
         schemaId: credOffer.schema_id,
       },
       state: CredentialState.OfferSent,
-      tags: { threadId: credentialOfferMessage.id },
+      tags: { threadId: credentialOfferMessage.id, connectionId: connectionRecord.id },
     })
 
     await this.credentialRepository.save(credentialRecord)
@@ -321,11 +320,10 @@ export class CredentialService {
 
     try {
       // Credential record already exists
-      credentialRecord = await this.getByThreadId(credentialOfferMessage.threadId)
+      credentialRecord = await this.getByConnectionAndThreadId(connection.id, credentialOfferMessage.threadId)
 
       // Assert
       credentialRecord.assertState(CredentialState.ProposalSent)
-      credentialRecord.assertConnection(connection.id)
 
       credentialRecord.offerMessage = credentialOfferMessage
       credentialRecord.credentialAttributes = credentialOfferMessage.credentialPreview.attributes
@@ -343,7 +341,7 @@ export class CredentialService {
           schemaId: indyCredentialOffer.schema_id,
         },
         state: CredentialState.OfferReceived,
-        tags: { threadId: credentialOfferMessage.id },
+        tags: { threadId: credentialOfferMessage.id, connectionId: connection.id },
       })
 
       // Save in repository
@@ -446,9 +444,8 @@ export class CredentialService {
       )
     }
 
-    const credentialRecord = await this.getByThreadId(credentialRequestMessage.threadId)
+    const credentialRecord = await this.getByConnectionAndThreadId(connection.id, credentialRequestMessage.threadId)
     credentialRecord.assertState(CredentialState.OfferSent)
-    credentialRecord.assertConnection(connection.id)
 
     this.logger.debug('Credential record found when processing credential request', credentialRecord)
 
@@ -562,7 +559,7 @@ export class CredentialService {
     }
 
     // Assert credential record
-    const credentialRecord = await this.getByThreadId(issueCredentialMessage.threadId)
+    const credentialRecord = await this.getByConnectionAndThreadId(connection.id, issueCredentialMessage.threadId)
     credentialRecord.assertState(CredentialState.RequestSent)
 
     if (!credentialRecord.metadata.requestMetadata) {
@@ -646,7 +643,7 @@ export class CredentialService {
     }
 
     // Assert credential record
-    const credentialRecord = await this.getByThreadId(credentialAckMessage.threadId)
+    const credentialRecord = await this.getByConnectionAndThreadId(connection.id, credentialAckMessage.threadId)
     credentialRecord.assertState(CredentialState.CredentialIssued)
 
     // Update record
@@ -687,16 +684,18 @@ export class CredentialService {
   }
 
   /**
-   * Retrieve a credential record by thread id
+   * Retrieve a credential record by connection id and thread id
    *
+   * @param connectionId The connection id
    * @param threadId The thread id
    * @throws {RecordNotFoundError} If no record is found
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The credential record
    */
-  public getByThreadId(threadId: string): Promise<CredentialRecord> {
+  public getByConnectionAndThreadId(connectionId: string, threadId: string): Promise<CredentialRecord> {
     return this.credentialRepository.getSingleByQuery({
       threadId,
+      connectionId,
     })
   }
 

--- a/src/modules/proofs/ProofsModule.ts
+++ b/src/modules/proofs/ProofsModule.ts
@@ -243,15 +243,16 @@ export class ProofsModule {
   }
 
   /**
-   * Retrieve a proof record by thread id
+   * Retrieve a proof record by connection id and thread id
    *
+   * @param connectionId The connection id
    * @param threadId The thread id
    * @throws {RecordNotFoundError} If no record is found
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The proof record
    */
-  public async getByThreadId(threadId: string): Promise<ProofRecord> {
-    return this.proofService.getByThreadId(threadId)
+  public async getByConnectionAndThreadId(connectionId: string, threadId: string): Promise<ProofRecord> {
+    return this.proofService.getByConnectionAndThreadId(connectionId, threadId)
   }
 
   private registerHandlers(dispatcher: Dispatcher) {

--- a/src/modules/proofs/repository/ProofRecord.ts
+++ b/src/modules/proofs/repository/ProofRecord.ts
@@ -22,7 +22,8 @@ export interface ProofRecordProps {
   presentationMessage?: PresentationMessage
 }
 export interface ProofRecordTags extends Tags {
-  threadId?: string
+  threadId: string
+  connectionId: string
 }
 
 export class ProofRecord extends BaseRecord implements ProofRecordProps {
@@ -56,7 +57,7 @@ export class ProofRecord extends BaseRecord implements ProofRecordProps {
       this.state = props.state
       this.connectionId = props.connectionId
       this.presentationId = props.presentationId
-      this.tags = props.tags as { [keys: string]: string }
+      this.tags = props.tags
     }
   }
 

--- a/src/modules/proofs/services/ProofService.ts
+++ b/src/modules/proofs/services/ProofService.ts
@@ -109,7 +109,7 @@ export class ProofService {
       connectionId: connectionRecord.id,
       state: ProofState.ProposalSent,
       proposalMessage,
-      tags: { threadId: proposalMessage.threadId },
+      tags: { threadId: proposalMessage.threadId, connectionId: connectionRecord.id },
     })
     await this.proofRepository.save(proofRecord)
     this.eventEmitter.emit<ProofStateChangedEvent>({
@@ -180,11 +180,10 @@ export class ProofService {
 
     try {
       // Proof record already exists
-      proofRecord = await this.getByThreadId(proposalMessage.threadId)
+      proofRecord = await this.getByConnectionAndThreadId(connection.id, proposalMessage.threadId)
 
       // Assert
       proofRecord.assertState(ProofState.RequestSent)
-      proofRecord.assertConnection(connection.id)
 
       // Update record
       proofRecord.proposalMessage = proposalMessage
@@ -195,7 +194,7 @@ export class ProofService {
         connectionId: connection.id,
         proposalMessage,
         state: ProofState.ProposalReceived,
-        tags: { threadId: proposalMessage.threadId },
+        tags: { threadId: proposalMessage.threadId, connectionId: connection.id },
       })
 
       // Save record
@@ -293,7 +292,7 @@ export class ProofService {
       connectionId: connectionRecord.id,
       requestMessage: requestPresentationMessage,
       state: ProofState.RequestSent,
-      tags: { threadId: requestPresentationMessage.threadId },
+      tags: { threadId: requestPresentationMessage.threadId, connectionId: connectionRecord.id },
     })
 
     await this.proofRepository.save(proofRecord)
@@ -341,11 +340,10 @@ export class ProofService {
 
     try {
       // Proof record already exists
-      proofRecord = await this.getByThreadId(proofRequestMessage.threadId)
+      proofRecord = await this.getByConnectionAndThreadId(connection.id, proofRequestMessage.threadId)
 
       // Assert
       proofRecord.assertState(ProofState.ProposalSent)
-      proofRecord.assertConnection(connection.id)
 
       // Update record
       proofRecord.requestMessage = proofRequestMessage
@@ -356,7 +354,7 @@ export class ProofService {
         connectionId: connection.id,
         requestMessage: proofRequestMessage,
         state: ProofState.RequestReceived,
-        tags: { threadId: proofRequestMessage.threadId },
+        tags: { threadId: proofRequestMessage.threadId, connectionId: connection.id },
       })
 
       // Save in repository
@@ -442,7 +440,7 @@ export class ProofService {
     }
 
     // Assert proof record
-    const proofRecord = await this.getByThreadId(presentationMessage.threadId)
+    const proofRecord = await this.getByConnectionAndThreadId(connection.id, presentationMessage.threadId)
     proofRecord.assertState(ProofState.RequestSent)
 
     // TODO: add proof class with validator
@@ -513,7 +511,7 @@ export class ProofService {
     }
 
     // Assert proof record
-    const proofRecord = await this.getByThreadId(presentationAckMessage.threadId)
+    const proofRecord = await this.getByConnectionAndThreadId(connection.id, presentationAckMessage.threadId)
     proofRecord.assertState(ProofState.PresentationSent)
 
     // Update record
@@ -793,15 +791,16 @@ export class ProofService {
   }
 
   /**
-   * Retrieve a proof record by thread id
+   * Retrieve a proof record by connection id and thread id
    *
+   * @param connectionId The connection id
    * @param threadId The thread id
    * @throws {RecordNotFoundError} If no record is found
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The proof record
    */
-  public async getByThreadId(threadId: string): Promise<ProofRecord> {
-    return this.proofRepository.getSingleByQuery({ threadId })
+  public async getByConnectionAndThreadId(connectionId: string, threadId: string): Promise<ProofRecord> {
+    return this.proofRepository.getSingleByQuery({ threadId, connectionId })
   }
 
   /**


### PR DESCRIPTION
Using only the thread id gives errors when issuing or proving to yourself as there are multiple records for a single thread id. This retrieves records by both thread id an connection id. this also removes the requirement to check if the record has the correct connection id.