### PR TITLE
feat: add from record method to cred preview

### DIFF
--- a/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
@@ -1,6 +1,7 @@
 import type { ConnectionService } from '../../connections/services/ConnectionService'
 import type { StoreCredentialOptions } from '../../indy/services/IndyHolderService'
 import type { CredentialStateChangedEvent } from '../CredentialEvents'
+import type { CredentialPreviewAttribute } from '../messages'
 import type { CredentialRecordMetadata, CustomCredentialTags } from '../repository/CredentialRecord'
 import type { CredentialOfferTemplate } from '../services'
 
@@ -21,7 +22,6 @@ import { CredentialUtils } from '../CredentialUtils'
 import {
   CredentialAckMessage,
   CredentialPreview,
-  CredentialPreviewAttribute,
   INDY_CREDENTIAL_ATTACHMENT_ID,
   INDY_CREDENTIAL_OFFER_ATTACHMENT_ID,
   INDY_CREDENTIAL_REQUEST_ATTACHMENT_ID,
@@ -52,19 +52,9 @@ const connection = getMockConnection({
   state: ConnectionState.Complete,
 })
 
-const credentialPreview = new CredentialPreview({
-  attributes: [
-    new CredentialPreviewAttribute({
-      name: 'name',
-      mimeType: 'text/plain',
-      value: 'John',
-    }),
-    new CredentialPreviewAttribute({
-      name: 'age',
-      mimeType: 'text/plain',
-      value: '99',
-    }),
-  ],
+const credentialPreview = CredentialPreview.fromRecord({
+  name: 'John',
+  age: '99',
 })
 
 const offerAttachment = new Attachment({

--- a/packages/core/src/modules/credentials/messages/CredentialPreview.ts
+++ b/packages/core/src/modules/credentials/messages/CredentialPreview.ts
@@ -33,6 +33,29 @@ export class CredentialPreview {
   public toJSON(): Record<string, unknown> {
     return JsonTransformer.toJSON(this)
   }
+
+  /**
+   * Create a credential preview from a record with name and value entries.
+   *
+   * @example
+   * const preview = CredentialPreview.fromRecord({
+   *   name: "Bob",
+   *   age: "20"
+   * })
+   */
+  public fromRecord(record: Record<string, string>) {
+    const attributes = Object.entries(record).map(
+      ([name, value]) =>
+        new CredentialPreviewAttribute({
+          name,
+          value,
+        })
+    )
+
+    return new CredentialPreview({
+      attributes,
+    })
+  }
 }
 
 interface CredentialPreviewAttributeOptions {

--- a/packages/core/src/modules/credentials/messages/CredentialPreview.ts
+++ b/packages/core/src/modules/credentials/messages/CredentialPreview.ts
@@ -43,7 +43,7 @@ export class CredentialPreview {
    *   age: "20"
    * })
    */
-  public fromRecord(record: Record<string, string>) {
+  public static fromRecord(record: Record<string, string>) {
     const attributes = Object.entries(record).map(
       ([name, value]) =>
         new CredentialPreviewAttribute({

--- a/packages/core/src/modules/credentials/messages/CredentialPreview.ts
+++ b/packages/core/src/modules/credentials/messages/CredentialPreview.ts
@@ -48,6 +48,7 @@ export class CredentialPreview {
       ([name, value]) =>
         new CredentialPreviewAttribute({
           name,
+          mimeType: 'text/plain',
           value,
         })
     )

--- a/packages/core/src/modules/ledger/LedgerModule.ts
+++ b/packages/core/src/modules/ledger/LedgerModule.ts
@@ -47,14 +47,19 @@ export class LedgerModule {
     return this.ledgerService.getSchema(id)
   }
 
-  public async registerCredentialDefinition(credentialDefinitionTemplate: CredentialDefinitionTemplate) {
+  public async registerCredentialDefinition(
+    credentialDefinitionTemplate: Omit<CredentialDefinitionTemplate, 'signatureType'>
+  ) {
     const did = this.wallet.publicDid?.did
 
     if (!did) {
       throw new AriesFrameworkError('Agent has no public DID.')
     }
 
-    return this.ledgerService.registerCredentialDefinition(did, credentialDefinitionTemplate)
+    return this.ledgerService.registerCredentialDefinition(did, {
+      ...credentialDefinitionTemplate,
+      signatureType: 'CL',
+    })
   }
 
   public async getCredentialDefinition(id: string) {

--- a/packages/core/tests/connectionless-credentials.test.ts
+++ b/packages/core/tests/connectionless-credentials.test.ts
@@ -7,13 +7,14 @@ import { SubjectInboundTransporter } from '../../../tests/transport/SubjectInbou
 import { SubjectOutboundTransporter } from '../../../tests/transport/SubjectOutboundTransport'
 import { Agent } from '../src/agent/Agent'
 import {
+  CredentialPreview,
   AutoAcceptCredential,
   CredentialEventTypes,
   CredentialRecord,
   CredentialState,
 } from '../src/modules/credentials'
 
-import { getBaseConfig, previewFromAttributes, prepareForIssuance, waitForCredentialRecordSubject } from './helpers'
+import { getBaseConfig, prepareForIssuance, waitForCredentialRecordSubject } from './helpers'
 import testLogger from './logger'
 
 const faberConfig = getBaseConfig('Faber connection-less Credentials', {
@@ -24,7 +25,7 @@ const aliceConfig = getBaseConfig('Alice connection-less Credentials', {
   endpoint: 'rxjs:alice',
 })
 
-const credentialPreview = previewFromAttributes({
+const credentialPreview = CredentialPreview.fromRecord({
   name: 'John',
   age: '99',
 })

--- a/packages/core/tests/credentials-auto-accept.test.ts
+++ b/packages/core/tests/credentials-auto-accept.test.ts
@@ -1,19 +1,19 @@
 import type { Agent } from '../src/agent/Agent'
 import type { ConnectionRecord } from '../src/modules/connections'
 
-import { AutoAcceptCredential, CredentialRecord, CredentialState } from '../src/modules/credentials'
+import { AutoAcceptCredential, CredentialPreview, CredentialRecord, CredentialState } from '../src/modules/credentials'
 import { JsonTransformer } from '../src/utils/JsonTransformer'
 import { sleep } from '../src/utils/sleep'
 
-import { previewFromAttributes, setupCredentialTests, waitForCredentialRecord } from './helpers'
+import { setupCredentialTests, waitForCredentialRecord } from './helpers'
 import testLogger from './logger'
 
-const credentialPreview = previewFromAttributes({
+const credentialPreview = CredentialPreview.fromRecord({
   name: 'John',
   age: '99',
 })
 
-const newCredentialPreview = previewFromAttributes({
+const newCredentialPreview = CredentialPreview.fromRecord({
   name: 'John',
   age: '99',
   lastname: 'Appleseed',

--- a/packages/core/tests/credentials.test.ts
+++ b/packages/core/tests/credentials.test.ts
@@ -2,31 +2,16 @@ import type { Agent } from '../src/agent/Agent'
 import type { ConnectionRecord } from '../src/modules/connections'
 
 import { Attachment, AttachmentData } from '../src/decorators/attachment/Attachment'
-import {
-  CredentialPreview,
-  CredentialPreviewAttribute,
-  CredentialRecord,
-  CredentialState,
-} from '../src/modules/credentials'
+import { CredentialPreview, CredentialRecord, CredentialState } from '../src/modules/credentials'
 import { JsonTransformer } from '../src/utils/JsonTransformer'
 import { LinkedAttachment } from '../src/utils/LinkedAttachment'
 
 import { setupCredentialTests, waitForCredentialRecord } from './helpers'
 import testLogger from './logger'
 
-const credentialPreview = new CredentialPreview({
-  attributes: [
-    new CredentialPreviewAttribute({
-      name: 'name',
-      mimeType: 'text/plain',
-      value: 'John',
-    }),
-    new CredentialPreviewAttribute({
-      name: 'age',
-      mimeType: 'text/plain',
-      value: '99',
-    }),
-  ],
+const credentialPreview = CredentialPreview.fromRecord({
+  name: 'John',
+  age: '99',
 })
 
 describe('credentials', () => {

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -34,7 +34,6 @@ import {
   ConnectionState,
   CredentialEventTypes,
   CredentialPreview,
-  CredentialPreviewAttribute,
   CredentialState,
   DidCommService,
   DidDoc,

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -284,18 +284,6 @@ export async function registerDefinition(
   return credentialDefinition
 }
 
-export function previewFromAttributes(attributes: Record<string, string>): CredentialPreview {
-  return new CredentialPreview({
-    attributes: Object.entries(attributes).map(
-      ([name, value]) =>
-        new CredentialPreviewAttribute({
-          name,
-          value,
-        })
-    ),
-  })
-}
-
 export async function prepareForIssuance(agent: Agent, attributes: string[]) {
   const publicDid = agent.publicDid?.did
 
@@ -558,7 +546,7 @@ export async function setupCredentialTests(
 }
 
 export async function setupProofsTest(faberName: string, aliceName: string, autoAcceptProofs?: AutoAcceptProof) {
-  const credentialPreview = previewFromAttributes({
+  const credentialPreview = CredentialPreview.fromRecord({
     name: 'John',
     age: '99',
   })

--- a/tests/e2e-test.ts
+++ b/tests/e2e-test.ts
@@ -1,14 +1,9 @@
 import type { Agent } from '@aries-framework/core'
 
-import {
-  issueCredential,
-  makeConnection,
-  prepareForIssuance,
-  presentProof,
-  previewFromAttributes,
-} from '../packages/core/tests/helpers'
+import { issueCredential, makeConnection, prepareForIssuance, presentProof } from '../packages/core/tests/helpers'
 
 import {
+  CredentialPreview,
   AttributeFilter,
   CredentialState,
   MediationState,
@@ -53,7 +48,7 @@ export async function e2eTest({
     issuerConnectionId: senderRecipientConnection.id,
     credentialTemplate: {
       credentialDefinitionId: definition.id,
-      preview: previewFromAttributes({
+      preview: CredentialPreview.fromRecord({
         name: 'John',
         age: '25',
         // year month day


### PR DESCRIPTION
Two api improvements
1. register credential definition doesn't require `signatureType` parameter anymore (just add bloat to the API)
2. add `fromRecord` method to credential preview to be able to create a preview from json object. this makes it a lot simpler:


Before 

```ts
const credentialPreview = new CredentialPreview({
  attributes: [
    new CredentialPreviewAttribute({
      name: 'name',
      mimeType: 'text/plain',
      value: 'John',
    }),
    new CredentialPreviewAttribute({
      name: 'age',
      mimeType: 'text/plain',
      value: '99',
    }),
  ],
})
```

After

```ts
const credentialPreview = CredentialPreview.fromRecord({
  name: 'John',
  age: '99',
})
```