### PR TITLE
feat: allow for lazy wallet initialization

### DIFF
--- a/src/__tests__/agents.test.ts
+++ b/src/__tests__/agents.test.ts
@@ -4,7 +4,13 @@ import { Subject } from 'rxjs'
 
 import { Agent } from '../agent/Agent'
 
-import { SubjectInboundTransporter, SubjectOutboundTransporter, waitForBasicMessage, getBaseConfig } from './helpers'
+import {
+  SubjectInboundTransporter,
+  SubjectOutboundTransporter,
+  waitForBasicMessage,
+  getBaseConfig,
+  closeAndDeleteWallet,
+} from './helpers'
 
 const aliceConfig = getBaseConfig('Agents Alice')
 const bobConfig = getBaseConfig('Agents Bob')
@@ -16,8 +22,8 @@ describe('agents', () => {
   let bobConnection: ConnectionRecord
 
   afterAll(async () => {
-    await aliceAgent.closeAndDeleteWallet()
-    await bobAgent.closeAndDeleteWallet()
+    await closeAndDeleteWallet(aliceAgent)
+    await closeAndDeleteWallet(bobAgent)
   })
 
   test('make a connection between agents', async () => {
@@ -27,12 +33,12 @@ describe('agents', () => {
     aliceAgent = new Agent(aliceConfig)
     aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages, bobMessages))
     aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(bobMessages))
-    await aliceAgent.init()
+    await aliceAgent.initialize()
 
     bobAgent = new Agent(bobConfig)
     bobAgent.setInboundTransporter(new SubjectInboundTransporter(bobMessages, aliceMessages))
     bobAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages))
-    await bobAgent.init()
+    await bobAgent.initialize()
 
     const aliceConnectionAtAliceBob = await aliceAgent.connections.createConnection()
     const bobConnectionAtBobAlice = await bobAgent.connections.receiveInvitation(aliceConnectionAtAliceBob.invitation)

--- a/src/__tests__/credentials.test.ts
+++ b/src/__tests__/credentials.test.ts
@@ -21,6 +21,7 @@ import {
   waitForCredentialRecord,
   genesisPath,
   getBaseConfig,
+  closeAndDeleteWallet,
 } from './helpers'
 import testLogger from './logger'
 
@@ -64,12 +65,12 @@ describe('credentials', () => {
     faberAgent = new Agent(faberConfig)
     faberAgent.setInboundTransporter(new SubjectInboundTransporter(faberMessages, aliceMessages))
     faberAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages))
-    await faberAgent.init()
+    await faberAgent.initialize()
 
     aliceAgent = new Agent(aliceConfig)
     aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages, faberMessages))
     aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages))
