### PR TITLE
fix(core): do not use did-communication service

### DIFF
--- a/packages/core/src/agent/TransportService.ts
+++ b/packages/core/src/agent/TransportService.ts
@@ -1,4 +1,4 @@
-import type { DidDoc } from '../modules/connections/models'
+import type { DidDoc, IndyAgentService } from '../modules/connections/models'
 import type { ConnectionRecord } from '../modules/connections/repository'
 import type { OutboundPackage } from '../types'
 import type { AgentMessage } from './AgentMessage'
@@ -33,7 +33,7 @@ export class TransportService {
     delete this.transportSessionTable[session.id]
   }
 
-  public findDidCommServices(connection: ConnectionRecord): DidCommService[] {
+  public findDidCommServices(connection: ConnectionRecord): Array<DidCommService | IndyAgentService> {
     if (connection.theirDidDoc) {
       return connection.theirDidDoc.didCommServices
     }

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -30,7 +30,6 @@ import {
   Ed25119Sig2018,
   authenticationTypes,
   ReferencedAuthentication,
-  DidCommService,
   IndyAgentService,
 } from '../models'
 import { ConnectionRecord } from '../repository/ConnectionRecord'
@@ -455,14 +454,6 @@ export class ConnectionService {
       recipientKeys: [verkey],
       routingKeys: routingKeys,
     })
-    const didCommService = new DidCommService({
-      id: `${did}#did-communication`,
-      serviceEndpoint: endpoint,
-      recipientKeys: [verkey],
-      routingKeys: routingKeys,
-      // Prefer DidCommService over IndyAgentService
-      priority: 1,
-    })
 
     // TODO: abstract the second parameter for ReferencedAuthentication away. This can be
     // inferred from the publicKey class instance
@@ -471,7 +462,7 @@ export class ConnectionService {
     const didDoc = new DidDoc({
       id: did,
       authentication: [auth],
-      service: [didCommService, indyAgentService],
+      service: [indyAgentService],
       publicKey: [publicKey],
     })
 

--- a/packages/core/src/modules/credentials/messages/CredentialPreview.ts
+++ b/packages/core/src/modules/credentials/messages/CredentialPreview.ts
@@ -53,7 +53,7 @@ export class CredentialPreviewAttribute {
   public name!: string
 
   @Expose({ name: 'mime-type' })
-  public mimeType?: string
+  public mimeType?: string = 'text/plain'
 
   public value!: string
 


### PR DESCRIPTION
Do not include the `did-communication` service in the did doc for now. This break interop with AF.NET. We should solve this in the future by only using `IndyAgent` for connection protocol and did-communication for did exchange protocol