### PR TITLE
build: fixed setup when using ngrok

### DIFF
--- a/scripts/ngrok-wait.sh
+++ b/scripts/ngrok-wait.sh
@@ -17,5 +17,5 @@ done
 
 echo "fetched end point [$ENDPOINT]"
 
-export AGENT_ENDPOINT=$ENDPOINT
+export AGENT_ENDPOINTS=$ENDPOINT
 exec "$@"


### PR DESCRIPTION
Fixed the env var name to properly set Agent's endpoints when using ngrok