### PR TITLE
feat: added their label to the connection record

### DIFF
--- a/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -125,7 +125,7 @@ describe('ConnectionService', () => {
 
   describe('processInvitation', () => {
     it('returns a connection record containing the information from the connection invitation', async () => {
-      expect.assertions(9)
+      expect.assertions(10)
 
       const recipientKey = 'key-1'
       const invitation = new ConnectionInvitationMessage({
@@ -151,6 +151,7 @@ describe('ConnectionService', () => {
       expect(connection.invitation).toMatchObject(invitation)
       expect(connection.alias).toBeUndefined()
       expect(connectionAlias.alias).toBe('test-alias')
+      expect(connection.theirLabel).toBe('test label')
     })
 
     it('returns a connection record with the autoAcceptConnection parameter from the config', async () => {
@@ -235,7 +236,7 @@ describe('ConnectionService', () => {
 
   describe('processRequest', () => {
     it('returns a connection record containing the information from the connection request', async () => {
-      expect.assertions(5)
+      expect.assertions(6)
 
       const connectionRecord = getMockConnection({
         state: ConnectionState.Invited,
@@ -276,6 +277,7 @@ describe('ConnectionService', () => {
       expect(processedConnection.theirDid).toBe(theirDid)
       expect(processedConnection.theirDidDoc).toEqual(theirDidDoc)
       expect(processedConnection.theirKey).toBe(theirVerkey)
+      expect(processedConnection.theirLabel).toBe('test-label')
       expect(processedConnection.threadId).toBe(connectionRequest.id)
     })
 

--- a/src/modules/connections/repository/ConnectionRecord.ts
+++ b/src/modules/connections/repository/ConnectionRecord.ts
@@ -19,6 +19,7 @@ export interface ConnectionRecordProps {
   verkey: Verkey
   theirDid?: Did
   theirDidDoc?: DidDoc
+  theirLabel?: string
   invitation?: ConnectionInvitationMessage
   state: ConnectionState
   role: ConnectionRole
@@ -53,6 +54,7 @@ export class ConnectionRecord
   @Type(() => DidDoc)
   public theirDidDoc?: DidDoc
   public theirDid?: string
+  public theirLabel?: string
 
   @Type(() => ConnectionInvitationMessage)
   public invitation?: ConnectionInvitationMessage
@@ -75,6 +77,7 @@ export class ConnectionRecord
       this.verkey = props.verkey
       this.theirDid = props.theirDid
       this.theirDidDoc = props.theirDidDoc
+      this.theirLabel = props.theirLabel
       this.state = props.state
       this.role = props.role
       this.alias = props.alias

--- a/src/modules/connections/services/ConnectionService.ts
+++ b/src/modules/connections/services/ConnectionService.ts
@@ -117,6 +117,7 @@ export class ConnectionService {
       role: ConnectionRole.Invitee,
       state: ConnectionState.Invited,
       alias: config?.alias,
+      theirLabel: invitation.label,
       autoAcceptConnection: config?.autoAcceptConnection,
       invitation,
       tags: {
@@ -190,6 +191,7 @@ export class ConnectionService {
 
     connectionRecord.theirDid = message.connection.did
     connectionRecord.theirDidDoc = message.connection.didDoc
+    connectionRecord.theirLabel = message.label
     connectionRecord.threadId = message.id
 
     if (!connectionRecord.theirKey) {
@@ -423,6 +425,7 @@ export class ConnectionService {
     state: ConnectionState
     invitation?: ConnectionInvitationMessage
     alias?: string
+    theirLabel?: string
     autoAcceptConnection?: boolean
     tags?: CustomConnectionTags
   }): Promise<ConnectionRecord> {
@@ -472,6 +475,7 @@ export class ConnectionService {
       tags: options.tags,
       invitation: options.invitation,
       alias: options.alias,
+      theirLabel: options.theirLabel,
       autoAcceptConnection: options.autoAcceptConnection,
     })
 


### PR DESCRIPTION
Adds `theirLabel` to the connectionRecord for easy access. Correctly fetches the label from the invitation or connection request depending on whether or not the agent is the invitee or inviter. This is a followup to @blu3beri's PR #369.

Signed-off-by: James Ebert <jamesebert.k@gmail.com>