### PR TITLE
fix: mediator transports

### DIFF
--- a/docs/getting-started/1-transports.md
+++ b/docs/getting-started/1-transports.md
@@ -18,11 +18,11 @@ const agent = new Agent({
 
 // Use HTTP as outbound transporter
 const httpOutboundTransporter = new HttpOutboundTransporter()
-agent.setOutboundTransporter(httpOutboundTransporter)
+agent.registerOutboundTransporter(httpOutboundTransporter)
 
 // Or use WebSocket instead
 const wsOutboundTransporter = new WsOutboundTransporter()
-agent.setOutboundTransporter(wsOutboundTransporter)
+agent.registerOutboundTransporter(wsOutboundTransporter)
 ```
 
 ## Inbound Transport

--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -266,10 +266,10 @@ export class MessageSender {
     transportPriority?: TransportPriorityOptions
   ) {
     this.logger.debug(
-      `Retrieving services for connection '${connection.id}'${' (' && connection.theirLabel && ')'}${
-        (transportPriority?.restrictive && ' restrictively ',
-        transportPriority && ' by priority of the follow schemes: ' + transportPriority.schemes)
-      }`
+      `Retrieving services for connection '${connection.id}' (${connection.theirLabel})`,
+      {
+      	transportPriority
+      }
     )
     // Retrieve DIDComm services
     const allServices = this.transportService.findDidCommServices(connection)

--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -265,12 +265,9 @@ export class MessageSender {
     connection: ConnectionRecord,
     transportPriority?: TransportPriorityOptions
   ) {
-    this.logger.debug(
-      `Retrieving services for connection '${connection.id}' (${connection.theirLabel})`,
-      {
-      	transportPriority
-      }
-    )
+    this.logger.debug(`Retrieving services for connection '${connection.id}' (${connection.theirLabel})`, {
+      transportPriority,
+    })
     // Retrieve DIDComm services
     const allServices = this.transportService.findDidCommServices(connection)
 
@@ -296,9 +293,7 @@ export class MessageSender {
     }
 
     this.logger.debug(
-      `Retrieved ${services.length} services for message to connection '${connection.id}'${
-        ' (' && connection.theirLabel && ')'
-      }`
+      `Retrieved ${services.length} services for message to connection '${connection.id}'(${connection.theirLabel})'`
     )
     return { services, queueService }
   }

