### PR TITLE
feat(core): support image url in invitations

### DIFF
--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -115,4 +115,8 @@ export class AgentConfig {
   public get useLegacyDidSovPrefix() {
     return this.initConfig.useLegacyDidSovPrefix ?? false
   }
+
+  public get connectionImageUrl() {
+    return this.initConfig.connectionImageUrl
+  }
 }

--- a/packages/core/src/modules/connections/messages/ConnectionRequestMessage.ts
+++ b/packages/core/src/modules/connections/messages/ConnectionRequestMessage.ts
@@ -1,7 +1,7 @@
 import type { DidDoc } from '../models'
 
 import { Type } from 'class-transformer'
-import { Equals, IsString, ValidateNested } from 'class-validator'
+import { Equals, IsOptional, IsString, IsUrl, ValidateNested } from 'class-validator'
 
 import { AgentMessage } from '../../../agent/AgentMessage'
 import { Connection } from '../models'
@@ -11,10 +11,11 @@ export interface ConnectionRequestMessageOptions {
   label: string
   did: string
   didDoc?: DidDoc
+  imageUrl?: string
 }
 
 /**
- * Message to communicate the DID document to the other agent when creating a connectino
+ * Message to communicate the DID document to the other agent when creating a connection
  *
  * @see https://github.com/hyperledger/aries-rfcs/blob/master/features/0160-connection-protocol/README.md#1-connection-request
  */
@@ -29,6 +30,7 @@ export class ConnectionRequestMessage extends AgentMessage {
     if (options) {
       this.id = options.id || this.generateId()
       this.label = options.label
+      this.imageUrl = options.imageUrl
 
       this.connection = new Connection({
         did: options.did,
@@ -47,4 +49,8 @@ export class ConnectionRequestMessage extends AgentMessage {
   @Type(() => Connection)
   @ValidateNested()
   public connection!: Connection
+
+  @IsOptional()
+  @IsUrl()
+  public imageUrl?: string
 }

--- a/packages/core/src/modules/connections/repository/ConnectionRecord.ts
+++ b/packages/core/src/modules/connections/repository/ConnectionRecord.ts
@@ -26,6 +26,7 @@ export interface ConnectionRecordProps {
   autoAcceptConnection?: boolean
   threadId?: string
   tags?: CustomConnectionTags
+  imageUrl?: string
 }
 
 export type CustomConnectionTags = TagsBase
@@ -59,6 +60,7 @@ export class ConnectionRecord
   public invitation?: ConnectionInvitationMessage
   public alias?: string
   public autoAcceptConnection?: boolean
+  public imageUrl?: string
 
   public threadId?: string
 
@@ -84,6 +86,7 @@ export class ConnectionRecord
       this._tags = props.tags ?? {}
       this.invitation = props.invitation
       this.threadId = props.threadId
+      this.imageUrl = props.imageUrl
     }
   }
 

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -85,6 +85,7 @@ export class ConnectionService {
       recipientKeys: service.recipientKeys,
       serviceEndpoint: service.serviceEndpoint,
       routingKeys: service.routingKeys,
+      imageUrl: this.config.connectionImageUrl,
     })
 
     connectionRecord.invitation = invitation
@@ -127,6 +128,7 @@ export class ConnectionService {
       autoAcceptConnection: config?.autoAcceptConnection,
       routing: config.routing,
       invitation,
+      imageUrl: invitation.imageUrl,
       tags: {
         invitationKey: invitation.recipientKeys && invitation.recipientKeys[0],
       },
@@ -159,6 +161,7 @@ export class ConnectionService {
       label: this.config.label,
       did: connectionRecord.did,
       didDoc: connectionRecord.didDoc,
+      imageUrl: this.config.connectionImageUrl,
     })
 
     await this.updateState(connectionRecord, ConnectionState.Requested)
@@ -198,6 +201,7 @@ export class ConnectionService {
     connectionRecord.theirLabel = message.label
     connectionRecord.threadId = message.id
     connectionRecord.theirDid = message.connection.did
+    connectionRecord.imageUrl = message.imageUrl
 
     if (!connectionRecord.theirKey) {
       throw new AriesFrameworkError(`Connection with id ${connectionRecord.id} has no recipient keys.`)
@@ -534,6 +538,7 @@ export class ConnectionService {
     theirLabel?: string
     autoAcceptConnection?: boolean
     tags?: CustomConnectionTags
+    imageUrl?: string
   }): Promise<ConnectionRecord> {
     const { endpoints, did, verkey, routingKeys } = options.routing
 
@@ -579,6 +584,7 @@ export class ConnectionService {
       alias: options.alias,
       theirLabel: options.theirLabel,
       autoAcceptConnection: options.autoAcceptConnection,
+      imageUrl: options.imageUrl,
     })
 
     await this.connectionRepository.save(connectionRecord)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -47,6 +47,7 @@ export interface InitConfig {
   mediatorPickupStrategy?: MediatorPickupStrategy
 
   useLegacyDidSovPrefix?: boolean
+  connectionImageUrl?: string
 }
 
 export interface UnpackedMessage {


### PR DESCRIPTION
non-standard approach for showing images with connections. Almost all wallets and implementations support this (ACA-Py, AF.NET, Connect.Me, Lissi, Trinsic, etc...)

Signed-off-by: Timo Glastra <timo@animo.id>