### PR TITLE
fix: add error message to log

### DIFF
--- a/src/transport/HttpOutboundTransporter.ts
+++ b/src/transport/HttpOutboundTransporter.ts
@@ -60,8 +60,9 @@ export class HttpOutboundTransporter implements OutboundTransporter {
         this.agent.receiveMessage(wireMessage)
       }
     } catch (error) {
-      this.logger.error(`Error sending message to ${endpoint}`, {
+      this.logger.error(`Error sending message to ${endpoint}: ${error.message}`, {
         error,
+        message: error.message,
         body: payload,
         didCommMimeType: this.agentConfig.didCommMimeType,
       })


### PR DESCRIPTION
Adds error message to error log.

@jakubkoci this is what you get when you don't include the error message specifically. I think we need to fix this in rn-indy-sdk. I'll try to look at it in the near future. For now this fix helps

![image](https://user-images.githubusercontent.com/23165168/124268369-b3bc1a00-db39-11eb-8c28-d34f69ae6387.png)
