### PR TITLE
feat(redux-store): move from mobile agent repo

### DIFF
--- a/packages/redux-store/jest.config.ts
+++ b/packages/redux-store/jest.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from '@jest/types'
+
+import base from '../../jest.config.base'
+
+import packageJson from './package.json'
+
+const config: Config.InitialOptions = {
+  ...base,
+  name: packageJson.name,
+  displayName: packageJson.name,
+}
+
+export default config

--- a/packages/redux-store/package.json
+++ b/packages/redux-store/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@aries-framework/redux-store",
+  "main": "build/index",
+  "types": "build/index",
+  "version": "0.0.0",
+  "files": [
+    "build"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "homepage": "https://github.com/hyperledger/aries-framework-javascript/tree/main/packages/redux-store",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hyperledger/aries-framework-javascript",
+    "directory": "packages/redux-store"
+  },
+  "scripts": {
+    "build": "yarn run clean && yarn run compile",
+    "clean": "rimraf -rf ./build",
+    "compile": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "yarn run build",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@aries-framework/core": "*",
+    "@reduxjs/toolkit": "^1.6.0",
+    "react-redux": "^7.2.4"
+  },
+  "devDependencies": {
+    "rimraf": "~3.0.2",
+    "typescript": "~4.3.0"
+  }
+}

--- a/packages/redux-store/src/index.ts
+++ b/packages/redux-store/src/index.ts
@@ -1,0 +1,23 @@
+export { initializeStore } from './store'
+
+export { createAsyncAgentThunk, AgentThunkApiConfig } from './utils'
+
+export {
+  agentSlice,
+  AgentThunks,
+  // Connections
+  connectionsSlice,
+  ConnectionThunks,
+  startConnectionsListener,
+  ConnectionsSelectors,
+  // Credentials
+  credentialsSlice,
+  CredentialsThunks,
+  startCredentialsListener,
+  CredentialsSelectors,
+  // Proofs
+  proofsSlice,
+  ProofsThunks,
+  startProofsListener,
+  ProofsSelectors,
+} from './slices'

--- a/packages/redux-store/src/slices/agent.ts
+++ b/packages/redux-store/src/slices/agent.ts
@@ -1,0 +1,45 @@
+import type { AgentThunkApiConfig } from '../utils'
+import type { SerializedError } from '@reduxjs/toolkit'
+
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+
+export interface AgentState {
+  isInitializing: boolean
+  isInitialized: boolean
+  error: null | SerializedError
+}
+
+const initialState: AgentState = {
+  isInitializing: false,
+  isInitialized: false,
+  error: null,
+}
+
+const AgentThunks = {
+  initializeAgent: createAsyncThunk<boolean, void, AgentThunkApiConfig>('agent/initialize', async (_, thunkApi) => {
+    await thunkApi.extra.agent.initialize()
+    return true
+  }),
+}
+const agentSlice = createSlice({
+  name: 'agent',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder
+      .addCase(AgentThunks.initializeAgent.pending, (state) => {
+        state.isInitializing = true
+      })
+      .addCase(AgentThunks.initializeAgent.rejected, (state, action) => {
+        state.isInitializing = false
+        state.isInitialized = false
+        state.error = action.error
+      })
+      .addCase(AgentThunks.initializeAgent.fulfilled, (state) => {
+        state.isInitializing = false
+        state.isInitialized = true
+      })
+  },
+})
+
+export { agentSlice, AgentThunks }

--- a/packages/redux-store/src/slices/connections/connectionsListener.ts
+++ b/packages/redux-store/src/slices/connections/connectionsListener.ts
@@ -1,0 +1,28 @@
+import type { Agent, ConnectionStateChangedEvent } from '@aries-framework/core'
+import type { EnhancedStore } from '@reduxjs/toolkit'
+
+import { ConnectionEventTypes } from '@aries-framework/core'
+
+import { connectionsSlice } from './connectionsSlice'
+
+/**
+ * Starts an EventListener that listens for ConnectionRecord state changes
+ * and updates the store accordingly.
+ *
+ * This function **must** be called if you're working with ConnectionRecords.
+ * If you don't, the store won't be updated.
+ */
+const startConnectionsListener = (agent: Agent, store: EnhancedStore) => {
+  const listener = (event: ConnectionStateChangedEvent) => {
+    const record = event.payload.connectionRecord
+    store.dispatch(connectionsSlice.actions.updateOrAdd(record))
+  }
+
+  agent.events.on(ConnectionEventTypes.ConnectionStateChanged, listener)
+
+  return () => {
+    agent.events.off(ConnectionEventTypes.ConnectionStateChanged, listener)
+  }
+}
+
+export { startConnectionsListener }

