### PR TITLE
fix(core): handle undefined requested attributes and requested predicates

### DIFF
--- a/packages/core/src/modules/proofs/services/ProofService.ts
+++ b/packages/core/src/modules/proofs/services/ProofService.ts
@@ -911,7 +911,13 @@ export class ProofService {
       ...Object.values(requestedCredentials.requestedAttributes),
       ...Object.values(requestedCredentials.requestedPredicates),
     ]
-      .filter((c) => c !== undefined && c !== null)
+      .filter((c) => {
+        const isDefined = c !== undefined && c !== null
+        if (!isDefined) {
+          this.logger.warn('Received an undefined attribute or predicate')
+        }
+        return isDefined
+      })
       .map((c) => c.credentialInfo)
 
     const schemas = await this.getSchemas(new Set(credentialObjects.map((c) => c.schemaId)))

--- a/packages/core/src/modules/proofs/services/ProofService.ts
+++ b/packages/core/src/modules/proofs/services/ProofService.ts
@@ -659,9 +659,11 @@ export class ProofService {
       requestedAttributesNames.push(...(requestedAttributes.names ?? [requestedAttributes.name]))
 
       // Find the attributes that have a hashlink as a value
-      for (const attribute of Object.values(requestedAttribute.credentialInfo.attributes)) {
-        if (attribute.toLowerCase().startsWith('hl:')) {
-          credentialIds.add(requestedAttribute.credentialId)
+      if (requestedAttribute) {
+        for (const attribute of Object.values(requestedAttribute.credentialInfo.attributes)) {
+          if (attribute.toLowerCase().startsWith('hl:')) {
+            credentialIds.add(requestedAttribute.credentialId)
+          }
         }
       }
     }
@@ -908,7 +910,9 @@ export class ProofService {
     const credentialObjects = [
       ...Object.values(requestedCredentials.requestedAttributes),
       ...Object.values(requestedCredentials.requestedPredicates),
-    ].map((c) => c.credentialInfo)
+    ]
+      .filter(Boolean)
+      .map((c) => c.credentialInfo)
 
     const schemas = await this.getSchemas(new Set(credentialObjects.map((c) => c.schemaId)))
     const credentialDefinitions = await this.getCredentialDefinitions(

--- a/packages/core/src/modules/proofs/services/ProofService.ts
+++ b/packages/core/src/modules/proofs/services/ProofService.ts
@@ -911,7 +911,7 @@ export class ProofService {
       ...Object.values(requestedCredentials.requestedAttributes),
       ...Object.values(requestedCredentials.requestedPredicates),
     ]
-      .filter(Boolean)
+      .filter((c) => c !== undefined && c !== null)
       .map((c) => c.credentialInfo)
 
     const schemas = await this.getSchemas(new Set(credentialObjects.map((c) => c.schemaId)))


### PR DESCRIPTION
I had some issues with accepting a proof request that did not contain requested attributes (but only predicates or self attested attributes).

This should resolve this issue.

Signed-off-by: Berend Sliedrecht <berend@animo.id>