### PR TITLE
fix: legacy did:sov prefix on invitation

### DIFF
--- a/packages/core/src/modules/connections/__tests__/ConnectionInvitationMessage.test.ts
+++ b/packages/core/src/modules/connections/__tests__/ConnectionInvitationMessage.test.ts
@@ -1,5 +1,6 @@
 import { validateOrReject } from 'class-validator'
 
+import { JsonEncoder } from '../../../utils/JsonEncoder'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
 import { ConnectionInvitationMessage } from '../messages/ConnectionInvitationMessage'
 
@@ -41,5 +42,43 @@ describe('ConnectionInvitationMessage', () => {
 
     // Assert validation also works with the transformation
     await expect(validateOrReject(invitation)).resolves.toBeUndefined()
+  })
+
+  describe('toUrl', () => {
+    it('should correctly include the base64 encoded invitation in the url as the c_i query parameter', async () => {
+      const domain = 'https://example.com/ssi'
+      const json = {
+        '@type': 'https://didcomm.org/connections/1.0/invitation',
+        '@id': '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+        recipientKeys: ['recipientKeyOne', 'recipientKeyTwo'],
+        serviceEndpoint: 'https://example.com',
+        label: 'test',
+      }
+      const invitation = JsonTransformer.fromJSON(json, ConnectionInvitationMessage)
+      const invitationUrl = invitation.toUrl({
+        domain,
+      })
+
+      expect(invitationUrl).toBe(`${domain}?c_i=${JsonEncoder.toBase64URL(json)}`)
+    })
+
+    it('should use did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation as type if useLegacyDidSovPrefix is set to true', async () => {
+      const invitation = new ConnectionInvitationMessage({
+        id: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+        recipientKeys: ['recipientKeyOne', 'recipientKeyTwo'],
+        serviceEndpoint: 'https://example.com',
+        label: 'test',
+      })
+
+      const invitationUrl = invitation.toUrl({
+        domain: 'example.com',
+        useLegacyDidSovPrefix: true,
+      })
+
+      const [, encodedInvitation] = invitationUrl.split('?c_i=')
+      expect(JsonEncoder.fromBase64(encodedInvitation)['@type']).toBe(
+        'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.0/invitation'
+      )
+    })
   })
 })

--- a/packages/core/src/modules/connections/messages/ConnectionInvitationMessage.ts
+++ b/packages/core/src/modules/connections/messages/ConnectionInvitationMessage.ts
@@ -5,7 +5,7 @@ import { AgentMessage } from '../../../agent/AgentMessage'
 import { AriesFrameworkError } from '../../../error'
 import { JsonEncoder } from '../../../utils/JsonEncoder'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
