### PR TITLE
build: fix start scripts for mediators

### DIFF
--- a/docker/docker-compose-mediators.yml
+++ b/docker/docker-compose-mediators.yml
@@ -5,7 +5,7 @@ services:
     build: ..
     image: aries-framework-javascript
     container_name: afj-http-mediator
-    command: yarn mediator:start
+    command: yarn run-mediator
     platform: linux/amd64
     networks:
       - hyperledger
@@ -16,7 +16,7 @@ services:
     build: ..
     image: aries-framework-javascript
     container_name: afj-ws-mediator
-    command: yarn mediator:start-ws
+    command: yarn run-mediator-ws
     platform: linux/amd64
     networks:
       - hyperledger


### PR DESCRIPTION
the start scripts used in the docker-compose setup do not match with the actual name of the start scripts that are defined in the package.json