--- a/packages/redux-store/src/slices/connections/connectionsSelectors.ts
+++ b/packages/redux-store/src/slices/connections/connectionsSelectors.ts
@@ -1,0 +1,64 @@
+import type { ConnectionsState } from './connectionsSlice'
+import type { ConnectionState } from '@aries-framework/core'
+
+interface PartialConnectionState {
+  connections: ConnectionsState
+}
+
+/**
+ * Namespace that holds all ConnectionRecord related selectors.
+ */
+const ConnectionsSelectors = {
+  /**
+   * Selector that retrieves the entire **connections** store object.
+   */
+  connectionsStateSelector: (state: PartialConnectionState) => state.connections.connections,
+
+  /**
+   * Selector that retrieves all ConnectionRecords from the store.
+   */
+  connectionRecordsSelector: (state: PartialConnectionState) => state.connections.connections.records,
+
+  /**
+   * Selector that retrieves all ConnectionRecords from the store with specified {@link ConnectionState}.
+   */
+  connectionRecordsByStateSelector: (connectionState: ConnectionState) => (state: PartialConnectionState) =>
+    state.connections.connections.records.filter((record) => record.state === connectionState),
+
+  /**
+   * Selector that retrieves the entire **invitation** store object.
+   */
+  invitationStateSelector: (state: PartialConnectionState) => state.connections.invitation,
+
+  /**
+   * Selector that fetches a ConnectionRecord by id from the state.
+   */
+  connectionRecordByIdSelector: (connectionRecordId: string) => (state: PartialConnectionState) =>
+    state.connections.connections.records.find((x) => x.id === connectionRecordId),
+
+  /**
+   * Selector that fetches a ConnectionRecord by its verification key from the state.
+   */
+  connectionRecordByVerkeySelector: (verkey: string) => (state: PartialConnectionState) =>
+    state.connections.connections.records.find((x) => x.verkey === verkey),
+
+  /**
+   * Selector that fetches a ConnectionRecord by their key from the state.
+   */
+  connectionRecordByTheirKeySelector: (theirKey: string) => (state: PartialConnectionState) =>
+    state.connections.connections.records.find((x) => x.theirKey === theirKey),
+
+  /**
+   * Selector that fetches the InvitationMessage based on a ConnectionRecord id.
+   */
+  invitationByConnectionRecordIdSelector: (connectionRecordId: string) => (state: PartialConnectionState) => {
+    const record = state.connections.connections.records.find((x) => x.id == connectionRecordId)
+
+    if (!record) {
+      return null
+    }
+    return record.invitation
+  },
+}
+
+export { ConnectionsSelectors }