-    await aliceAgent.init()
+    await aliceAgent.initialize()
 
     const schemaTemplate = {
       name: `test-schema-${Date.now()}`,
@@ -97,8 +98,8 @@ describe('credentials', () => {
   })
 
   afterAll(async () => {
-    await faberAgent.closeAndDeleteWallet()
-    await aliceAgent.closeAndDeleteWallet()
+    await closeAndDeleteWallet(aliceAgent)
+    await closeAndDeleteWallet(faberAgent)
   })
 
   test('Alice starts with credential proposal to Faber', async () => {

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -6,12 +6,14 @@ import type { SchemaTemplate, CredentialDefinitionTemplate } from '../modules/le
 import type { ProofRecord, ProofState, ProofStateChangedEvent } from '../modules/proofs'
 import type { InboundTransporter, OutboundTransporter } from '../transport'
 import type { InitConfig, OutboundPackage, WireMessage } from '../types'
+import type { Wallet } from '../wallet/Wallet'
 import type { Schema, CredDef, Did } from 'indy-sdk'
 import type { Subject } from 'rxjs'
 
 import indy from 'indy-sdk'
 import path from 'path'
 
+import { InjectionSymbols } from '../constants'
 import { BasicMessageEventTypes } from '../modules/basic-messages'
 import {
   ConnectionInvitationMessage,
@@ -49,6 +51,12 @@ export function getBaseConfig(name: string, extraConfig: Partial<InitConfig> = {
   }
 
   return config
+}
+
+export async function closeAndDeleteWallet(agent: Agent) {
+  const wallet = agent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
+
+  await wallet.deleteWallet()
 }
 
 export async function waitForProofRecord(

--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -56,7 +56,7 @@ export function getBaseConfig(name: string, extraConfig: Partial<InitConfig> = {
 export async function closeAndDeleteWallet(agent: Agent) {
   const wallet = agent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
 
-  await wallet.deleteWallet()
+  await wallet.delete()
 }
 
 export async function waitForProofRecord(

--- a/src/__tests__/ledger.test.ts
+++ b/src/__tests__/ledger.test.ts
@@ -7,7 +7,7 @@ import { Agent } from '../agent/Agent'
 import { DID_IDENTIFIER_REGEX, VERKEY_REGEX, isFullVerkey, isAbbreviatedVerkey } from '../utils/did'
 import { sleep } from '../utils/sleep'
 
-import { genesisPath, getBaseConfig } from './helpers'
+import { closeAndDeleteWallet, genesisPath, getBaseConfig } from './helpers'
 import testLogger from './logger'
 
 const faberConfig = getBaseConfig('Faber Ledger', { genesisPath })
@@ -18,11 +18,11 @@ describe('ledger', () => {
 
   beforeAll(async () => {
     faberAgent = new Agent(faberConfig)
-    await faberAgent.init()
+    await faberAgent.initialize()
   })
 
   afterAll(async () => {
-    await faberAgent.closeAndDeleteWallet()
+    await closeAndDeleteWallet(faberAgent)
   })
 
   test(`initialization of agent's public DID`, async () => {

--- a/src/__tests__/proofs.test.ts
+++ b/src/__tests__/proofs.test.ts
@@ -27,6 +27,7 @@ import {
   issueCredential,
   waitForProofRecord,
   getBaseConfig,
+  closeAndDeleteWallet,
 } from './helpers'
 import testLogger from './logger'
 
@@ -63,12 +64,12 @@ describe('Present Proof', () => {
     faberAgent = new Agent(faberConfig)
     faberAgent.setInboundTransporter(new SubjectInboundTransporter(faberMessages, aliceMessages))
     faberAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages))
-    await faberAgent.init()
+    await faberAgent.initialize()
 
     aliceAgent = new Agent(aliceConfig)
     aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages, faberMessages))
     aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages))
-    await aliceAgent.init()
+    await aliceAgent.initialize()
 
     const schemaTemplate = {
       name: `test-schema-${Date.now()}`,
@@ -125,8 +126,8 @@ describe('Present Proof', () => {
   })
 
   afterAll(async () => {
-    await faberAgent.closeAndDeleteWallet()
-    await aliceAgent.closeAndDeleteWallet()
+    await closeAndDeleteWallet(aliceAgent)
+    await closeAndDeleteWallet(faberAgent)
   })
 
   test('Alice starts with proof proposal to Faber', async () => {

--- a/src/decorators/signature/SignatureDecoratorUtils.test.ts
+++ b/src/decorators/signature/SignatureDecoratorUtils.test.ts
@@ -47,7 +47,7 @@ describe('Decorators | Signature | SignatureDecoratorUtils', () => {
   })
 
   afterAll(async () => {
-    await wallet.deleteWallet()
+    await wallet.delete()
   })
 
   test('signData signs json object and returns SignatureDecorator', async () => {

--- a/src/decorators/signature/SignatureDecoratorUtils.test.ts
+++ b/src/decorators/signature/SignatureDecoratorUtils.test.ts
@@ -41,13 +41,13 @@ describe('Decorators | Signature | SignatureDecoratorUtils', () => {
   let wallet: IndyWallet
 
   beforeAll(async () => {
-    wallet = new IndyWallet(new AgentConfig(getBaseConfig('SignatureDecoratorUtilsTest')))
-    await wallet.init()
+    const config = new AgentConfig(getBaseConfig('SignatureDecoratorUtilsTest'))
+    wallet = new IndyWallet(config)
+    await wallet.initialize(config.walletConfig!, config.walletCredentials!)
   })
 
   afterAll(async () => {
-    await wallet.close()
-    await wallet.delete()
+    await wallet.deleteWallet()
   })
 
   test('signData signs json object and returns SignatureDecorator', async () => {

--- a/src/modules/basic-messages/__tests__/BasicMessageService.test.ts
+++ b/src/modules/basic-messages/__tests__/BasicMessageService.test.ts
@@ -26,14 +26,14 @@ describe('BasicMessageService', () => {
   let storageService: StorageService<BasicMessageRecord>
 
   beforeAll(async () => {
-    wallet = new IndyWallet(new AgentConfig(getBaseConfig('BasicMessageServiceTest')))
-    await wallet.init()
+    const config = new AgentConfig(getBaseConfig('BasicMessageServiceTest'))
+    wallet = new IndyWallet(config)
+    await wallet.initialize(config.walletConfig!, config.walletCredentials!)
     storageService = new IndyStorageService(wallet)
   })
 
   afterAll(async () => {
-    await wallet.close()
-    await wallet.delete()
+    await wallet.deleteWallet()
   })
 
   describe('save', () => {

--- a/src/modules/basic-messages/__tests__/BasicMessageService.test.ts
+++ b/src/modules/basic-messages/__tests__/BasicMessageService.test.ts
@@ -33,7 +33,7 @@ describe('BasicMessageService', () => {
   })
 
   afterAll(async () => {
-    await wallet.deleteWallet()
+    await wallet.delete()
   })
 
   describe('save', () => {

--- a/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -39,12 +39,11 @@ describe('ConnectionService', () => {
   beforeAll(async () => {
     agentConfig = new AgentConfig(initConfig)
     wallet = new IndyWallet(agentConfig)
-    await wallet.init()
+    await wallet.initialize(agentConfig.walletConfig!, agentConfig.walletCredentials!)
   })
 
   afterAll(async () => {
-    await wallet.close()
-    await wallet.delete()
+    await wallet.deleteWallet()
   })
 
   beforeEach(() => {

--- a/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -43,7 +43,7 @@ describe('ConnectionService', () => {
   })
 
   afterAll(async () => {
-    await wallet.deleteWallet()
+    await wallet.delete()
   })
 
   beforeEach(() => {

--- a/src/modules/credentials/__tests__/StubWallet.ts
+++ b/src/modules/credentials/__tests__/StubWallet.ts
@@ -2,23 +2,35 @@
 
 import type { UnpackedMessageContext } from '../../../types'
 import type { Wallet } from '../../../wallet/Wallet'
-import type { DidConfig, WalletRecordOptions, WalletRecord, WalletQuery, LedgerRequest } from 'indy-sdk'
+import type {
+  DidConfig,
+  WalletRecordOptions,
+  WalletRecord,
+  WalletQuery,
+  LedgerRequest,
+  WalletConfig,
+  WalletCredentials,
+} from 'indy-sdk'
 
 export class StubWallet implements Wallet {
+  public get isInitialized() {
+    return true
+  }
+
   public get walletHandle() {
     return 0
   }
   public get publicDid() {
     return undefined
   }
-  public init(): Promise<void> {
+  public initialize(walletConfig: WalletConfig, walletCredentials: WalletCredentials): Promise<void> {
     return Promise.resolve()
   }
-  public close(): Promise<void> {
+  public closeWallet(): Promise<void> {
     throw new Error('Method not implemented.')
   }
 
-  public delete(): Promise<void> {
+  public deleteWallet(): Promise<void> {
     throw new Error('Method not implemented.')
   }
   public initPublicDid(didConfig: DidConfig): Promise<void> {

--- a/src/modules/credentials/__tests__/StubWallet.ts
+++ b/src/modules/credentials/__tests__/StubWallet.ts
@@ -26,11 +26,11 @@ export class StubWallet implements Wallet {
   public initialize(walletConfig: WalletConfig, walletCredentials: WalletCredentials): Promise<void> {
     return Promise.resolve()
   }
-  public closeWallet(): Promise<void> {
+  public close(): Promise<void> {
     throw new Error('Method not implemented.')
   }
 
-  public deleteWallet(): Promise<void> {
+  public delete(): Promise<void> {
     throw new Error('Method not implemented.')
   }
   public initPublicDid(didConfig: DidConfig): Promise<void> {

--- a/src/storage/__tests__/IndyStorageService.test.ts
+++ b/src/storage/__tests__/IndyStorageService.test.ts
@@ -20,7 +20,7 @@ describe('IndyStorageService', () => {
   })
 
   afterEach(async () => {
-    await wallet.deleteWallet()
+    await wallet.delete()
   })
 
   const insertRecord = async ({ id, tags }: { id?: string; tags?: TagsBase }) => {

--- a/src/storage/__tests__/IndyStorageService.test.ts
+++ b/src/storage/__tests__/IndyStorageService.test.ts
@@ -13,14 +13,14 @@ describe('IndyStorageService', () => {
   let storageService: IndyStorageService<TestRecord>
 
   beforeEach(async () => {
-    wallet = new IndyWallet(new AgentConfig(getBaseConfig('IndyStorageServiceTest')))
-    await wallet.init()
+    const config = new AgentConfig(getBaseConfig('IndyStorageServiceTest'))
+    wallet = new IndyWallet(config)
+    await wallet.initialize(config.walletConfig!, config.walletCredentials!)
     storageService = new IndyStorageService<TestRecord>(wallet)
   })
 
   afterEach(async () => {
-    await wallet.close()
-    await wallet.delete()
+    await wallet.deleteWallet()
   })
 
   const insertRecord = async ({ id, tags }: { id?: string; tags?: TagsBase }) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,8 @@ export interface InitConfig {
   label: string
   publicDidSeed?: string
   mediatorUrl?: string
-  walletConfig: WalletConfig
-  walletCredentials: WalletCredentials
+  walletConfig?: WalletConfig
+  walletCredentials?: WalletCredentials
   autoAcceptConnections?: boolean
   poolName?: string
   logger?: Logger

--- a/src/wallet/IndyWallet.ts
+++ b/src/wallet/IndyWallet.ts
@@ -22,21 +22,30 @@ import { AriesFrameworkError } from '../error'
 import { JsonEncoder } from '../utils/JsonEncoder'
 import { isIndyError } from '../utils/indyError'
 
+import { WalletDuplicateError, WalletNotFoundError, WalletError } from './error'
+
+export interface IndyOpenWallet {
+  walletHandle: number
+  masterSecretId: string
+  walletConfig: WalletConfig
+  walletCredentials: WalletCredentials
+}
+
 @scoped(Lifecycle.ContainerScoped)
 export class IndyWallet implements Wallet {
-  private _walletHandle?: number
-  private _masterSecretId?: string
-  private walletConfig: WalletConfig
-  private walletCredentials: WalletCredentials
+  private openWalletInfo?: IndyOpenWallet
+
   private logger: Logger
   private publicDidInfo: DidInfo | undefined
   private indy: typeof Indy
 
   public constructor(agentConfig: AgentConfig) {
-    this.walletConfig = agentConfig.walletConfig
-    this.walletCredentials = agentConfig.walletCredentials
     this.logger = agentConfig.logger
     this.indy = agentConfig.indy
+  }
+
+  public get isInitialized() {
+    return this.openWalletInfo !== undefined
   }
 
   public get publicDid() {
@@ -44,64 +53,236 @@ export class IndyWallet implements Wallet {
   }
 
   public get walletHandle() {
-    if (!this._walletHandle) {
+    if (!this.openWalletInfo) {
       throw new AriesFrameworkError('Wallet has not been initialized yet')
     }
 
-    return this._walletHandle
+    return this.openWalletInfo.walletHandle
   }
 
   public get masterSecretId() {
-    // In theory this is not possible if the wallet handle is available
-    if (!this._masterSecretId) {
-      throw new AriesFrameworkError('Master secret has not been initialized yet')
+    if (!this.openWalletInfo) {
+      throw new AriesFrameworkError('Wallet has not been initialized yet')
     }
 
-    return this._masterSecretId
+    return this.openWalletInfo.masterSecretId
   }
 
-  public async init() {
-    this.logger.info(`Initializing wallet '${this.walletConfig.id}'`, this.walletConfig)
+  public async initialize(walletConfig: WalletConfig, walletCredentials: WalletCredentials) {
+    this.logger.info(`Initializing wallet '${walletConfig.id}'`, walletConfig)
+
+    if (this.isInitialized) {
+      throw new WalletError(
+        'Wallet instance already initialized. Close the currently opened wallet before re-initializing the wallet'
+      )
+    }
+
+    // Allow wallet already exists
     try {
-      await this.indy.createWallet(this.walletConfig, this.walletCredentials)
+      await this.createWallet(walletConfig, walletCredentials)
     } catch (error) {
-      if (isIndyError(error, 'WalletAlreadyExistsError')) {
-        this.logger.debug(`Wallet '${this.walletConfig.id} already exists'`, {
-          indyError: 'WalletAlreadyExistsError',
-        })
-      } else {
-        this.logger.error(`Error opening wallet ${this.walletConfig.id}`, {
-          indyError: error.indyName,
-          error,
-        })
+      if (!(error instanceof WalletDuplicateError)) {
         throw error
       }
     }
 
-    this._walletHandle = await this.indy.openWallet(this.walletConfig, this.walletCredentials)
+    this.openWalletInfo = await this.openWallet(walletConfig, walletCredentials)
+
+    this.logger.debug(`Wallet '${walletConfig.id}' initialized with handle '${this.walletHandle}'`)
+  }
+
+  /**
+   * Creates indy wallet using config and credentials
+   *
+   * @param walletConfig the wallet config
+   * @param walletCredentials the wallet credentials
+   * @throws {WalletDuplicateError} if the wallet already exists
+   * @throws {WalletError} if another error occurs
+   */
+  private async createWallet(walletConfig: WalletConfig, walletCredentials: WalletCredentials): Promise<void> {
+    const storageType = walletConfig.storage_type ?? 'SQLite'
+    this.logger.debug(`Creating wallet '${walletConfig.id}' using ${storageType} storage`, {
+      storageConfig: walletConfig.storage_config,
+    })
 
     try {
-      this.logger.debug(`Creating master secret`)
-      this._masterSecretId = await this.indy.proverCreateMasterSecret(this.walletHandle, this.walletConfig.id)
+      await this.indy.createWallet(walletConfig, walletCredentials)
+    } catch (error) {
+      if (isIndyError(error, 'WalletAlreadyExistsError')) {
+        const errorMessage = `Wallet '${walletConfig.id}' already exists`
+        this.logger.debug(errorMessage)
+
+        throw new WalletDuplicateError(errorMessage, {
+          walletType: 'IndyWallet',
+          cause: error,
+        })
+      } else {
+        const errorMessage = `Error creating wallet '${walletConfig.id}'`
+        this.logger.error(errorMessage, {
+          error,
+          errorMessage: error.message,
+        })
+
+        throw new WalletError(errorMessage, { cause: error })
+      }
+    }
+  }
+
+  /**
+   * Open wallet using config and credentials and return wallet handle
+   *
+   * @param walletConfig the wallet config
+   * @param walletCredentials the wallet credentials
+   * @returns the wallet handle of the opened wallet
+   * @throws {WalletNotFoundError} if the wallet does not exist
+   * @throws {WalletError} if another error occurs
+   */
+  private async openWallet(walletConfig: WalletConfig, walletCredentials: WalletCredentials): Promise<IndyOpenWallet> {
+    try {
+      const walletHandle = await this.indy.openWallet(walletConfig, walletCredentials)
+      const masterSecretId = await this.createMasterSecret(walletHandle, walletConfig.id)
+
+      return {
+        walletConfig,
+        walletCredentials,
+        walletHandle,
+        masterSecretId,
+      }
+    } catch (error) {
+      if (isIndyError(error, 'WalletNotFoundError')) {
+        const errorMessage = `Wallet '${walletConfig.id}' not found`
+        this.logger.debug(errorMessage)
+
+        throw new WalletNotFoundError(errorMessage, {
+          walletType: 'IndyWallet',
+          cause: error,
+        })
+      } else {
+        const errorMessage = `Error opening wallet '${walletConfig.id}'`
+        this.logger.error(errorMessage, {
+          error,
+          errorMessage: error.message,
+        })
+
+        throw new WalletError(errorMessage, { cause: error })
+      }
+    }
+  }
+
+  /**
+   * Delete wallet with config and credentials
+   *
+   * @param walletConfig the wallet config
+   * @param walletCredentials the wallet credentials
+   * @throws {WalletNotFoundError} if the wallet does not exist
+   * @throws {WalletError} if another error occurs
+   */
+  public async deleteWallet(): Promise<void> {
+    const walletInfo = this.openWalletInfo
+
+    if (!walletInfo) {
+      throw new WalletError(
+        'Can not delete wallet that is not initialized. Make sure to call initialize before deleting the wallet'
+      )
+    }
+
+    this.logger.info(`Deleting wallet '${walletInfo.walletConfig.id}'`)
+
+    await this.closeWallet()
+
+    try {
+      await this.indy.deleteWallet(walletInfo.walletConfig, walletInfo.walletCredentials)
+    } catch (error) {
+      if (isIndyError(error, 'WalletNotFoundError')) {
+        const errorMessage = `Error deleting wallet: wallet '${walletInfo.walletConfig.id}' not found`
+        this.logger.debug(errorMessage)
+
+        throw new WalletNotFoundError(errorMessage, {
+          walletType: 'IndyWallet',
+          cause: error,
+        })
+      } else {
+        const errorMessage = `Error deleting wallet '${walletInfo.walletConfig.id}': ${error.message}`
+        this.logger.error(errorMessage, {
+          error,
+          errorMessage: error.message,
+        })
+
+        throw new WalletError(errorMessage, { cause: error })
+      }
+    }
+  }
+
+  /**
+   * Close currently opened wallet
+   *
+   * @throws {WalletError} if the wallet is already closed or another error occurs
+   */
+  public async closeWallet(): Promise<void> {
+    try {
+      await this.indy.closeWallet(this.walletHandle)
+      this.openWalletInfo = undefined
+      this.publicDidInfo = undefined
+    } catch (error) {
+      if (isIndyError(error, 'WalletInvalidHandle')) {
+        const errorMessage = `Error closing wallet: wallet already closed not found`
+        this.logger.debug(errorMessage)
+
+        throw new WalletError(errorMessage, {
+          cause: error,
+        })
+      } else {
+        const errorMessage = `Error closing wallet': ${error.message}`
+        this.logger.error(errorMessage, {
+          error,
+          errorMessage: error.message,
+        })
+
+        throw new WalletError(errorMessage, { cause: error })
+      }
+    }
+  }
+
+  /**
+   * Create master secret with specified id in currently opened wallet.
+   *
+   * If a master secret by this id already exists in the current wallet, the method
+   * will return without doing anything.
+   *
+   * @param masterSecretId the master secret id
+   * @throws {WalletError} if an error occurs
+   */
+  private async createMasterSecret(walletHandle: number, masterSecretId: string): Promise<string> {
+    this.logger.debug(`Creating master secret with id '${masterSecretId}' in wallet with handle '${walletHandle}'`)
+
+    try {
+      await this.indy.proverCreateMasterSecret(walletHandle, masterSecretId)
+
+      return masterSecretId
     } catch (error) {
       if (isIndyError(error, 'AnoncredsMasterSecretDuplicateNameError')) {
         // master secret id is the same as the master secret id passed in the create function
         // so if it already exists we can just assign it.
-        this._masterSecretId = this.walletConfig.id
-        this.logger.debug(`Master secret with id '${this.masterSecretId}' already exists`, {
-          indyError: 'AnoncredsMasterSecretDuplicateNameError',
-        })
+        this.logger.debug(
+          `Master secret with id '${masterSecretId}' already exists in wallet with handle '${walletHandle}'`,
+          {
+            indyError: 'AnoncredsMasterSecretDuplicateNameError',
+          }
+        )
+
+        return masterSecretId
       } else {
-        this.logger.error(`Error creating master secret with id ${this.walletConfig.id}`, {
+        this.logger.error(`Error creating master secret with id ${masterSecretId}`, {
           indyError: error.indyName,
           error,
         })
 
-        throw error
+        throw new WalletError(
+          `Error creating master secret with id ${masterSecretId} in wallet with handle '${walletHandle}'`,
+          { cause: error }
+        )
       }
     }
-
-    this.logger.debug(`Wallet opened with handle: '${this.walletHandle}'`)
   }
 
   public async initPublicDid(didConfig: DidConfig) {
@@ -142,14 +323,6 @@ export class IndyWallet implements Wallet {
     const isValid = await this.indy.cryptoVerify(signerVerkey, data, signature)
 
     return isValid
-  }
-
-  public async close() {
-    return this.indy.closeWallet(this.walletHandle)
-  }
-
-  public async delete() {
-    return this.indy.deleteWallet(this.walletConfig, this.walletCredentials)
   }
 
   public async addWalletRecord(type: string, id: string, value: string, tags: Record<string, string>) {

--- a/src/wallet/Wallet.test.ts
+++ b/src/wallet/Wallet.test.ts
@@ -19,6 +19,6 @@ describe('Wallet', () => {
   })
 
   afterEach(async () => {
-    await wallet.deleteWallet()
+    await wallet.delete()
   })
 })

--- a/src/wallet/Wallet.test.ts
+++ b/src/wallet/Wallet.test.ts
@@ -4,10 +4,11 @@ import { AgentConfig } from '../agent/AgentConfig'
 import { IndyWallet } from './IndyWallet'
 
 describe('Wallet', () => {
-  const wallet = new IndyWallet(new AgentConfig(getBaseConfig('WalletTest')))
+  const config = new AgentConfig(getBaseConfig('WalletTest'))
+  const wallet = new IndyWallet(config)
 
   test('initialize public did', async () => {
-    await wallet.init()
+    await wallet.initialize(config.walletConfig!, config.walletCredentials!)
 
     await wallet.initPublicDid({ seed: '00000000000000000000000Forward01' })
 
@@ -18,7 +19,6 @@ describe('Wallet', () => {
   })
 
   afterEach(async () => {
-    await wallet.close()
-    await wallet.delete()
+    await wallet.deleteWallet()
   })
 })

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -8,14 +8,18 @@ import type {
   WalletQuery,
   WalletSearchOptions,
   LedgerRequest,
+  WalletConfig,
+  WalletCredentials,
 } from 'indy-sdk'
 
 export interface Wallet {
   publicDid: DidInfo | undefined
+  isInitialized: boolean
 
-  init(): Promise<void>
-  close(): Promise<void>
-  delete(): Promise<void>
+  initialize(walletConfig: WalletConfig, walletCredentials: WalletCredentials): Promise<void>
+  closeWallet(): Promise<void>
+  deleteWallet(): Promise<void>
+
   initPublicDid(didConfig: DidConfig): Promise<void>
   createDid(didConfig?: DidConfig): Promise<[Did, Verkey]>
   pack(payload: Record<string, unknown>, recipientKeys: Verkey[], senderVk: Verkey | null): Promise<JsonWebKey>

--- a/src/wallet/Wallet.ts
+++ b/src/wallet/Wallet.ts
@@ -17,8 +17,8 @@ export interface Wallet {
   isInitialized: boolean
 
   initialize(walletConfig: WalletConfig, walletCredentials: WalletCredentials): Promise<void>
-  closeWallet(): Promise<void>
-  deleteWallet(): Promise<void>
+  close(): Promise<void>
+  delete(): Promise<void>
 
   initPublicDid(didConfig: DidConfig): Promise<void>
   createDid(didConfig?: DidConfig): Promise<[Did, Verkey]>

--- a/src/wallet/error/WalletDuplicateError.ts
+++ b/src/wallet/error/WalletDuplicateError.ts
@@ -1,0 +1,7 @@
+import { AriesFrameworkError } from '../../error/AriesFrameworkError'
+
+export class WalletDuplicateError extends AriesFrameworkError {
+  public constructor(message: string, { walletType, cause }: { walletType: string; cause?: Error }) {
+    super(`${walletType}: ${message}`, { cause })
+  }
+}

--- a/src/wallet/error/WalletError.ts
+++ b/src/wallet/error/WalletError.ts
@@ -1,0 +1,7 @@
+import { AriesFrameworkError } from '../../error/AriesFrameworkError'
+
+export class WalletError extends AriesFrameworkError {
+  public constructor(message: string, { cause }: { cause?: Error } = {}) {
+    super(message, { cause })
+  }
+}

--- a/src/wallet/error/WalletNotFoundError.ts
+++ b/src/wallet/error/WalletNotFoundError.ts
@@ -1,0 +1,7 @@
+import { AriesFrameworkError } from '../../error/AriesFrameworkError'
+
+export class WalletNotFoundError extends AriesFrameworkError {
+  public constructor(message: string, { walletType, cause }: { walletType: string; cause?: Error }) {
+    super(`${walletType}: ${message}`, { cause })
+  }
+}

--- a/src/wallet/error/index.ts
+++ b/src/wallet/error/index.ts
@@ -1,0 +1,3 @@
+export { WalletDuplicateError } from './WalletDuplicateError'
+export { WalletNotFoundError } from './WalletNotFoundError'
+export { WalletError } from './WalletError'

--- a/tests/__tests__/e2e-ws.test.ts
+++ b/tests/__tests__/e2e-ws.test.ts
@@ -1,8 +1,9 @@
 import type { InboundTransporter } from '../../src'
 
 import { Agent, WsOutboundTransporter } from '../../src'
-import { getBaseConfig, waitForBasicMessage } from '../../src/__tests__/helpers'
+import { closeAndDeleteWallet, getBaseConfig, waitForBasicMessage } from '../../src/__tests__/helpers'
 import testLogger from '../../src/__tests__/logger'
+import { sleep } from '../../src/utils/sleep'
 import { get } from '../http'
 
 const logger = testLogger
@@ -20,22 +21,22 @@ describe('websockets with mediator', () => {
     await bobAgent.outboundTransporter?.stop()
 
     // Wait for messages to flush out
-    await new Promise((r) => setTimeout(r, 1000))
+    await sleep(1000)
 
-    await aliceAgent.closeAndDeleteWallet()
-    await bobAgent.closeAndDeleteWallet()
+    await closeAndDeleteWallet(aliceAgent)
+    await closeAndDeleteWallet(bobAgent)
   })
 
   test('Alice and Bob make a connection with mediator', async () => {
     aliceAgent = new Agent(aliceConfig)
     aliceAgent.setInboundTransporter(new WsInboundTransporter())
     aliceAgent.setOutboundTransporter(new WsOutboundTransporter(aliceAgent))
-    await aliceAgent.init()
+    await aliceAgent.initialize()
 
     bobAgent = new Agent(bobConfig)
     bobAgent.setInboundTransporter(new WsInboundTransporter())
     bobAgent.setOutboundTransporter(new WsOutboundTransporter(bobAgent))
-    await bobAgent.init()
+    await bobAgent.initialize()
 
     const aliceInbound = aliceAgent.routing.getInboundConnection()
     const aliceInboundConnection = aliceInbound?.connection

--- a/tests/__tests__/e2e.test.ts
+++ b/tests/__tests__/e2e.test.ts
@@ -1,6 +1,7 @@
 import { Agent, HttpOutboundTransporter, PollingInboundTransporter } from '../../src'
-import { getBaseConfig, waitForBasicMessage } from '../../src/__tests__/helpers'
+import { closeAndDeleteWallet, getBaseConfig, waitForBasicMessage } from '../../src/__tests__/helpers'
 import logger from '../../src/__tests__/logger'
+import { sleep } from '../../src/utils/sleep'
 import { get } from '../http'
 
 const aliceConfig = getBaseConfig('E2E Alice', { mediatorUrl: 'http://localhost:3001' })
@@ -16,22 +17,22 @@ describe('with mediator', () => {
     ;(bobAgent.inboundTransporter as PollingInboundTransporter).stop = true
 
     // Wait for messages to flush out
-    await new Promise((r) => setTimeout(r, 1000))
+    await sleep(1000)
 
-    await aliceAgent.closeAndDeleteWallet()
-    await bobAgent.closeAndDeleteWallet()
+    await closeAndDeleteWallet(aliceAgent)
+    await closeAndDeleteWallet(bobAgent)
   })
 
   test('Alice and Bob make a connection with mediator', async () => {
     aliceAgent = new Agent(aliceConfig)
     aliceAgent.setInboundTransporter(new PollingInboundTransporter())
     aliceAgent.setOutboundTransporter(new HttpOutboundTransporter(aliceAgent))
-    await aliceAgent.init()
+    await aliceAgent.initialize()
 
     bobAgent = new Agent(bobConfig)
     bobAgent.setInboundTransporter(new PollingInboundTransporter())
     bobAgent.setOutboundTransporter(new HttpOutboundTransporter(bobAgent))
-    await bobAgent.init()
+    await bobAgent.initialize()
 
     const aliceInbound = aliceAgent.routing.getInboundConnection()
     const aliceInboundConnection = aliceInbound?.connection

--- a/tests/mediator-ws.ts
+++ b/tests/mediator-ws.ts
@@ -108,7 +108,7 @@ app.get('/api/routes', async (req, res) => {
 })
 
 const server = app.listen(PORT, async () => {
-  await agent.init()
+  await agent.initialize()
   messageReceiver.start(agent)
   logger.info(`WebSockets application started on port ${PORT}`)
 })

--- a/tests/mediator.ts
+++ b/tests/mediator.ts
@@ -123,7 +123,7 @@ app.get('/api/routes', async (req, res) => {
 })
 
 app.listen(PORT, async () => {
-  await agent.init()
+  await agent.initialize()
   messageReceiver.start(agent)
   testLogger.info(`Application started on port ${PORT}`)
 })


### PR DESCRIPTION
- remove agent `closeAndDeleteWallet` as it was only used for tests. They now inject the wallet to close and delete
- make `walletConfig` and `walletCredentials` optional in `InitConfig`
- user can now manually initiale the wallet
- If agent is initialized and wallet is not yet initialized and no `walletConfig` and `walletCredentials` are available an error will be thrown