### PR TITLE
docs: fix faulty url of readme npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
       alt="License"
       src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"
   /></a>
-  <a href="https://npmjs.com/package/aries-framework-javascript"
+  <a href="https://npmjs.com/package/aries-framework"
     ><img
       alt="aries-framework-javascript npm version"
       src="https://img.shields.io/npm/v/aries-framework"


### PR DESCRIPTION
Changed https://www.npmjs.com/package/aries-framework-javascript
to https://www.npmjs.com/package/aries-framework

Signed-off-by: Karim Stekelenburg <karim@animo.id>