### PR TITLE
chore: add repository url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "files": [
     "build/src"
   ],
+  "repository": {
+    "url": "https://github.com/hyperledger/aries-framework-javascript",
+    "type": "git"
+  },
   "scripts": {
     "compile": "tsc",
     "lint": "eslint --ignore-path .gitignore .",


### PR DESCRIPTION
This will add a url on the npm site and allow to use relative links in the readme. (they are now broken on npm)