### PR TITLE
fix: handle receive message promise rejection

### DIFF
--- a/src/modules/connections/ConnectionsModule.ts
+++ b/src/modules/connections/ConnectionsModule.ts
@@ -7,7 +7,7 @@ import { AgentConfig } from '../../agent/AgentConfig'
 import { Dispatcher } from '../../agent/Dispatcher'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
-import { ConsumerRoutingService } from '../routing'
+import { ConsumerRoutingService } from '../routing/services/ConsumerRoutingService'
 
 import {
   ConnectionRequestHandler,

--- a/tests/mediator.ts
+++ b/tests/mediator.ts
@@ -22,13 +22,18 @@ class HttpInboundTransporter implements InboundTransporter {
 
   public async start(agent: Agent) {
     this.app.post('/msg', async (req, res) => {
-      const message = req.body
-      const packedMessage = JSON.parse(message)
-      const outboundMessage = await agent.receiveMessage(packedMessage)
-      if (outboundMessage) {
-        res.status(200).json(outboundMessage.payload).end()
-      } else {
-        res.status(200).end()
+      try {
+        const message = req.body
+        const packedMessage = JSON.parse(message)
+
+        const outboundMessage = await agent.receiveMessage(packedMessage)
+        if (outboundMessage) {
+          res.status(200).json(outboundMessage.payload).end()
+        } else {
+          res.status(200).end()
+        }
+      } catch {
+        res.status(500).send('Error processing message')
       }
     })
   }


### PR DESCRIPTION
Node v16 exists if it encounters an unhandled promise rejection.

We should send a 500 response when receiving a message gives an error