--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -45,12 +45,12 @@ export class MessageSender {
     // map all supported schema into a new list
     // reduce the list of listed schemas into a single list
     // remove duplicates by creating a new set and spreading it into a list
-	const schemeTuples = outboundTransporters.map(transport => transport.supportedSchemes)
-    
+    const schemeTuples = this.outboundTransporters.map((transport) => transport.supportedSchemes)
+
     const allSchemes = new Array<string>().concat(...schemeTuples)
-	const uniqueSchemes = [...new Set(allSchemes)]
-		
-	return uniqueSchemes
+    const uniqueSchemes = [...new Set(allSchemes)]
+
+    return uniqueSchemes
   }
 
   public get outboundTransporters() {

--- a/packages/core/src/agent/__tests__/MessageSender.test.ts
+++ b/packages/core/src/agent/__tests__/MessageSender.test.ts
@@ -31,7 +31,7 @@ class DummyOutboundTransporter implements OutboundTransporter {
     throw new Error('Method not implemented.')
   }
 
-  public supportedSchemes: string[] = []
+  public supportedSchemes: string[] = ['https']
 
   public sendMessage() {
     return Promise.resolve()
@@ -109,11 +109,11 @@ describe('MessageSender', () => {
     })
 
     test('throw error when there is no outbound transport', async () => {
-      await expect(messageSender.sendMessage(outboundMessage)).rejects.toThrow(`Agent has no outbound transporter!`)
+      await expect(messageSender.sendMessage(outboundMessage)).rejects.toThrow(/Message is undeliverable to connection/)
     })
 
     test('throw error when there is no service or queue', async () => {
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       transportServiceFindServicesMock.mockReturnValue([])
 
       await expect(messageSender.sendMessage(outboundMessage)).rejects.toThrow(
@@ -122,11 +122,11 @@ describe('MessageSender', () => {
     })
 
     test('call send message when session send method fails', async () => {
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       transportServiceFindSessionMock.mockReturnValue(session)
       session.send = jest.fn().mockRejectedValue(new Error('some error'))
 
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       const sendMessageSpy = jest.spyOn(outboundTransporter, 'sendMessage')
 
       await messageSender.sendMessage(outboundMessage)
@@ -140,10 +140,10 @@ describe('MessageSender', () => {
     })
 
     test('call send message when session send method fails with missing keys', async () => {
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       transportServiceFindSessionMock.mockReturnValue(sessionWithoutKeys)
 
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       const sendMessageSpy = jest.spyOn(outboundTransporter, 'sendMessage')
 
       await messageSender.sendMessage(outboundMessage)
@@ -157,7 +157,7 @@ describe('MessageSender', () => {
     })
 
     test('call send message on session when there is a session for a given connection', async () => {
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       const sendMessageSpy = jest.spyOn(outboundTransporter, 'sendMessage')
       const sendMessageToServiceSpy = jest.spyOn(messageSender, 'sendMessageToService')
 
@@ -174,7 +174,7 @@ describe('MessageSender', () => {
     })
 
     test('calls sendMessageToService with payload and endpoint from second DidComm service when the first fails', async () => {
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       const sendMessageSpy = jest.spyOn(outboundTransporter, 'sendMessage')
       const sendMessageToServiceSpy = jest.spyOn(messageSender, 'sendMessageToService')
 
@@ -229,7 +229,7 @@ describe('MessageSender', () => {
     })
 
     test('calls send message with payload and endpoint from DIDComm service', async () => {
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       const sendMessageSpy = jest.spyOn(outboundTransporter, 'sendMessage')
 
       await messageSender.sendMessageToService({
@@ -247,7 +247,7 @@ describe('MessageSender', () => {
     })
 
     test('call send message with responseRequested when message has return route', async () => {
-      messageSender.setOutboundTransporter(outboundTransporter)
+      messageSender.registerOutboundTransporter(outboundTransporter)
       const sendMessageSpy = jest.spyOn(outboundTransporter, 'sendMessage')
 
       const message = new AgentMessage()

--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -222,6 +222,17 @@ export class ConnectionsModule {
   }
 
   /**
+   * Find connection by Invitation key.
+   *
+   * @param key the invitation key to search for
+   * @returns the connection record, or null if not found
+   * @throws {RecordDuplicateError} if multiple connections are found for the given verkey
+   */
+  public findByInvitationKey(key: string): Promise<ConnectionRecord | null> {
+    return this.connectionService.findByInvitationKey(key)
+  }
+
+  /**
    * Retrieve a connection record by thread id
    *
    * @param threadId The thread id

--- a/packages/core/src/modules/connections/models/did/service/Service.ts
+++ b/packages/core/src/modules/connections/models/did/service/Service.ts
@@ -9,6 +9,10 @@ export class Service {
     }
   }
 
+  public get protocolScheme(): string {
+    return this.serviceEndpoint.split(':')[0]
+  }
+
   @IsString()
   public id!: string
 

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -580,10 +580,6 @@ export class ConnectionService {
       return connection.id === connectionId && connection.state === ConnectionState.Complete
     }
 
-    // Check if already done
-    const connection = await this.connectionRepository.findById(connectionId)
-    if (connection && isConnected(connection)) return connection //TODO: check if this leaves trailing listeners behind?
-
     const promise = new Promise<ConnectionRecord>((resolve) => {
       const listener = ({ payload: { connectionRecord } }: ConnectionStateChangedEvent) => {
         if (isConnected(connectionRecord)) {
@@ -594,6 +590,10 @@ export class ConnectionService {
 
       this.eventEmitter.on<ConnectionStateChangedEvent>(ConnectionEventTypes.ConnectionStateChanged, listener)
     })
+
+    // Check if already done
+    const connection = await this.connectionRepository.findById(connectionId)
+    if (connection && isConnected(connection)) return connection //TODO: check if this leaves trailing listeners behind?
 
     // return listener
     return promise

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -208,7 +208,7 @@ export class RecipientModule {
         routing,
       })
       this.logger.debug('Processed mediation invitation', {
-      	connectionId: invitationConnectionRecord
+        connectionId: invitationConnectionRecord,
       })
       const { message, connectionRecord: connectionRecord } = await this.connectionService.createRequest(
         invitationConnectionRecord.id

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '../../logger'
 import type { ConnectionRecord } from '../connections'
 import type { MediationStateChangedEvent } from './RoutingEvents'
 import type { MediationRecord } from './index'
@@ -11,6 +12,8 @@ import { Dispatcher } from '../../agent/Dispatcher'
 import { EventEmitter } from '../../agent/EventEmitter'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
+import { AriesFrameworkError } from '../../error'
+import { ConnectionInvitationMessage } from '../connections'
 import { ConnectionService } from '../connections/services'
 
 import { MediatorPickupStrategy } from './MediatorPickupStrategy'
@@ -29,6 +32,7 @@ export class RecipientModule {
   private connectionService: ConnectionService
   private messageSender: MessageSender
   private eventEmitter: EventEmitter
+  private logger: Logger
 
   public constructor(
     dispatcher: Dispatcher,
@@ -43,6 +47,7 @@ export class RecipientModule {
     this.mediationRecipientService = mediationRecipientService
     this.messageSender = messageSender
     this.eventEmitter = eventEmitter
+    this.logger = agentConfig.logger
     this.registerHandlers(dispatcher)
   }
 
@@ -178,6 +183,66 @@ export class RecipientModule {
     return event.payload.mediationRecord
   }
 
+  public async provision(mediatorConnInvite: string) {
+    this.logger.debug('Provision Mediation with invitation', { invite: mediatorConnInvite })
+    if (!mediatorConnInvite) {
+      throw new AriesFrameworkError('Mediation provision requires an invitation to be passed')
+    }
+    // Connect to mediator through provided invitation if provided in config
+    // Also requests mediation ans sets as default mediator
+    // Because this requires the connections module, we do this in the agent constructor
+
+    // Assumption: processInvitation is a URL-encoded invitation
+    const invitation = await ConnectionInvitationMessage.fromUrl(mediatorConnInvite)
+    // Check if invitation has been used already
+    if (!invitation || !invitation.recipientKeys || !invitation.recipientKeys[0]) {
+      throw new Error(`Invalid mediation invitation`)
+    }
+    const connection = await this.connectionService.findByInvitationKey(invitation.recipientKeys[0])
+    if (!connection) {
+      this.logger.debug('Mediation Connection does not exist, creating connection')
+      const routing = await this.mediationRecipientService.getRouting()
+
+      const invitationConnectionRecord = await this.connectionService.processInvitation(invitation, {
+        autoAcceptConnection: true,
+        routing: routing,
+      })
+      this.logger.debug('Processed invitation')
+      const { message, connectionRecord: connectionRecord } = await this.connectionService.createRequest(
+        invitationConnectionRecord.id
+      )
+      const outbound = createOutboundMessage(connectionRecord, message)
+      await this.messageSender.sendMessage(outbound)
+
+      // TODO: add timeout to returnWhenIsConnected
+      const completedConnectionRecord = await this.connectionService.returnWhenIsConnected(connectionRecord.id)
+      this.logger.debug('Connection completed, requesting mediation')
+      const mediationRecord = await this.requestAndAwaitGrant(completedConnectionRecord, 60000) // TODO: put timeout as a config parameter
+      this.logger.debug('Mediation Granted, setting as default mediator')
+      await this.setDefaultMediator(mediationRecord)
+      this.logger.debug('Default mediator set')
+      return
+    } else if (connection && !connection.isReady) {
+      const connectionRecord = await this.connectionService.returnWhenIsConnected(connection.id)
+      const mediationRecord = await this.requestAndAwaitGrant(connectionRecord, 60000) // TODO: put timeout as a config parameter
+      await this.setDefaultMediator(mediationRecord)
+      return
+    } else if (connection.isReady) {
+      this.agentConfig.logger.warn('Mediator Invitation in configuration has already been used to create a connection.')
+      const mediator = await this.findByConnectionId(connection.id)
+      if (!mediator) {
+        this.agentConfig.logger.warn('requesting mediation over connection.')
+        const mediationRecord = await this.requestAndAwaitGrant(connection, 60000) // TODO: put timeout as a config parameter
+        await this.setDefaultMediator(mediationRecord)
+      } else {
+        this.agentConfig.logger.warn(
+          `Mediator Invitation in configuration has already been ${
+            mediator.isReady ? 'granted' : 'requested'
+          } mediation`
+        )
+      }
+    }
+  }
   // Register handlers for the several messages for the mediator.
   private registerHandlers(dispatcher: Dispatcher) {
     dispatcher.registerHandler(new KeylistUpdateResponseHandler(this.mediationRecipientService))

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -207,7 +207,9 @@ export class RecipientModule {
         autoAcceptConnection: true,
         routing,
       })
-      this.logger.debug('Processed invitation')
+      this.logger.debug('Processed mediation invitation', {
+      	connectionId: invitationConnectionRecord
+      })
       const { message, connectionRecord: connectionRecord } = await this.connectionService.createRequest(
         invitationConnectionRecord.id
       )

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -185,13 +185,8 @@ export class RecipientModule {
 
   public async provision(mediatorConnInvite: string) {
     this.logger.debug('Provision Mediation with invitation', { invite: mediatorConnInvite })
-    if (!mediatorConnInvite) {
-      throw new AriesFrameworkError('Mediation provision requires an invitation to be passed')
-    }
-    // Connect to mediator through provided invitation if provided in config
-    // Also requests mediation ans sets as default mediator
-    // Because this requires the connections module, we do this in the agent constructor
-
+    // Connect to mediator through provided invitation
+    // Also requests mediation and sets as default mediator
     // Assumption: processInvitation is a URL-encoded invitation
     const invitation = await ConnectionInvitationMessage.fromUrl(mediatorConnInvite)
     // Check if invitation has been used already
@@ -210,9 +205,7 @@ export class RecipientModule {
       this.logger.debug('Processed mediation invitation', {
         connectionId: invitationConnectionRecord,
       })
-      const { message, connectionRecord: connectionRecord } = await this.connectionService.createRequest(
-        invitationConnectionRecord.id
-      )
+      const { message, connectionRecord } = await this.connectionService.createRequest(invitationConnectionRecord.id)
       const outbound = createOutboundMessage(connectionRecord, message)
       await this.messageSender.sendMessage(outbound)
 

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -196,7 +196,7 @@ export class RecipientModule {
     const invitation = await ConnectionInvitationMessage.fromUrl(mediatorConnInvite)
     // Check if invitation has been used already
     if (!invitation || !invitation.recipientKeys || !invitation.recipientKeys[0]) {
-      throw new Error(`Invalid mediation invitation`)
+      throw new AriesFrameworkError(`Invalid mediation invitation. Invitation must have at least one recipient key.`)
     }
     const connection = await this.connectionService.findByInvitationKey(invitation.recipientKeys[0])
     if (!connection) {

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -205,7 +205,7 @@ export class RecipientModule {
 
       const invitationConnectionRecord = await this.connectionService.processInvitation(invitation, {
         autoAcceptConnection: true,
-        routing: routing,
+        routing,
       })
       this.logger.debug('Processed invitation')
       const { message, connectionRecord: connectionRecord } = await this.connectionService.createRequest(

--- a/packages/core/src/modules/routing/__tests__/mediation.test.ts
+++ b/packages/core/src/modules/routing/__tests__/mediation.test.ts
@@ -55,7 +55,7 @@ describe('mediator establishment', () => {
 
     // Initialize mediatorReceived message
     mediatorAgent = new Agent(mediatorConfig.config, recipientConfig.agentDependencies)
-    mediatorAgent.setOutboundTransporter(new SubjectOutboundTransporter(mediatorMessages, subjectMap))
+    mediatorAgent.registerOutboundTransporter(new SubjectOutboundTransporter(mediatorMessages, subjectMap))
     mediatorAgent.setInboundTransporter(new SubjectInboundTransporter(mediatorMessages))
     await mediatorAgent.initialize()
 
@@ -72,7 +72,7 @@ describe('mediator establishment', () => {
       { ...recipientConfig.config, mediatorConnectionsInvite: mediatorInvitation.toUrl() },
       recipientConfig.agentDependencies
     )
-    recipientAgent.setOutboundTransporter(new SubjectOutboundTransporter(recipientMessages, subjectMap))
+    recipientAgent.registerOutboundTransporter(new SubjectOutboundTransporter(recipientMessages, subjectMap))
     recipientAgent.setInboundTransporter(new SubjectInboundTransporter(recipientMessages))
     await recipientAgent.initialize()
 
@@ -94,7 +94,7 @@ describe('mediator establishment', () => {
 
     // Initialize sender agent
     senderAgent = new Agent(senderConfig.config, senderConfig.agentDependencies)
-    senderAgent.setOutboundTransporter(new SubjectOutboundTransporter(senderMessages, subjectMap))
+    senderAgent.registerOutboundTransporter(new SubjectOutboundTransporter(senderMessages, subjectMap))
     senderAgent.setInboundTransporter(new SubjectInboundTransporter(senderMessages))
     await senderAgent.initialize()
 

--- a/packages/core/src/modules/routing/messages/KeylistUpdateMessage.ts
+++ b/packages/core/src/modules/routing/messages/KeylistUpdateMessage.ts
@@ -25,7 +25,7 @@ export class KeylistUpdateMessage extends AgentMessage {
 
   @Equals(KeylistUpdateMessage.type)
   public readonly type = KeylistUpdateMessage.type
-  public static readonly type = 'https://didcomm.org/coordinatemediation/1.0/keylist-update'
+  public static readonly type = 'https://didcomm.org/coordinate-mediation/1.0/keylist-update'
 
   @Type(() => KeylistUpdate)
   @IsArray()

--- a/packages/core/src/modules/routing/messages/KeylistUpdateResponseMessage.ts
+++ b/packages/core/src/modules/routing/messages/KeylistUpdateResponseMessage.ts
@@ -31,7 +31,7 @@ export class KeylistUpdateResponseMessage extends AgentMessage {
 
   @Equals(KeylistUpdateResponseMessage.type)
   public readonly type = KeylistUpdateResponseMessage.type
-  public static readonly type = 'https://didcomm.org/coordinatemediation/1.0/keylist-update-response'
+  public static readonly type = 'https://didcomm.org/coordinate-mediation/1.0/keylist-update-response'
 
   @Type(() => KeylistUpdated)
   @IsArray()

--- a/packages/core/tests/agents.test.ts
+++ b/packages/core/tests/agents.test.ts
@@ -43,12 +43,12 @@ describe('agents', () => {
 
     aliceAgent = new Agent(aliceConfig.config, aliceConfig.agentDependencies)
     aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages))
-    aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages, subjectMap))
+    aliceAgent.registerOutboundTransporter(new SubjectOutboundTransporter(aliceMessages, subjectMap))
     await aliceAgent.initialize()
 
     bobAgent = new Agent(bobConfig.config, bobConfig.agentDependencies)
     bobAgent.setInboundTransporter(new SubjectInboundTransporter(bobMessages))
-    bobAgent.setOutboundTransporter(new SubjectOutboundTransporter(bobMessages, subjectMap))
+    bobAgent.registerOutboundTransporter(new SubjectOutboundTransporter(bobMessages, subjectMap))
     await bobAgent.initialize()
 
     const aliceConnectionAtAliceBob = await aliceAgent.connections.createConnection()

--- a/packages/core/tests/connectionless-credentials.test.ts
+++ b/packages/core/tests/connectionless-credentials.test.ts
@@ -46,12 +46,12 @@ describe('credentials', () => {
     }
     faberAgent = new Agent(faberConfig.config, faberConfig.agentDependencies)
     faberAgent.setInboundTransporter(new SubjectInboundTransporter(faberMessages))
-    faberAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages, subjectMap))
+    faberAgent.registerOutboundTransporter(new SubjectOutboundTransporter(aliceMessages, subjectMap))
     await faberAgent.initialize()
 
     aliceAgent = new Agent(aliceConfig.config, aliceConfig.agentDependencies)
     aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages))
-    aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages, subjectMap))
+    aliceAgent.registerOutboundTransporter(new SubjectOutboundTransporter(faberMessages, subjectMap))
     await aliceAgent.initialize()
 
     const { definition } = await prepareForIssuance(faberAgent, ['name', 'age'])

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -539,12 +539,12 @@ export async function setupCredentialTests(
   })
   const faberAgent = new Agent(faberConfig.config, faberConfig.agentDependencies)
   faberAgent.setInboundTransporter(new SubjectInboundTransporter(faberMessages))
-  faberAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages, subjectMap))
+  faberAgent.registerOutboundTransporter(new SubjectOutboundTransporter(aliceMessages, subjectMap))
   await faberAgent.initialize()
 
   const aliceAgent = new Agent(aliceConfig.config, aliceConfig.agentDependencies)
   aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages))
-  aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages, subjectMap))
+  aliceAgent.registerOutboundTransporter(new SubjectOutboundTransporter(faberMessages, subjectMap))
   await aliceAgent.initialize()
 
   const {
@@ -586,12 +586,12 @@ export async function setupProofsTest(faberName: string, aliceName: string, auto
   }
   const faberAgent = new Agent(faberConfig.config, faberConfig.agentDependencies)
   faberAgent.setInboundTransporter(new SubjectInboundTransporter(faberMessages))
-  faberAgent.setOutboundTransporter(new SubjectOutboundTransporter(aliceMessages, subjectMap))
+  faberAgent.registerOutboundTransporter(new SubjectOutboundTransporter(aliceMessages, subjectMap))
   await faberAgent.initialize()
 
   const aliceAgent = new Agent(aliceConfig.config, aliceConfig.agentDependencies)
   aliceAgent.setInboundTransporter(new SubjectInboundTransporter(aliceMessages))
-  aliceAgent.setOutboundTransporter(new SubjectOutboundTransporter(faberMessages, subjectMap))
+  aliceAgent.registerOutboundTransporter(new SubjectOutboundTransporter(faberMessages, subjectMap))
   await aliceAgent.initialize()
 
   const { definition } = await prepareForIssuance(faberAgent, ['name', 'age', 'image_0', 'image_1'])

--- a/samples/mediator-ws.ts
+++ b/samples/mediator-ws.ts
@@ -29,7 +29,7 @@ const config = agent.injectionContainer.resolve(AgentConfig)
 const messageSender = new WsOutboundTransporter()
 const messageReceiver = new WsInboundTransport({ server: socketServer })
 agent.setInboundTransporter(messageReceiver)
-agent.setOutboundTransporter(messageSender)
+agent.registerOutboundTransporter(messageSender)
 
 // Allow to create invitation, no other way to ask for invitation yet
 app.get('/invitation', async (req, res) => {

--- a/samples/mediator.ts
+++ b/samples/mediator.ts
@@ -31,7 +31,7 @@ const inboundTransporter = new HttpInboundTransport({ port })
 const outboundTransporter = new HttpOutboundTransporter()
 
 agent.setInboundTransporter(inboundTransporter)
-agent.setOutboundTransporter(outboundTransporter)
+agent.registerOutboundTransporter(outboundTransporter)
 
 // Allow to create invitation, no other way to ask for invitation yet
 inboundTransporter.app.get('/invitation', async (req, res) => {

--- a/tests/e2e-http.test.ts
+++ b/tests/e2e-http.test.ts
@@ -41,17 +41,17 @@ describe('E2E HTTP tests', () => {
 
   test('Full HTTP flow (connect, request mediation, issue, verify)', async () => {
     // Recipient Setup
-    recipientAgent.setOutboundTransporter(new HttpOutboundTransporter())
+    recipientAgent.registerOutboundTransporter(new HttpOutboundTransporter())
     await recipientAgent.initialize()
 
     // Mediator Setup
     mediatorAgent.setInboundTransporter(new HttpInboundTransport({ port: mediatorPort }))
-    mediatorAgent.setOutboundTransporter(new HttpOutboundTransporter())
+    mediatorAgent.registerOutboundTransporter(new HttpOutboundTransporter())
     await mediatorAgent.initialize()
 
     // Sender Setup
     senderAgent.setInboundTransporter(new HttpInboundTransport({ port: senderPort }))
-    senderAgent.setOutboundTransporter(new HttpOutboundTransporter())
+    senderAgent.registerOutboundTransporter(new HttpOutboundTransporter())
     await senderAgent.initialize()
 
     await e2eTest({

--- a/tests/e2e-subject.test.ts
+++ b/tests/e2e-subject.test.ts
@@ -51,17 +51,17 @@ describe('E2E Subject tests', () => {
     }
 
     // Recipient Setup
-    recipientAgent.setOutboundTransporter(new SubjectOutboundTransporter(recipientMessages, subjectMap))
+    recipientAgent.registerOutboundTransporter(new SubjectOutboundTransporter(recipientMessages, subjectMap))
     recipientAgent.setInboundTransporter(new SubjectInboundTransporter(recipientMessages))
     await recipientAgent.initialize()
 
     // Mediator Setup
-    mediatorAgent.setOutboundTransporter(new SubjectOutboundTransporter(mediatorMessages, subjectMap))
+    mediatorAgent.registerOutboundTransporter(new SubjectOutboundTransporter(mediatorMessages, subjectMap))
     mediatorAgent.setInboundTransporter(new SubjectInboundTransporter(mediatorMessages))
     await mediatorAgent.initialize()
 
     // Sender Setup
-    senderAgent.setOutboundTransporter(new SubjectOutboundTransporter(senderMessages, subjectMap))
+    senderAgent.registerOutboundTransporter(new SubjectOutboundTransporter(senderMessages, subjectMap))
     senderAgent.setInboundTransporter(new SubjectInboundTransporter(senderMessages))
     await senderAgent.initialize()
 

--- a/tests/e2e-ws.test.ts
+++ b/tests/e2e-ws.test.ts
@@ -41,17 +41,17 @@ describe('E2E WS tests', () => {
 
   test('Full WS flow (connect, request mediation, issue, verify)', async () => {
     // Recipient Setup
-    recipientAgent.setOutboundTransporter(new WsOutboundTransporter())
+    recipientAgent.registerOutboundTransporter(new WsOutboundTransporter())
     await recipientAgent.initialize()
 
     // Mediator Setup
     mediatorAgent.setInboundTransporter(new WsInboundTransport({ port: mediatorPort }))
-    mediatorAgent.setOutboundTransporter(new WsOutboundTransporter())
+    mediatorAgent.registerOutboundTransporter(new WsOutboundTransporter())
     await mediatorAgent.initialize()
 
     // Sender Setup
     senderAgent.setInboundTransporter(new WsInboundTransport({ port: senderPort }))
-    senderAgent.setOutboundTransporter(new WsOutboundTransporter())
+    senderAgent.registerOutboundTransporter(new WsOutboundTransporter())
     await senderAgent.initialize()
 
     await e2eTest({

--- a/tests/transport/SubjectOutboundTransport.ts
+++ b/tests/transport/SubjectOutboundTransport.ts
@@ -11,7 +11,7 @@ export class SubjectOutboundTransporter implements OutboundTransporter {
   private ourSubject: Subject<SubjectMessage>
   private subjectMap: { [key: string]: Subject<SubjectMessage> | undefined }
 
-  public supportedSchemes = []
+  public supportedSchemes = ['rxjs']
 
   public constructor(
     ourSubject: Subject<SubjectMessage>,


### PR DESCRIPTION
This PR has code that corrects issues related to mediation.
Corrections
- multiple restarts with the same mediation invitation 
- second sorting of connection transport services based on inbound services
- multiple outbound transport support
  - add transport is now register transport, which allows using multiple types of transport.