### PR TITLE
feat: Use session to send outbound message

### DIFF
--- a/src/__tests__/helpers.ts
+++ b/src/__tests__/helpers.ts
@@ -135,10 +135,12 @@ export async function waitForBasicMessage(agent: Agent, { content }: { content?:
 }
 
 class SubjectTransportSession implements TransportSession {
+  public id: string
   public readonly type = 'subject'
   private theirSubject: Subject<WireMessage>
 
-  public constructor(theirSubject: Subject<WireMessage>) {
+  public constructor(id: string, theirSubject: Subject<WireMessage>) {
+    this.id = id
     this.theirSubject = theirSubject
   }
 
@@ -164,7 +166,7 @@ export class SubjectInboundTransporter implements InboundTransporter {
   private subscribe(agent: Agent) {
     this.subject.subscribe({
       next: async (message: WireMessage) => {
-        const session = new SubjectTransportSession(this.theirSubject)
+        const session = new SubjectTransportSession('subject-session-1', this.theirSubject)
         await agent.receiveMessage(message, session)
       },
     })

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -184,7 +184,7 @@ export class Agent {
     await this.wallet.delete()
   }
 
-  public closeSession(session: TransportSession) {
+  public removeSession(session: TransportSession) {
     this.transportService.removeSession(session)
   }
 

--- a/src/agent/Agent.ts
+++ b/src/agent/Agent.ts
@@ -30,6 +30,7 @@ import { EventEmitter } from './EventEmitter'
 import { AgentEventTypes } from './Events'
 import { MessageReceiver } from './MessageReceiver'
 import { MessageSender } from './MessageSender'
+import { TransportService } from './TransportService'
 
 export class Agent {
   protected agentConfig: AgentConfig
@@ -38,6 +39,7 @@ export class Agent {
   protected eventEmitter: EventEmitter
   protected wallet: Wallet
   protected messageReceiver: MessageReceiver
+  protected transportService: TransportService
   protected messageSender: MessageSender
   public inboundTransporter?: InboundTransporter
   private _isInitialized = false
@@ -96,6 +98,7 @@ export class Agent {
     this.eventEmitter = this.container.resolve(EventEmitter)
     this.messageSender = this.container.resolve(MessageSender)
     this.messageReceiver = this.container.resolve(MessageReceiver)
+    this.transportService = this.container.resolve(TransportService)
     this.wallet = this.container.resolve(InjectionSymbols.Wallet)
 
     // We set the modules in the constructor because that allows to set them as read-only
@@ -174,6 +177,15 @@ export class Agent {
 
   public async receiveMessage(inboundPackedMessage: unknown, session?: TransportSession) {
     return await this.messageReceiver.receiveMessage(inboundPackedMessage, session)
+  }
+
+  public async closeAndDeleteWallet() {
+    await this.wallet.close()
+    await this.wallet.delete()
+  }
+
+  public closeSession(session: TransportSession) {
+    this.transportService.removeSession(session)
   }
 
   public get injectionContainer() {

--- a/src/agent/MessageReceiver.ts
+++ b/src/agent/MessageReceiver.ts
@@ -74,6 +74,13 @@ export class MessageReceiver {
     }
 
     if (connection && session) {
+      const keys = {
+        // TODO handle the case when senderKey is missing
+        recipientKeys: senderKey ? [senderKey] : [],
+        routingKeys: [],
+        senderKey: connection?.verkey || null,
+      }
+      session.keys = keys
       this.transportService.saveSession(connection.id, session)
     }
 

--- a/src/agent/MessageReceiver.ts
+++ b/src/agent/MessageReceiver.ts
@@ -73,17 +73,6 @@ export class MessageReceiver {
       }
     }
 
-    if (connection && session) {
-      const keys = {
-        // TODO handle the case when senderKey is missing
-        recipientKeys: senderKey ? [senderKey] : [],
-        routingKeys: [],
-        senderKey: connection?.verkey || null,
-      }
-      session.keys = keys
-      this.transportService.saveSession(connection.id, session)
-    }
-
     this.logger.info(`Received message with type '${unpackedMessage.message['@type']}'`, unpackedMessage.message)
 
     const message = await this.transformMessage(unpackedMessage)
@@ -92,6 +81,21 @@ export class MessageReceiver {
       senderVerkey: senderKey,
       recipientVerkey: unpackedMessage.recipient_verkey,
     })
+
+    // We want to save a session if there is a chance of returning outbound message via inbound transport.
+    // That can happen when inbound message has `return_route` set to `all` or `thread`.
+    // If `return_route` defines just `thread`, we decide later whether to use session according to outbound message `threadId`.
+    if (connection && message.hasAnyReturnRoute() && session) {
+      const keys = {
+        // TODO handle the case when senderKey is missing
+        recipientKeys: senderKey ? [senderKey] : [],
+        routingKeys: [],
+        senderKey: connection?.verkey || null,
+      }
+      session.keys = keys
+      session.inboundMessage = message
+      this.transportService.saveSession(connection.id, session)
+    }
 
     return await this.dispatcher.dispatch(messageContext)
   }

--- a/src/agent/MessageReceiver.ts
+++ b/src/agent/MessageReceiver.ts
@@ -94,7 +94,8 @@ export class MessageReceiver {
       }
       session.keys = keys
       session.inboundMessage = message
-      this.transportService.saveSession(connection.id, session)
+      session.connection = connection
+      this.transportService.saveSession(session)
     }
 
     return await this.dispatcher.dispatch(messageContext)

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -1,5 +1,6 @@
 import type { ConnectionRecord } from '../modules/connections/repository'
 import type { OutboundPackage } from '../types'
+import type { EnvelopeKeys } from './EnvelopeService'
 
 import { Lifecycle, scoped, inject } from 'tsyringe'
 
@@ -55,5 +56,6 @@ interface TransportSessionTable {
 
 export interface TransportSession {
   type: string
+  keys?: EnvelopeKeys
   send(outboundMessage: OutboundPackage): Promise<void>
 }

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -1,4 +1,5 @@
 import type { ConnectionRecord } from '../modules/connections/repository'
+import type { OutboundPackage } from '../types'
 
 import { Lifecycle, scoped, inject } from 'tsyringe'
 
@@ -54,4 +55,5 @@ interface TransportSessionTable {
 
 export interface TransportSession {
   type: string
+  send(outboundMessage: OutboundPackage): Promise<void>
 }

--- a/src/agent/TransportService.ts
+++ b/src/agent/TransportService.ts
@@ -1,5 +1,6 @@
 import type { ConnectionRecord } from '../modules/connections/repository'
 import type { OutboundPackage } from '../types'
+import type { AgentMessage } from './AgentMessage'
 import type { EnvelopeKeys } from './EnvelopeService'
 
 import { Lifecycle, scoped, inject } from 'tsyringe'
@@ -57,5 +58,6 @@ interface TransportSessionTable {
 export interface TransportSession {
   type: string
   keys?: EnvelopeKeys
+  inboundMessage?: AgentMessage
   send(outboundMessage: OutboundPackage): Promise<void>
 }

--- a/src/agent/__tests__/MessageSender.test.ts
+++ b/src/agent/__tests__/MessageSender.test.ts
@@ -1,6 +1,6 @@
 import type { ConnectionRecord } from '../../modules/connections'
 import type { OutboundTransporter } from '../../transport'
-import type { OutboundMessage } from '../../types'
+import type { OutboundMessage, OutboundPackage } from '../../types'
 import type { TransportSession } from '../TransportService'
 
 import { getMockConnection, mockFunction } from '../../__tests__/helpers'
@@ -36,6 +36,9 @@ class DummyOutboundTransporter implements OutboundTransporter {
 
 class DummyTransportSession implements TransportSession {
   public readonly type = 'dummy'
+  public send(outboundMessage: OutboundPackage): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
 }
 
 describe('MessageSender', () => {

--- a/src/agent/__tests__/TransportService.test.ts
+++ b/src/agent/__tests__/TransportService.test.ts
@@ -1,9 +1,8 @@
 import { getMockConnection } from '../../__tests__/helpers'
-import testLogger from '../../__tests__/logger'
 import { ConnectionInvitationMessage, ConnectionRole, DidCommService, DidDoc } from '../../modules/connections'
 import { TransportService } from '../TransportService'
 
-const logger = testLogger
+import { DummyTransportSession } from './stubs'
 
 describe('TransportService', () => {
   describe('findServices', () => {
@@ -23,7 +22,7 @@ describe('TransportService', () => {
         service: [testDidCommService],
       })
 
-      transportService = new TransportService(logger)
+      transportService = new TransportService()
     })
 
     test(`returns empty array when there is no their DidDoc and role is ${ConnectionRole.Inviter}`, () => {
@@ -60,6 +59,26 @@ describe('TransportService', () => {
           recipientKeys: ['verkey'],
         }),
       ])
+    })
+  })
+
+  describe('removeSession', () => {
+    let transportService: TransportService
+
+    beforeEach(() => {
+      transportService = new TransportService()
+    })
+
+    test(`remove session saved for a given connection`, () => {
+      const connection = getMockConnection({ id: 'test-123', role: ConnectionRole.Inviter })
+      const session = new DummyTransportSession('dummy-session-123')
+      session.connection = connection
+
+      transportService.saveSession(session)
+      expect(transportService.findSessionByConnectionId(connection.id)).toEqual(session)
+
+      transportService.removeSession(session)
+      expect(transportService.findSessionByConnectionId(connection.id)).toEqual(undefined)
     })
   })
 })

--- a/src/agent/__tests__/stubs.ts
+++ b/src/agent/__tests__/stubs.ts
@@ -1,0 +1,20 @@
+import type { ConnectionRecord } from '../../modules/connections'
+import type { AgentMessage } from '../AgentMessage'
+import type { EnvelopeKeys } from '../EnvelopeService'
+import type { TransportSession } from '../TransportService'
+
+export class DummyTransportSession implements TransportSession {
+  public id: string
+  public readonly type = 'http'
+  public keys?: EnvelopeKeys
+  public inboundMessage?: AgentMessage
+  public connection?: ConnectionRecord
+
+  public constructor(id: string) {
+    this.id = id
+  }
+
+  public send(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/src/decorators/transport/TransportDecoratorExtension.ts
+++ b/src/decorators/transport/TransportDecoratorExtension.ts
@@ -31,6 +31,11 @@ export function TransportDecorated<T extends BaseMessageConstructor>(Base: T) {
       // transport is thread but threadId is either missing or doesn't match. Return false
       return false
     }
+
+    public hasAnyReturnRoute() {
+      const returnRoute = this.transport?.returnRoute
+      return returnRoute && (returnRoute === ReturnRouteTypes.all || returnRoute === ReturnRouteTypes.thread)
+    }
   }
 
   return TransportDecoratorExtension

--- a/src/transport/WsOutboundTransporter.ts
+++ b/src/transport/WsOutboundTransporter.ts
@@ -1,5 +1,4 @@
 import type { Agent } from '../agent/Agent'
-import type { TransportSession } from '../agent/TransportService'
 import type { Logger } from '../logger'
 import type { ConnectionRecord } from '../modules/connections'
 import type { OutboundPackage } from '../types'
@@ -7,23 +6,6 @@ import type { OutboundTransporter } from './OutboundTransporter'
 
 import { InjectionSymbols } from '../constants'
 import { WebSocket } from '../utils/ws'
-
-export class WebSocketTransportSession implements TransportSession {
-  public readonly type = 'websocket'
-  public socket: WebSocket
-
-  public constructor(socket: WebSocket) {
-    this.socket = socket
-  }
-
-  public async send(outboundMessage: OutboundPackage): Promise<void> {
-    // logger.debug(`Sending outbound message via ${this.type} transport session`)
-    if (this.socket.readyState !== WebSocket.OPEN) {
-      throw new Error(`${this.type} transport session has been closed.`)
-    }
-    this.socket.send(JSON.stringify(outboundMessage.payload))
-  }
-}
 
 export class WsOutboundTransporter implements OutboundTransporter {
   private transportTable: Map<string, WebSocket> = new Map<string, WebSocket>()

--- a/src/transport/WsOutboundTransporter.ts
+++ b/src/transport/WsOutboundTransporter.ts
@@ -49,18 +49,10 @@ export class WsOutboundTransporter implements OutboundTransporter {
   }
 
   public async sendMessage(outboundPackage: OutboundPackage) {
-    const { connection, payload, endpoint, session } = outboundPackage
-    this.logger.debug(
-      `Sending outbound message to connection ${connection.id} over ${session?.type} transport.`,
-      payload
-    )
-
-    if (session instanceof WebSocketTransportSession && session.socket?.readyState === WebSocket.OPEN) {
-      session.socket.send(JSON.stringify(payload))
-    } else {
-      const socket = await this.resolveSocket(connection, endpoint)
-      socket.send(JSON.stringify(payload))
-    }
+    const { connection, payload, endpoint } = outboundPackage
+    this.logger.debug(`Sending outbound message to connection ${connection.id} over websocket transport.`, payload)
+    const socket = await this.resolveSocket(connection, endpoint)
+    socket.send(JSON.stringify(payload))
   }
 
   private async resolveSocket(connection: ConnectionRecord, endpoint?: string) {

--- a/src/transport/WsOutboundTransporter.ts
+++ b/src/transport/WsOutboundTransporter.ts
@@ -10,10 +10,18 @@ import { WebSocket } from '../utils/ws'
 
 export class WebSocketTransportSession implements TransportSession {
   public readonly type = 'websocket'
-  public socket?: WebSocket
+  public socket: WebSocket
 
-  public constructor(socket?: WebSocket) {
+  public constructor(socket: WebSocket) {
     this.socket = socket
+  }
+
+  public async send(outboundMessage: OutboundPackage): Promise<void> {
+    // logger.debug(`Sending outbound message via ${this.type} transport session`)
+    if (this.socket.readyState !== WebSocket.OPEN) {
+      throw new Error(`${this.type} transport session has been closed.`)
+    }
+    this.socket.send(JSON.stringify(outboundMessage.payload))
   }
 }
 

--- a/tests/__tests__/e2e.test.ts
+++ b/tests/__tests__/e2e.test.ts
@@ -7,7 +7,7 @@ import { get } from '../http'
 const aliceConfig = getBaseConfig('E2E Alice', { mediatorUrl: 'http://localhost:3001' })
 const bobConfig = getBaseConfig('E2E Bob', { mediatorUrl: 'http://localhost:3002' })
 
-describe('with http mediator', () => {
+describe('with mediator', () => {
   let aliceAgent: Agent
   let bobAgent: Agent
   let aliceAtAliceBobId: string

--- a/tests/__tests__/e2e.test.ts
+++ b/tests/__tests__/e2e.test.ts
@@ -7,7 +7,7 @@ import { get } from '../http'
 const aliceConfig = getBaseConfig('E2E Alice', { mediatorUrl: 'http://localhost:3001' })
 const bobConfig = getBaseConfig('E2E Bob', { mediatorUrl: 'http://localhost:3002' })
 
-describe('with mediator', () => {
+describe('with http mediator', () => {
   let aliceAgent: Agent
   let bobAgent: Agent
   let aliceAtAliceBobId: string

--- a/tests/mediator-ws.ts
+++ b/tests/mediator-ws.ts
@@ -45,10 +45,7 @@ class WsInboundTransporter implements InboundTransporter {
       logger.debug('WebSocket message event received.', { url: event.target.url, data: event.data })
       // @ts-expect-error Property 'dispatchEvent' is missing in type WebSocket imported from 'ws' module but required in type 'WebSocket'.
       const session = new WebSocketTransportSession(socket)
-      const outboundMessage = await agent.receiveMessage(JSON.parse(event.data), session)
-      if (outboundMessage) {
-        socket.send(JSON.stringify(outboundMessage.payload))
-      }
+      await agent.receiveMessage(JSON.parse(event.data), session)
     })
   }
 }

--- a/tests/mediator-ws.ts
+++ b/tests/mediator-ws.ts
@@ -56,7 +56,7 @@ class WsInboundTransporter implements InboundTransporter {
         this.listenOnWebSocketMessages(agent, socket, session)
         socket.on('close', () => {
           logger.debug('Socket closed.')
-          agent.closeSession(session)
+          agent.removeSession(session)
         })
       } else {
         logger.debug(`Socket with id ${socketId} already exists.`)

--- a/tests/mediator-ws.ts
+++ b/tests/mediator-ws.ts
@@ -1,18 +1,39 @@
 import type { InboundTransporter } from '../src'
+import type { TransportSession } from '../src/agent/TransportService'
+import type { OutboundPackage } from '../src/types'
 
 import cors from 'cors'
 import express from 'express'
-import { v4 as uuid } from 'uuid'
 import WebSocket from 'ws'
 
-import { Agent, WebSocketTransportSession, WsOutboundTransporter } from '../src'
+import { Agent, WsOutboundTransporter, AriesFrameworkError } from '../src'
 import testLogger from '../src/__tests__/logger'
 import { InMemoryMessageRepository } from '../src/storage/InMemoryMessageRepository'
 import { DidCommMimeType } from '../src/types'
+import { uuid } from '../src/utils/uuid'
 
 import config from './config'
 
 const logger = testLogger
+
+class WebSocketTransportSession implements TransportSession {
+  public id: string
+  public readonly type = 'websocket'
+  public socket: WebSocket
+
+  public constructor(id: string, socket: WebSocket) {
+    this.id = id
+    this.socket = socket
+  }
+
+  public async send(outboundMessage: OutboundPackage): Promise<void> {
+    // logger.debug(`Sending outbound message via ${this.type} transport session`)
+    if (this.socket.readyState !== WebSocket.OPEN) {
+      throw new AriesFrameworkError(`${this.type} transport session has been closed.`)
+    }
+    this.socket.send(JSON.stringify(outboundMessage.payload))
+  }
+}
 
 class WsInboundTransporter implements InboundTransporter {
   private socketServer: WebSocket.Server
@@ -31,20 +52,22 @@ class WsInboundTransporter implements InboundTransporter {
       if (!this.socketIds[socketId]) {
         logger.debug(`Saving new socket with id ${socketId}.`)
         this.socketIds[socketId] = socket
-        this.listenOnWebSocketMessages(agent, socket)
-        socket.on('close', () => logger.debug('Socket closed.'))
+        const session = new WebSocketTransportSession(socketId, socket)
+        this.listenOnWebSocketMessages(agent, socket, session)
+        socket.on('close', () => {
+          logger.debug('Socket closed.')
+          agent.closeSession(session)
+        })
       } else {
         logger.debug(`Socket with id ${socketId} already exists.`)
       }
     })
   }
 
-  private listenOnWebSocketMessages(agent: Agent, socket: WebSocket) {
+  private listenOnWebSocketMessages(agent: Agent, socket: WebSocket, session: TransportSession) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     socket.addEventListener('message', async (event: any) => {
       logger.debug('WebSocket message event received.', { url: event.target.url, data: event.data })
-      // @ts-expect-error Property 'dispatchEvent' is missing in type WebSocket imported from 'ws' module but required in type 'WebSocket'.
-      const session = new WebSocketTransportSession(socket)
       await agent.receiveMessage(JSON.parse(event.data), session)
     })
   }

--- a/tests/mediator.ts
+++ b/tests/mediator.ts
@@ -7,14 +7,14 @@ import type { Express, Request, Response } from 'express'
 import cors from 'cors'
 import express from 'express'
 
-import { Agent, AriesFrameworkError, ConsoleLogger, LogLevel } from '../src'
+import { Agent, AriesFrameworkError } from '../src'
 import testLogger from '../src/__tests__/logger'
 import { InMemoryMessageRepository } from '../src/storage/InMemoryMessageRepository'
 import { DidCommMimeType } from '../src/types'
 
 import config from './config'
 
-const logger = new ConsoleLogger(LogLevel.test)
+const logger = testLogger
 
 class HttpTransportSession implements TransportSession {
   public readonly type = 'http'

--- a/tests/mediator.ts
+++ b/tests/mediator.ts
@@ -1,17 +1,41 @@
 import type { InboundTransporter, OutboundTransporter } from '../src'
+import type { TransportSession } from '../src/agent/TransportService'
 import type { MessageRepository } from '../src/storage/MessageRepository'
 import type { OutboundPackage } from '../src/types'
-import type { Express } from 'express'
+import type { Express, Request, Response } from 'express'
 
 import cors from 'cors'
 import express from 'express'
 
-import { Agent, AriesFrameworkError } from '../src'
+import { Agent, AriesFrameworkError, ConsoleLogger, LogLevel } from '../src'
 import testLogger from '../src/__tests__/logger'
 import { InMemoryMessageRepository } from '../src/storage/InMemoryMessageRepository'
 import { DidCommMimeType } from '../src/types'
 
 import config from './config'
+
+const logger = new ConsoleLogger(LogLevel.test)
+
+class HttpTransportSession implements TransportSession {
+  public readonly type = 'http'
+  public req: Request
+  public res: Response
+
+  public constructor(req: Request, res: Response) {
+    this.req = req
+    this.res = res
+  }
+
+  public async send(outboundMessage: OutboundPackage): Promise<void> {
+    logger.debug(`Sending outbound message via ${this.type} transport session`)
+
+    if (this.res.headersSent) {
+      throw new Error(`${this.type} transport session has been closed.`)
+    }
+
+    this.res.status(200).json(outboundMessage.payload).end()
+  }
+}
 
 class HttpInboundTransporter implements InboundTransporter {
   private app: Express
@@ -26,13 +50,15 @@ class HttpInboundTransporter implements InboundTransporter {
         const message = req.body
         const packedMessage = JSON.parse(message)
 
-        const outboundMessage = await agent.receiveMessage(packedMessage)
-        if (outboundMessage) {
-          res.status(200).json(outboundMessage.payload).end()
-        } else {
+        const session = new HttpTransportSession(req, res)
+        await agent.receiveMessage(packedMessage, session)
+
+        // If agent did not use session when processing message we need to send response here.
+        if (!res.headersSent) {
           res.status(200).end()
         }
-      } catch {
+      } catch (error) {
+        logger.error(error)
         res.status(500).send('Error processing message')
       }
     })
@@ -67,7 +93,7 @@ class StorageOutboundTransporter implements OutboundTransporter {
       throw new AriesFrameworkError('Trying to save message without theirKey!')
     }
 
-    testLogger.debug('Storing message', { connection, payload })
+    logger.debug('Storing message', { connection, payload })
 
     this.messageRepository.save(connection.theirKey, payload)
   }
@@ -125,5 +151,5 @@ app.get('/api/routes', async (req, res) => {
 app.listen(PORT, async () => {
   await agent.initialize()
   messageReceiver.start(agent)
-  testLogger.info(`Application started on port ${PORT}`)
+  logger.info(`Application started on port ${PORT}`)
 })


### PR DESCRIPTION
This PR contains the following changes:
* A session object is saved only if there is a `return_route` param in an inbound message. 
* An outbound message is sent via session object, and the dispatcher doesn't return the message to the caller. It works for both HTTP and WebSocket.
* The session object also contains the inbound message. The reason for this is that we can decide if we want to use the session to send a message later in MessageSender. We don't try to send a message via session if there is no `return_route` set for a given session.