--- a/packages/redux-store/src/slices/connections/connectionsSlice.ts
+++ b/packages/redux-store/src/slices/connections/connectionsSlice.ts
@@ -1,0 +1,124 @@
+import type { ConnectionRecord, ConnectionInvitationMessage } from '@aries-framework/core'
+import type { PayloadAction, SerializedError } from '@reduxjs/toolkit'
+
+import { createSlice } from '@reduxjs/toolkit'
+
+import { ConnectionThunks } from './connectionsThunks'
+
+interface ConnectionsState {
+  connections: {
+    records: ConnectionRecord[]
+    isLoading: boolean
+    error: null | SerializedError
+  }
+  invitation: {
+    message: null | ConnectionInvitationMessage
+    connectionRecordId: null | string
+    isLoading: boolean
+    error: null | SerializedError
+  }
+}
+
+const initialState: ConnectionsState = {
+  connections: {
+    records: [],
+    isLoading: false,
+    error: null,
+  },
+  invitation: {
+    message: null,
+    connectionRecordId: null,
+    isLoading: false,
+    error: null,
+  },
+}
+
+const connectionsSlice = createSlice({
+  name: 'connections',
+  initialState,
+  reducers: {
+    updateOrAdd: (state, action: PayloadAction<ConnectionRecord>) => {
+      const index = state.connections.records.findIndex((record) => record.id == action.payload.id)
+
+      if (index == -1) {
+        // records doesn't exist, add it
+        state.connections.records.push(action.payload)
+        return state
+      }
+
+      // record does exist, update it
+      state.connections.records[index] = action.payload
+      return state
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // fetchAllConnections
+      .addCase(ConnectionThunks.getAllConnections.pending, (state) => {
+        state.connections.isLoading = true
+      })
+      .addCase(ConnectionThunks.getAllConnections.rejected, (state, action) => {
+        state.connections.isLoading = false
+        state.connections.error = action.error
+      })
+      .addCase(ConnectionThunks.getAllConnections.fulfilled, (state, action) => {
+        state.connections.isLoading = false
+        state.connections.records = action.payload
+      })
+      // createConnection
+      .addCase(ConnectionThunks.createConnection.pending, (state) => {
+        state.invitation.isLoading = true
+      })
+      .addCase(ConnectionThunks.createConnection.rejected, (state, action) => {
+        state.invitation.isLoading = false
+        state.connections.error = action.error
+      })
+      .addCase(ConnectionThunks.createConnection.fulfilled, (state, action) => {
+        state.invitation.isLoading = false
+        state.invitation.message = action.payload.invitation
+        state.invitation.connectionRecordId = action.payload.connectionRecord.id
+      })
+      // receiveInvitation
+      .addCase(ConnectionThunks.receiveInvitation.pending, (state) => {
+        state.invitation.isLoading = true
+      })
+      .addCase(ConnectionThunks.receiveInvitation.rejected, (state, action) => {
+        state.invitation.isLoading = false
+        state.invitation.error = action.error
+      })
+      .addCase(ConnectionThunks.receiveInvitation.fulfilled, (state) => {
+        state.invitation.isLoading = false
+      })
+      // receiveInvitationFromUrl
+      .addCase(ConnectionThunks.receiveInvitationFromUrl.pending, (state) => {
+        state.invitation.isLoading = true
+      })
+      .addCase(ConnectionThunks.receiveInvitationFromUrl.rejected, (state, action) => {
+        state.invitation.isLoading = false
+        state.invitation.error = action.error
+      })
+      .addCase(ConnectionThunks.receiveInvitationFromUrl.fulfilled, (state) => {
+        state.invitation.isLoading = false
+      })
+      // acceptInvitation
+      .addCase(ConnectionThunks.acceptInvitation.pending, (state) => {
+        state.invitation.isLoading = true
+      })
+      .addCase(ConnectionThunks.acceptInvitation.rejected, (state, action) => {
+        state.invitation.isLoading = false
+        state.invitation.error = action.error
+      })
+      .addCase(ConnectionThunks.acceptInvitation.fulfilled, (state) => {
+        state.invitation.isLoading = false
+      })
+      .addCase(ConnectionThunks.deleteConnection.fulfilled, (state, action) => {
+        const connectionId = action.payload.id
+        const index = state.connections.records.findIndex((connectionRecord) => connectionRecord.id === connectionId)
+        state.connections.records.splice(index, 1)
+      })
+  },
+})
+
+export { connectionsSlice }
+
+export type { ConnectionsState }

--- a/packages/redux-store/src/slices/connections/connectionsThunks.ts
+++ b/packages/redux-store/src/slices/connections/connectionsThunks.ts
@@ -1,0 +1,110 @@
+import type { ClassMethodParameters } from '../../utils'
+import type { ConnectionInvitationMessage, ConnectionsModule } from '@aries-framework/core'
+
+import { ConnectionRepository } from '@aries-framework/core'
+
+import { createAsyncAgentThunk } from '../../utils'
+
+const ConnectionThunks = {
+  /**
+   * Retrieve all connections records
+   */
+  getAllConnections: createAsyncAgentThunk('connections/getAll', async (_, thunkApi) => {
+    return thunkApi.extra.agent.connections.getAll()
+  }),
+
+  /**
+   * Creates a new ConnectionRecord and InvitationMessage.
+   * These are both added to the state.
+   */
+  createConnection: createAsyncAgentThunk(
+    'connections/createConnection',
+    async (config: ClassMethodParameters<typeof ConnectionsModule, 'createConnection'>[0], thunkApi) => {
+      return thunkApi.extra.agent.connections.createConnection(config)
+    }
+  ),
+
+  /**
+   * Receive connection invitation as invitee and create connection. If auto accepting is enabled
+   * via either the config passed in the function or the global agent config, a connection
+   * request message will be send.
+   */
+  receiveInvitation: createAsyncAgentThunk(
+    'connections/receiveInvitation',
+    async (
+      {
+        invitation,
+        config,
+      }: {
+        invitation: ConnectionInvitationMessage
+        config?: ClassMethodParameters<typeof ConnectionsModule, 'receiveInvitation'>[1]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.connections.receiveInvitation(invitation, config)
+    }
+  ),
+
+  /**
+   * Receive connection invitation as invitee encoded as url and create connection. If auto accepting is enabled
+   * via either the config passed in the function or the global agent config, a connection
+   * request message will be send.
+   */
+  receiveInvitationFromUrl: createAsyncAgentThunk(
+    'connections/receiveInvitationFromUrl',
+    async (
+      {
+        invitationUrl,
+        config,
+      }: {
+        invitationUrl: string
+        config?: ClassMethodParameters<typeof ConnectionsModule, 'receiveInvitationFromUrl'>[1]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.connections.receiveInvitationFromUrl(invitationUrl, config)
+    }
+  ),
+
+  /**
+   * Accept a connection invitation as invitee (by sending a connection request message) for the connection with the specified connection id.
+   * This is not needed when auto accepting of connections is enabled.
+   */
+  acceptInvitation: createAsyncAgentThunk('connections/acceptInvitation', async (connectionId: string, thunkApi) => {
+    return thunkApi.extra.agent.connections.acceptInvitation(connectionId)
+  }),
+
+  /**
+   * Accept a connection request as inviter (by sending a connection response message) for the connection with the specified connection id.
+   * This is not needed when auto accepting of connection is enabled.
+   */
+  acceptRequest: createAsyncAgentThunk(
+    'connections/acceptRequest',
+    async (connectionId: ClassMethodParameters<typeof ConnectionsModule, 'acceptRequest'>[0], thunkApi) => {
+      return thunkApi.extra.agent.connections.acceptRequest(connectionId)
+    }
+  ),
+
+  /**
+   * Accept a connection response as invitee (by sending a trust ping message) for the connection with the specified connection id.
+   * This is not needed when auto accepting of connection is enabled.
+   */
+  acceptResponse: createAsyncAgentThunk(
+    'connections/acceptResponse',
+    async (connectionId: ClassMethodParameters<typeof ConnectionsModule, 'acceptRequest'>[0], thunkApi) => {
+      return thunkApi.extra.agent.connections.acceptResponse(connectionId)
+    }
+  ),
+
+  /**
+   * Deletes a connectionRecord in the connectionRepository
+   */
+  deleteConnection: createAsyncAgentThunk('connections/deleteConnection', async (connectionId: string, thunksApi) => {
+    const connectionRepository = thunksApi.extra.agent.injectionContainer.resolve(ConnectionRepository)
+    const connectionRecord = await connectionRepository.getById(connectionId)
+    await connectionRepository.delete(connectionRecord)
+    return connectionRecord
+  }),
+}
+
+export { ConnectionThunks }

--- a/packages/redux-store/src/slices/connections/index.ts
+++ b/packages/redux-store/src/slices/connections/index.ts
@@ -1,0 +1,4 @@
+export { connectionsSlice } from './connectionsSlice'
+export { ConnectionThunks } from './connectionsThunks'
+export { ConnectionsSelectors } from './connectionsSelectors'
+export { startConnectionsListener } from './connectionsListener'

--- a/packages/redux-store/src/slices/credentials/credentialsListener.ts
+++ b/packages/redux-store/src/slices/credentials/credentialsListener.ts
@@ -1,0 +1,28 @@
+import type { CredentialStateChangedEvent, Agent } from '@aries-framework/core'
+import type { EnhancedStore } from '@reduxjs/toolkit'
+
+import { CredentialEventTypes } from '@aries-framework/core'
+
+import { credentialsSlice } from './credentialsSlice'
+
+/**
+ * Starts an EventListener that listens for CredentialRecord state changes
+ * and updates the store accordingly.
+ *
+ * This function **must** be called if you're working with CredentialRecords.
+ * If you don't, the store won't be updated.
+ */
+const startCredentialsListener = (agent: Agent, store: EnhancedStore) => {
+  const listener = (event: CredentialStateChangedEvent) => {
+    const record = event.payload.credentialRecord
+    store.dispatch(credentialsSlice.actions.updateOrAdd(record))
+  }
+
+  agent.events.on(CredentialEventTypes.CredentialStateChanged, listener)
+
+  return () => {
+    agent.events.off(CredentialEventTypes.CredentialStateChanged, listener)
+  }
+}
+
+export { startCredentialsListener }

--- a/packages/redux-store/src/slices/credentials/credentialsSelectors.ts
+++ b/packages/redux-store/src/slices/credentials/credentialsSelectors.ts
@@ -1,0 +1,35 @@
+import type { CredentialsState } from './credentialsSlice'
+import type { CredentialState } from '@aries-framework/core'
+
+interface PartialCredentialState {
+  credentials: CredentialsState
+}
+
+/**
+ * Namespace that holds all CredentialRecord related selectors.
+ */
+const CredentialsSelectors = {
+  /**
+   * Selector that retrieves the entire **credentials** store object.
+   */
+  credentialsStateSelector: (state: PartialCredentialState) => state.credentials.credentials,
+
+  /**
+   * Selector that retrieves all CredentialRecords from the store.
+   */
+  credentialRecordsSelector: (state: PartialCredentialState) => state.credentials.credentials.records,
+
+  /**
+   * Selector that retrieves all CredentialRecords from the store by specified credential state.
+   */
+  credentialsRecordsByStateSelector: (credentialState: CredentialState) => (state: PartialCredentialState) =>
+    state.credentials.credentials.records.filter((record) => record.state === credentialState),
+
+  /**
+   * Selector that fetches a CredentialRecord by id from the state.
+   */
+  connectionRecordByIdSelector: (credentialRecordId: string) => (state: PartialCredentialState) =>
+    state.credentials.credentials.records.find((x) => x.id === credentialRecordId),
+}
+
+export { CredentialsSelectors }

--- a/packages/redux-store/src/slices/credentials/credentialsSlice.ts
+++ b/packages/redux-store/src/slices/credentials/credentialsSlice.ts
@@ -1,0 +1,84 @@
+import type { CredentialRecord } from '@aries-framework/core'
+import type { PayloadAction, SerializedError } from '@reduxjs/toolkit'
+
+import { createSlice } from '@reduxjs/toolkit'
+
+import { CredentialsThunks } from './credentialsThunks'
+
+interface CredentialsState {
+  credentials: {
+    records: CredentialRecord[]
+    isLoading: boolean
+  }
+  error: null | SerializedError
+}
+
+const initialState: CredentialsState = {
+  credentials: {
+    records: [],
+    isLoading: false,
+  },
+  error: null,
+}
+
+const credentialsSlice = createSlice({
+  name: 'credentials',
+  initialState,
+  reducers: {
+    updateOrAdd: (state, action: PayloadAction<CredentialRecord>) => {
+      const index = state.credentials.records.findIndex((record) => record.id == action.payload.id)
+
+      if (index == -1) {
+        // records doesn't exist, add it
+        state.credentials.records.push(action.payload)
+        return state
+      }
+
+      // record does exist, update it
+      state.credentials.records[index] = action.payload
+      return state
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // getAllCredentials
+      .addCase(CredentialsThunks.getAllCredentials.pending, (state) => {
+        state.credentials.isLoading = true
+      })
+      .addCase(CredentialsThunks.getAllCredentials.rejected, (state, action) => {
+        state.credentials.isLoading = false
+        state.error = action.error
+      })
+      .addCase(CredentialsThunks.getAllCredentials.fulfilled, (state, action) => {
+        state.credentials.isLoading = false
+        state.credentials.records = action.payload
+      })
+      // proposeCredential
+      .addCase(CredentialsThunks.proposeCredential.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // acceptProposal
+      .addCase(CredentialsThunks.acceptProposal.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // offerCredential
+      .addCase(CredentialsThunks.offerCredential.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // acceptOffer
+      .addCase(CredentialsThunks.acceptOffer.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // acceptRequest
+      .addCase(CredentialsThunks.acceptRequest.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // acceptCredential
+      .addCase(CredentialsThunks.acceptCredential.rejected, (state, action) => {
+        state.error = action.error
+      })
+  },
+})
+
+export { credentialsSlice }
+export type { CredentialsState }

--- a/packages/redux-store/src/slices/credentials/credentialsThunks.ts
+++ b/packages/redux-store/src/slices/credentials/credentialsThunks.ts
@@ -1,0 +1,126 @@
+import type { ClassMethodParameters } from '../../utils'
+import type { CredentialsModule } from '@aries-framework/core'
+
+import { createAsyncAgentThunk } from '../../utils'
+
+/**
+ * Namespace containing all **credential** related actions.
+ */
+const CredentialsThunks = {
+  /**
+   * Retrieve all credential records
+   */
+  getAllCredentials: createAsyncAgentThunk('credentials/getAll', async (_, thunkApi) => {
+    return thunkApi.extra.agent.credentials.getAll()
+  }),
+
+  /**
+   * Initiate a new credential exchange as holder by sending a credential proposal message
+   * to the connection with the specified connection id.
+   */
+  proposeCredential: createAsyncAgentThunk(
+    'credentials/proposeCredential',
+    async (
+      {
+        connectionId,
+        config,
+      }: {
+        connectionId: string
+        config?: ClassMethodParameters<typeof CredentialsModule, 'proposeCredential'>[1]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.credentials.proposeCredential(connectionId, config)
+    }
+  ),
+
+  /**
+   * Accept a credential proposal as issuer (by sending a credential offer message) to the connection
+   * associated with the credential record.
+   */
+  acceptProposal: createAsyncAgentThunk(
+    'credentials/acceptProposal',
+    async (
+      {
+        credentialId,
+        config,
+      }: {
+        credentialId: string
+        config?: ClassMethodParameters<typeof CredentialsModule, 'acceptProposal'>[1]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.credentials.acceptProposal(credentialId, config)
+    }
+  ),
+
+  /**
+   * Initiate a new credential exchange as issuer by sending a credential offer message
+   * to the connection with the specified connection id.
+   */
+  offerCredential: createAsyncAgentThunk(
+    'credentials/offerCredential',
+    async (
+      {
+        connectionId,
+        config,
+      }: {
+        connectionId: string
+        config: ClassMethodParameters<typeof CredentialsModule, 'offerCredential'>[1]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.credentials.offerCredential(connectionId, config)
+    }
+  ),
+
+  /**
+   * Accept a credential offer as holder (by sending a credential request message) to the connection
+   * associated with the credential record.
+   */
+  acceptOffer: createAsyncAgentThunk(
+    'credentials/acceptOffer',
+    async (
+      {
+        credentialId,
+        config,
+      }: {
+        credentialId: string
+        config?: ClassMethodParameters<typeof CredentialsModule, 'acceptOffer'>[1]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.credentials.acceptOffer(credentialId, config)
+    }
+  ),
+
+  /**
+   * Accept a credential request as issuer (by sending a credential message) to the connection
+   * associated with the credential record.
+   */
+  acceptRequest: createAsyncAgentThunk(
+    'credentials/acceptRequest',
+    async (
+      {
+        credentialId,
+        config,
+      }: {
+        credentialId: string
+        config?: ClassMethodParameters<typeof CredentialsModule, 'acceptRequest'>[1]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.credentials.acceptRequest(credentialId, config)
+    }
+  ),
+
+  /**
+   * Accept a credential as holder (by sending a credential acknowledgement message) to the connection
+   * associated with the credential record.
+   */
+  acceptCredential: createAsyncAgentThunk('credentials/acceptCredential', async (credentialId: string, thunkApi) => {
+    return thunkApi.extra.agent.credentials.acceptCredential(credentialId)
+  }),
+}
+
+export { CredentialsThunks }

--- a/packages/redux-store/src/slices/credentials/index.ts
+++ b/packages/redux-store/src/slices/credentials/index.ts
@@ -1,0 +1,4 @@
+export { credentialsSlice } from './credentialsSlice'
+export { CredentialsThunks } from './credentialsThunks'
+export { CredentialsSelectors } from './credentialsSelectors'
+export { startCredentialsListener } from './credentialsListener'

--- a/packages/redux-store/src/slices/index.ts
+++ b/packages/redux-store/src/slices/index.ts
@@ -1,0 +1,4 @@
+export { agentSlice, AgentThunks } from './agent'
+export { connectionsSlice, ConnectionThunks, ConnectionsSelectors, startConnectionsListener } from './connections'
+export { credentialsSlice, CredentialsThunks, CredentialsSelectors, startCredentialsListener } from './credentials'
+export { proofsSlice, ProofsThunks, ProofsSelectors, startProofsListener } from './proofs'

--- a/packages/redux-store/src/slices/proofs/index.ts
+++ b/packages/redux-store/src/slices/proofs/index.ts
@@ -1,0 +1,4 @@
+export { proofsSlice } from './proofsSlice'
+export { ProofsThunks } from './proofsThunks'
+export { ProofsSelectors } from './proofsSelectors'
+export { startProofsListener } from './proofsListener'

--- a/packages/redux-store/src/slices/proofs/proofsListener.ts
+++ b/packages/redux-store/src/slices/proofs/proofsListener.ts
@@ -1,0 +1,28 @@
+import type { ProofStateChangedEvent, Agent } from '@aries-framework/core'
+import type { EnhancedStore } from '@reduxjs/toolkit'
+
+import { ProofEventTypes } from '@aries-framework/core'
+
+import { proofsSlice } from './proofsSlice'
+
+/**
+ * Starts an EventListener that listens for ProofRecords state changes
+ * and updates the store accordingly.
+ *
+ * This function **must** be called if you're working with ProofRecords.
+ * If you don't, the store won't be updated.
+ */
+const startProofsListener = (agent: Agent, store: EnhancedStore) => {
+  const listener = (event: ProofStateChangedEvent) => {
+    const record = event.payload.proofRecord
+    store.dispatch(proofsSlice.actions.updateOrAdd(record))
+  }
+
+  agent.events.on(ProofEventTypes.ProofStateChanged, listener)
+
+  return () => {
+    agent.events.off(ProofEventTypes.ProofStateChanged, listener)
+  }
+}
+
+export { startProofsListener }

--- a/packages/redux-store/src/slices/proofs/proofsSelectors.ts
+++ b/packages/redux-store/src/slices/proofs/proofsSelectors.ts
@@ -1,0 +1,35 @@
+import type { ProofsState } from './proofsSlice'
+import type { ProofState } from '@aries-framework/core'
+
+interface PartialProofsState {
+  proofs: ProofsState
+}
+
+/**
+ * Namespace that holds all ProofRecords related selectors.
+ */
+const ProofsSelectors = {
+  /**
+   * Selector that retrieves the entire **proofs** store object.
+   */
+  proofsStateSelector: (state: PartialProofsState) => state.proofs.proofs,
+
+  /**
+   * Selector that retrieves all ProofRecords from the state.
+   */
+  proofRecordsSelector: (state: PartialProofsState) => state.proofs.proofs.records,
+
+  /**
+   * Selector that retrieves all ProofRecords from the store by specified state.
+   */
+  proofRecordsByStateSelector: (proofState: ProofState) => (state: PartialProofsState) =>
+    state.proofs.proofs.records.filter((record) => record.state === proofState),
+
+  /**
+   * Selector that fetches a ProofRecord by id from the state.
+   */
+  connectionRecordByIdSelector: (proofRecordId: string) => (state: PartialProofsState) =>
+    state.proofs.proofs.records.find((x) => x.id === proofRecordId),
+}
+
+export { ProofsSelectors }

--- a/packages/redux-store/src/slices/proofs/proofsSlice.ts
+++ b/packages/redux-store/src/slices/proofs/proofsSlice.ts
@@ -1,0 +1,89 @@
+import type { ProofRecord } from '@aries-framework/core'
+import type { PayloadAction, SerializedError } from '@reduxjs/toolkit'
+
+import { createSlice } from '@reduxjs/toolkit'
+
+import { ProofsThunks } from './proofsThunks'
+
+interface ProofsState {
+  proofs: {
+    records: ProofRecord[]
+    isLoading: boolean
+  }
+  error: null | SerializedError
+}
+
+const initialState: ProofsState = {
+  proofs: {
+    records: [],
+    isLoading: false,
+  },
+  error: null,
+}
+
+const proofsSlice = createSlice({
+  name: 'proofs',
+  initialState,
+  reducers: {
+    updateOrAdd: (state, action: PayloadAction<ProofRecord>) => {
+      const index = state.proofs.records.findIndex((record) => record.id == action.payload.id)
+
+      if (index == -1) {
+        // records doesn't exist, add it
+        state.proofs.records.push(action.payload)
+        return state
+      }
+
+      // record does exist, update it
+      state.proofs.records[index] = action.payload
+      return state
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // getAllProofs
+      .addCase(ProofsThunks.getAllProofs.pending, (state) => {
+        state.proofs.isLoading = true
+      })
+      .addCase(ProofsThunks.getAllProofs.rejected, (state, action) => {
+        state.proofs.isLoading = false
+        state.error = action.error
+      })
+      .addCase(ProofsThunks.getAllProofs.fulfilled, (state, action) => {
+        state.proofs.isLoading = false
+        state.proofs.records = action.payload
+      })
+      // proposeProof
+      .addCase(ProofsThunks.proposeProof.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // acceptProposal
+      .addCase(ProofsThunks.acceptProposal.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // requestProof
+      .addCase(ProofsThunks.requestProof.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // acceptRequest
+      .addCase(ProofsThunks.acceptRequest.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // acceptPresentation
+      .addCase(ProofsThunks.acceptPresentation.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // getRequestedCredentialsForProofRequest
+      .addCase(ProofsThunks.getRequestedCredentialsForProofRequest.rejected, (state, action) => {
+        state.error = action.error
+      })
+      // autoSelectCredentialsForProofRequest
+      .addCase(ProofsThunks.autoSelectCredentialsForProofRequest.rejected, (state, action) => {
+        state.error = action.error
+      })
+  },
+})
+
+export { proofsSlice }
+
+export type { ProofsState }

--- a/packages/redux-store/src/slices/proofs/proofsThunks.ts
+++ b/packages/redux-store/src/slices/proofs/proofsThunks.ts
@@ -1,0 +1,147 @@
+import type { ClassMethodParameters } from '../../utils'
+import type { RequestedCredentials, ProofsModule, RetrievedCredentials } from '@aries-framework/core'
+
+import { createAsyncAgentThunk } from '../../utils'
+
+/**
+ * Namespace containing all **proof** related actions.
+ */
+const ProofsThunks = {
+  /**
+   * Retrieve all ProofRecords
+   */
+  getAllProofs: createAsyncAgentThunk('proofs/getAll', async (_, thunkApi) => {
+    return thunkApi.extra.agent.proofs.getAll()
+  }),
+
+  /**
+   * Initiate a new presentation exchange as prover by sending a presentation proposal message
+   * to the connection with the specified connection id.
+   */
+  proposeProof: createAsyncAgentThunk(
+    'proofs/proposeProof',
+    async (
+      {
+        connectionId,
+        presentationProposal,
+        config,
+      }: {
+        connectionId: string
+        presentationProposal: ClassMethodParameters<typeof ProofsModule, 'proposeProof'>[1]
+        config?: ClassMethodParameters<typeof ProofsModule, 'proposeProof'>[2]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.proofs.proposeProof(connectionId, presentationProposal, config)
+    }
+  ),
+  /**
+   * Accept a presentation proposal as verifier (by sending a presentation request message) to the connection
+   * associated with the proof record.
+   */
+  acceptProposal: createAsyncAgentThunk(
+    'proofs/acceptProposal',
+    async (
+      {
+        proofRecordId,
+        config,
+      }: {
+        proofRecordId: string
+        config?: ClassMethodParameters<typeof ProofsModule, 'acceptProposal'>[1]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.proofs.acceptProposal(proofRecordId, config)
+    }
+  ),
+  /**
+   * Initiate a new presentation exchange as verifier by sending a presentation request message
+   * to the connection with the specified connection id.
+   */
+  requestProof: createAsyncAgentThunk(
+    'proofs/requestProof',
+    async (
+      {
+        connectionId,
+        proofRequestOptions,
+        config,
+      }: {
+        connectionId: string
+        proofRequestOptions: ClassMethodParameters<typeof ProofsModule, 'requestProof'>[1]
+        config?: ClassMethodParameters<typeof ProofsModule, 'requestProof'>[2]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.proofs.requestProof(connectionId, proofRequestOptions, config)
+    }
+  ),
+
+  /**
+   * Accept a presentation request as prover (by sending a presentation message) to the connection
+   * associated with the proof record.
+   */
+  acceptRequest: createAsyncAgentThunk(
+    'proofs/acceptRequest',
+    async (
+      {
+        proofRecordId,
+        requestedCredentials,
+        config,
+      }: {
+        proofRecordId: string
+        requestedCredentials: ClassMethodParameters<typeof ProofsModule, 'acceptRequest'>[1]
+        config?: ClassMethodParameters<typeof ProofsModule, 'acceptRequest'>[2]
+      },
+      thunkApi
+    ) => {
+      return thunkApi.extra.agent.proofs.acceptRequest(proofRecordId, requestedCredentials, config)
+    }
+  ),
+
+  /**
+   * Accept a presentation as prover (by sending a presentation acknowledgement message) to the connection
+   * associated with the proof record.
+   */
+  acceptPresentation: createAsyncAgentThunk('proofs/acceptPresentation', async (proofRecordId: string, thunkApi) => {
+    return thunkApi.extra.agent.proofs.acceptPresentation(proofRecordId)
+  }),
+
+  /**
+   * Create a {@link RetrievedCredentials} object. Given input proof request and presentation proposal,
+   * use credentials in the wallet to build indy requested credentials object for input to proof creation.
+   * If restrictions allow, self attested attributes will be used.
+   */
+  getRequestedCredentialsForProofRequest: createAsyncAgentThunk(
+    'proofs/getRequestedCredentialsForProofRequest',
+    async (
+      {
+        proofRequest,
+        presentationProposal,
+      }: {
+        proofRequest: ClassMethodParameters<typeof ProofsModule, 'getRequestedCredentialsForProofRequest'>[0]
+        presentationProposal?: ClassMethodParameters<typeof ProofsModule, 'getRequestedCredentialsForProofRequest'>[1]
+      },
+      thunkApi
+    ): Promise<RetrievedCredentials> => {
+      return thunkApi.extra.agent.proofs.getRequestedCredentialsForProofRequest(proofRequest, presentationProposal)
+    }
+  ),
+
+  /**
+   * Create a RequestedCredentials object. Given input proof request and presentation proposal,
+   * use credentials in the wallet to build indy requested credentials object for input to proof creation.
+   * If restrictions allow, self attested attributes will be used.
+   */
+  autoSelectCredentialsForProofRequest: createAsyncAgentThunk(
+    'proofs/autoSelectCredentialsForProofRequest',
+    async (
+      retrievedCredentials: ClassMethodParameters<typeof ProofsModule, 'autoSelectCredentialsForProofRequest'>[0],
+
+      thunkApi
+    ): Promise<RequestedCredentials> => {
+      return thunkApi.extra.agent.proofs.autoSelectCredentialsForProofRequest(retrievedCredentials)
+    }
+  ),
+}
+
+export { ProofsThunks }

--- a/packages/redux-store/src/store.ts
+++ b/packages/redux-store/src/store.ts
@@ -1,0 +1,42 @@
+import type { Agent } from '@aries-framework/core'
+import type { TypedUseSelectorHook } from 'react-redux'
+
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { agentSlice } from './slices/agent'
+import { connectionsSlice } from './slices/connections/connectionsSlice'
+
+const rootReducer = combineReducers({
+  agent: agentSlice.reducer,
+  connections: connectionsSlice.reducer,
+})
+
+type RootState = ReturnType<typeof rootReducer>
+const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+
+const initializeStore = (agent: Agent) => {
+  const store = configureStore({
+    reducer: rootReducer,
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware({
+        thunk: {
+          extraArgument: {
+            agent,
+          },
+        },
+      }),
+  })
+
+  type AppDispatch = typeof store.dispatch
+  const useAppDispatch = () => useDispatch<AppDispatch>()
+
+  return {
+    store,
+    useAppDispatch,
+  }
+}
+
+export { initializeStore, useAppSelector }
+
+export type { RootState }

--- a/packages/redux-store/src/utils.ts
+++ b/packages/redux-store/src/utils.ts
@@ -1,0 +1,36 @@
+import type { Agent } from '@aries-framework/core'
+import type { AsyncThunkPayloadCreator } from '@reduxjs/toolkit'
+
+import { createAsyncThunk } from '@reduxjs/toolkit'
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Constructor<T = unknown> = new (...args: any[]) => T
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Method<M> = M extends (...args: any) => any ? M : never
+type ClassMethodParameters<T, M> = T extends Constructor
+  ? M extends keyof InstanceType<T>
+    ? Parameters<Method<InstanceType<T>[M]>>
+    : never
+  : M extends keyof T
+  ? Parameters<Method<T[M]>>
+  : never
+interface AgentThunkApiConfig {
+  extra: {
+    agent: Agent
+  }
+}
+
+function createAsyncAgentThunk<Returned, ThunkArg = void>(
+  typePrefix: string,
+  payloadCreator: AsyncThunkPayloadCreator<Returned, ThunkArg, AgentThunkApiConfig>
+) {
+  return createAsyncThunk<Returned, ThunkArg, AgentThunkApiConfig>(typePrefix, async (thunkArg, thunkApi) => {
+    if (!thunkApi.extra.agent) return thunkApi.rejectWithValue('Agent not set')
+    if (!thunkApi.extra.agent.isInitialized) return thunkApi.rejectWithValue('Agent not initialized, call agent.init()')
+    return payloadCreator(thunkArg, thunkApi)
+  })
+}
+
+export { createAsyncAgentThunk }
+
+export type { AgentThunkApiConfig, ClassMethodParameters }

--- a/packages/redux-store/tests/index.test.ts
+++ b/packages/redux-store/tests/index.test.ts
@@ -1,0 +1,3 @@
+describe('@aries-framework/redux-store', () => {
+  it.todo('Redux store tests')
+})

--- a/packages/redux-store/tsconfig.build.json
+++ b/packages/redux-store/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.build.json",
+
+  "compilerOptions": {
+    "outDir": "./build",
+    "types": []
+  },
+
+  "include": ["src/**/*"]
+}

--- a/packages/redux-store/tsconfig.json
+++ b/packages/redux-store/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest"]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -678,7 +678,7 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
-"@babel/runtime@^7.8.4":
+"@babel/runtime@^7.12.1", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
   integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
@@ -1979,6 +1979,16 @@
   resolved "https://registry.yarnpkg.com/@react-native/polyfills/-/polyfills-1.0.0.tgz#05bb0031533598f9458cf65a502b8df0eecae780"
   integrity sha512-0jbp4RxjYopTsIdLl+/Fy2TiwVYHy4mgeu07DG4b/LyM0OS/+lPP5c9sbnt/AMlnF6qz2JRZpPpGw1eMNS6A4w==
 
+"@reduxjs/toolkit@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@reduxjs/toolkit/-/toolkit-1.6.0.tgz#0a17c6941c57341f8b31e982352b495ab69d5add"
+  integrity sha512-eGL50G+Vj5AG5uD0lineb6rRtbs96M8+hxbcwkHpZ8LQcmt0Bm33WyBSnj5AweLkjQ7ZP+KFRDHiLMznljRQ3A==
+  dependencies:
+    immer "^9.0.1"
+    redux "^4.1.0"
+    redux-thunk "^2.3.0"
+    reselect "^4.0.0"
+
 "@sideway/address@^4.1.0":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.2.tgz#811b84333a335739d3969cfc434736268170cad1"
@@ -2144,6 +2154,14 @@
   dependencies:
     "@types/node" "*"
 
+"@types/hoist-non-react-statics@^3.3.0":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/indy-sdk@^1.16.5", "@types/rn-indy-sdk@npm:@types/indy-sdk@^1.16.5":
   version "1.16.5"
   resolved "https://registry.yarnpkg.com/@types/indy-sdk/-/indy-sdk-1.16.5.tgz#e9b6b917f8a95b5782d9eb7bc8be713c0f971b21"
@@ -2257,6 +2275,16 @@
   integrity sha512-3Kb9QM5/WZ6p58yZ7VPbvjvi6Wc/ZkESgJhKso1gKkNuHBe/4WL6586R2JRDiz9Tsxal9lMnbj3fligBVGl8PA==
   dependencies:
     "@types/react" "*"
+
+"@types/react-redux@^7.1.16":
+  version "7.1.18"
+  resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.18.tgz#2bf8fd56ebaae679a90ebffe48ff73717c438e04"
+  integrity sha512-9iwAsPyJ9DLTRH+OFeIrm9cAbIj1i2ANL3sKQFATqnPWRbg+jEFXyZOKHiQK/N86pNRXbb4HRxAxo0SIX1XwzQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.0"
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+    redux "^4.0.0"
 
 "@types/react@*":
   version "17.0.13"
@@ -5060,6 +5088,13 @@ hermes-profile-transformer@^0.0.6:
   dependencies:
     source-map "^0.7.3"
 
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
+
 hosted-git-info@^2.1.4:
   version "2.8.9"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
@@ -5194,6 +5229,11 @@ image-size@^0.6.0:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.6.3.tgz#e7e5c65bb534bd7cdcedd6cb5166272a85f75fb2"
   integrity sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==
+
+immer@^9.0.1:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.5.tgz#a7154f34fe7064f15f00554cc94c66cc0bf453ec"
+  integrity sha512-2WuIehr2y4lmYz9gaQzetPR2ECniCifk4ORaQbU3g5EalLt+0IVTosEPJ5BoYl/75ky2mivzdRzV8wWgQGOSYQ==
 
 import-fresh@^2.0.0:
   version "2.0.0"
@@ -8247,7 +8287,7 @@ react-devtools-core@^4.6.0:
     shell-quote "^1.6.1"
     ws "^7"
 
-react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -8318,6 +8358,18 @@ react-native@0.64.2:
     use-subscription "^1.0.0"
     whatwg-fetch "^3.0.0"
     ws "^6.1.4"
+
+react-redux@^7.2.4:
+  version "7.2.4"
+  resolved "https://registry.yarnpkg.com/react-redux/-/react-redux-7.2.4.tgz#1ebb474032b72d806de2e0519cd07761e222e225"
+  integrity sha512-hOQ5eOSkEJEXdpIKbnRyl04LhaWabkDPV+Ix97wqQX3T3d2NQ8DUblNXXtNMavc7DpswyQM6xfaN4HQDKNY2JA==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    "@types/react-redux" "^7.1.16"
+    hoist-non-react-statics "^3.3.2"
+    loose-envify "^1.4.0"
+    prop-types "^15.7.2"
+    react-is "^16.13.1"
 
 react-refresh@^0.4.0:
   version "0.4.3"
@@ -8474,6 +8526,18 @@ redent@^3.0.0:
     indent-string "^4.0.0"
     strip-indent "^3.0.0"
 
+redux-thunk@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.3.0.tgz#51c2c19a185ed5187aaa9a2d08b666d0d6467622"
+  integrity sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw==
+
+redux@^4.0.0, redux@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-4.1.0.tgz#eb049679f2f523c379f1aff345c8612f294c88d4"
+  integrity sha512-uI2dQN43zqLWCt6B/BMGRMY6db7TTY4qeHHfGeKb3EOhmOKjU3KdWvNLJyqaHRksv/ErdNH7cFZWg9jXtewy4g==
+  dependencies:
+    "@babel/runtime" "^7.9.2"
+
 reflect-metadata@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/reflect-metadata/-/reflect-metadata-0.1.13.tgz#67ae3ca57c972a2aa1642b10fe363fe32d49dc08"
@@ -8595,6 +8659,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resolve-cwd@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Moves the `@aries-framework/redux-store` package from the mobile agent to here for easier management.

This is just the state as it was in the mobile agent repo. @jakubkoci You'll probably have opinions on this, and I'm interested to hear it. 

I'd like to merge first so we can use the package without manually packing every time, and then discuss maybe at the AFJ WG call.

Fixes hyperledger/aries-mobile-agent-react-native#64