### PR TITLE
build: docker containers are compatible with m1

### DIFF
--- a/DEVREADME.md
+++ b/DEVREADME.md
@@ -46,7 +46,7 @@ For testing we've added a setup to this repo that allows you to quickly setup an
 
 ```sh
 # Build indy pool
-docker build -f network/indy-pool.dockerfile -t indy-pool .
+docker build -f network/indy-pool.dockerfile -t indy-pool . --platform linux/amd64
 
 # Start indy pool
 docker run -d --rm --name indy-pool -p 9701-9708:9701-9708 indy-pool

--- a/docker/docker-compose-mediators.yml
+++ b/docker/docker-compose-mediators.yml
@@ -6,6 +6,7 @@ services:
     image: aries-framework-javascript
     container_name: alice-mediator
     command: ./scripts/run-mediator.sh alice
+    platform: linux/amd64
     networks:
       - hyperledger
     ports:
@@ -16,6 +17,7 @@ services:
     image: aries-framework-javascript
     container_name: bob-mediator
     command: ./scripts/run-mediator.sh bob
+    platform: linux/amd64
     networks:
       - hyperledger
     ports:
@@ -26,6 +28,7 @@ services:
     image: aries-framework-javascript
     container_name: alice-ws-mediator
     command: ./scripts/run-mediator.sh alice-ws
+    platform: linux/amd64
     networks:
       - hyperledger
     ports:
@@ -36,6 +39,7 @@ services:
     image: aries-framework-javascript
     container_name: bob-ws-mediator
     command: ./scripts/run-mediator.sh bob-ws
+    platform: linux/amd64
     networks:
       - hyperledger
     ports:


### PR DESCRIPTION
Adds support for Apple silicon M1. Just specifies the platforms for which the containers were build and with Rosetta it should be possible to start the test ledger and mediators now.

Signed-off-by: Berend Sliedrecht <berend@animo.id>