-import { replaceLegacyDidSovPrefix } from '../../../utils/messageType'
+import { replaceLegacyDidSovPrefix, replaceNewDidCommPrefixWithLegacyDidSovOnMessage } from '../../../utils/messageType'
 
 // TODO: improve typing of `DIDInvitationData` and `InlineInvitationData` so properties can't be mixed
 export interface InlineInvitationData {
@@ -91,8 +91,19 @@ export class ConnectionInvitationMessage extends AgentMessage {
    * @param domain domain name to use for invitation url
    * @returns invitation url with base64 encoded invitation
    */
-  public toUrl(domain = 'https://example.com/ssi') {
+  public toUrl({
+    domain = 'https://example.com/ssi',
+    useLegacyDidSovPrefix = false,
+  }: {
+    domain: string
+    useLegacyDidSovPrefix?: boolean
+  }) {
     const invitationJson = this.toJSON()
+
+    if (useLegacyDidSovPrefix) {
+      replaceNewDidCommPrefixWithLegacyDidSovOnMessage(invitationJson)
+    }
+
     const encodedInvitation = JsonEncoder.toBase64URL(invitationJson)
     const invitationUrl = `${domain}?c_i=${encodedInvitation}`
 

--- a/packages/core/src/modules/connections/messages/ConnectionInvitationMessage.ts
+++ b/packages/core/src/modules/connections/messages/ConnectionInvitationMessage.ts
@@ -91,13 +91,7 @@ export class ConnectionInvitationMessage extends AgentMessage {
    * @param domain domain name to use for invitation url
    * @returns invitation url with base64 encoded invitation
    */
-  public toUrl({
-    domain = 'https://example.com/ssi',
-    useLegacyDidSovPrefix = false,
-  }: {
-    domain: string
-    useLegacyDidSovPrefix?: boolean
-  }) {
+  public toUrl({ domain, useLegacyDidSovPrefix = false }: { domain: string; useLegacyDidSovPrefix?: boolean }) {
     const invitationJson = this.toJSON()
 
     if (useLegacyDidSovPrefix) {

--- a/packages/core/src/modules/routing/__tests__/mediation.test.ts
+++ b/packages/core/src/modules/routing/__tests__/mediation.test.ts
@@ -69,7 +69,12 @@ describe('mediator establishment', () => {
 
     // Initialize recipient with mediation connections invitation
     recipientAgent = new Agent(
-      { ...recipientConfig.config, mediatorConnectionsInvite: mediatorInvitation.toUrl() },
+      {
+        ...recipientConfig.config,
+        mediatorConnectionsInvite: mediatorInvitation.toUrl({
+          domain: 'https://example.com/ssi',
+        }),
+      },
       recipientConfig.agentDependencies
     )
     recipientAgent.registerOutboundTransport(new SubjectOutboundTransport(recipientMessages, subjectMap))
@@ -109,7 +114,9 @@ describe('mediator establishment', () => {
     expect(recipientInvitation.serviceEndpoint).toBe(endpoints[0])
 
     let senderRecipientConnection = await senderAgent.connections.receiveInvitationFromUrl(
-      recipientInvitation.toUrl(),
+      recipientInvitation.toUrl({
+        domain: 'https://example.com/ssi',
+      }),
       {
         autoAcceptConnection: true,
       }
@@ -163,7 +170,10 @@ describe('mediator establishment', () => {
 
     // Initialize recipient with mediation connections invitation
     recipientAgent = new Agent(
-      { ...recipientConfig.config, mediatorConnectionsInvite: mediatorInvitation.toUrl() },
+      {
+        ...recipientConfig.config,
+        mediatorConnectionsInvite: mediatorInvitation.toUrl({ domain: 'https://example.com/ssi' }),
+      },
       recipientConfig.agentDependencies
     )
     recipientAgent.registerOutboundTransport(new SubjectOutboundTransport(recipientMessages, subjectMap))
@@ -189,7 +199,12 @@ describe('mediator establishment', () => {
     // Restart recipient agent
     await recipientAgent.shutdown()
     recipientAgent = new Agent(
-      { ...recipientConfig.config, mediatorConnectionsInvite: mediatorInvitation.toUrl() },
+      {
+        ...recipientConfig.config,
+        mediatorConnectionsInvite: mediatorInvitation.toUrl({
+          domain: 'https://example.com/ssi',
+        }),
+      },
       recipientConfig.agentDependencies
     )
     recipientAgent.registerOutboundTransport(new SubjectOutboundTransport(recipientMessages, subjectMap))
@@ -213,7 +228,9 @@ describe('mediator establishment', () => {
     expect(recipientInvitation.serviceEndpoint).toBe(endpoints[0])
 
     let senderRecipientConnection = await senderAgent.connections.receiveInvitationFromUrl(
-      recipientInvitation.toUrl(),
+      recipientInvitation.toUrl({
+        domain: 'https://example.com/ssi',
+      }),
       {
         autoAcceptConnection: true,
       }

--- a/packages/core/src/utils/messageType.ts
+++ b/packages/core/src/utils/messageType.ts
@@ -1,7 +1,7 @@
 import type { UnpackedMessage } from '../types'
 
-export function replaceLegacyDidSovPrefixOnMessage(message: UnpackedMessage) {
-  message['@type'] = replaceLegacyDidSovPrefix(message['@type'])
+export function replaceLegacyDidSovPrefixOnMessage(message: UnpackedMessage | Record<string, unknown>) {
+  message['@type'] = replaceLegacyDidSovPrefix(message['@type'] as string)
 }
 
 export function replaceNewDidCommPrefixWithLegacyDidSovOnMessage(message: Record<string, unknown>) {

--- a/samples/mediator.ts
+++ b/samples/mediator.ts
@@ -77,7 +77,7 @@ httpInboundTransport.app.get('/invitation', async (req, res) => {
     const { invitation } = await agent.connections.createConnection()
 
     const httpEndpoint = config.endpoints.find((e) => e.startsWith('http'))
-    res.send(invitation.toUrl(httpEndpoint + '/invitation'))
+    res.send(invitation.toUrl({ domain: httpEndpoint + '/invitation' }))
   }
 })
 


### PR DESCRIPTION
Addition to #442 where we forgot to also transform the invitation `@type`. 

This is required to interop with agents that don't support the https://didcomm.org message type prefix yet (e.g. Trinsic wallet)

Signed-off-by: Timo Glastra <timo@animo.id>