### PR TITLE
fix(redux-store): credential and proof selector by id

### DIFF
--- a/packages/redux-store/src/slices/credentials/credentialsSelectors.ts
+++ b/packages/redux-store/src/slices/credentials/credentialsSelectors.ts
@@ -28,7 +28,7 @@ const CredentialsSelectors = {
   /**
    * Selector that fetches a CredentialRecord by id from the state.
    */
-  connectionRecordByIdSelector: (credentialRecordId: string) => (state: PartialCredentialState) =>
+  credentialRecordByIdSelector: (credentialRecordId: string) => (state: PartialCredentialState) =>
     state.credentials.credentials.records.find((x) => x.id === credentialRecordId),
 }
 

--- a/packages/redux-store/src/slices/proofs/proofsSelectors.ts
+++ b/packages/redux-store/src/slices/proofs/proofsSelectors.ts
@@ -28,7 +28,7 @@ const ProofsSelectors = {
   /**
    * Selector that fetches a ProofRecord by id from the state.
    */
-  connectionRecordByIdSelector: (proofRecordId: string) => (state: PartialProofsState) =>
+  proofRecordByIdSelector: (proofRecordId: string) => (state: PartialProofsState) =>
     state.proofs.proofs.records.find((x) => x.id === proofRecordId),
 }
 


### PR DESCRIPTION
The current `ById` selectors in the proof and credential selector were probably copied from the `connectionSelector`. Two function names did not change.
