### PR TITLE
docs: updated macos install script

### DIFF
--- a/docs/libindy/macos.md
+++ b/docs/libindy/macos.md
@@ -12,6 +12,17 @@ ls /usr/local/lib/libindy.dylib
 
 ## MacOS
 
+It is now possible to install libindy and all its dependencies with homebrew!
+
+<p align="center">⚠️ This does not currenlty work on the Macbooks with Apple silicon ⚠️</p>
+
+```bash
+brew tap blu3beri/homebrew-libindy
+brew install libindy
+```
+
+If this does not work, you could also use the old steps to install libindy.
+
 1. Download libindy for macOS from the [Sovrin binary repo](https://repo.sovrin.org/macos/libindy/stable/1.16.0/)
 2. Extract the ZIP and execute the following commands in the unzipped directory:
 


### PR DESCRIPTION
Libindy should now be installable for macOS users by using brew. This should make the setup easier for beginners :).

Signed-off-by: Berend Sliedrecht <berend@animo.id>