### PR TITLE
ci: cancel old job, require commits for release 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -19,7 +19,9 @@ env:
 # Make sure we're not running multiple release steps at the same time as this can give issues with determining the next npm version to release.
 # Ideally we only add this to the 'release' job so it doesn't limit PR runs, but github can't guarantee the job order in that case:
 # "When concurrency is specified at the job level, order is not guaranteed for jobs or runs that queue within 5 minutes of each other."
-concurrency: aries-framework-${{ github.ref }}-${{ github.repository }}-${{ github.event_name }}
+concurrency:
+  group: aries-framework-${{ github.ref }}-${{ github.repository }}-${{ github.event_name }}
+  cancel-in-progress: true
 
 jobs:
   validate:

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "git": {
       "requireBranch": "main",
       "push": false,
-      "commit": false
+      "commit": false,
+      "requireCommits": true
     }
   },
   "engines": {

--- a/src/modules/connections/ConnectionsModule.ts
+++ b/src/modules/connections/ConnectionsModule.ts
@@ -7,7 +7,7 @@ import { AgentConfig } from '../../agent/AgentConfig'
 import { Dispatcher } from '../../agent/Dispatcher'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
-import { ConsumerRoutingService } from '../routing'
+import { ConsumerRoutingService } from '../routing/services/ConsumerRoutingService'
 
 import {
   ConnectionRequestHandler,


### PR DESCRIPTION
This fixes a require cycle that got into main.

It also adds some extra guards to hopefully prevent race conditions with parallel merges. I discovered what the problem is, just now sure how to fix it yet: https://github.com/release-it/release-it/issues/773