### PR TITLE
style: Enable check for camelcase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,8 +19,6 @@ module.exports = {
     // Type is enforced by callers. Not entirely, but it's good enough.
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
-    // Aries protocol defines attributes with snake case.
-    '@typescript-eslint/camelcase': 'off',
     '@typescript-eslint/no-use-before-define': ['error', { functions: false, classes: false, variables: true }],
     '@typescript-eslint/explicit-member-accessibility': 'error',
     'no-console': 'error',


### PR DESCRIPTION
It has been turned off because of the JSON-LD naming convention. Now, we use decorators to transform camelCase JS properties to the correct naming convention.