### PR TITLE
feat(core): support multiple indy ledgers

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "express": "^4.17.1",
     "husky": "^7.0.1",
+    "indy-sdk": "^1.16.0-dev-1636",
     "jest": "^27.0.4",
     "lerna": "^4.0.0",
     "prettier": "^2.3.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
+    "@multiformats/base-x": "^4.0.1",
     "@types/indy-sdk": "^1.16.6",
     "@types/node-fetch": "^2.5.10",
     "@types/ws": "^7.4.4",

--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -46,16 +46,8 @@ export class AgentConfig {
     return this.initConfig.publicDidSeed
   }
 
-  public get poolName() {
-    return this.initConfig.poolName ?? 'default-pool'
-  }
-
-  public get genesisPath() {
-    return this.initConfig.genesisPath
-  }
-
-  public get genesisTransactions() {
-    return this.initConfig.genesisTransactions
+  public get indyLedgers() {
+    return this.initConfig.indyLedgers ?? []
   }
 
   public get walletConfig() {

--- a/packages/core/src/modules/ledger/IndyPool.ts
+++ b/packages/core/src/modules/ledger/IndyPool.ts
@@ -1,0 +1,170 @@
+import type { AgentConfig } from '../../agent/AgentConfig'
+import type { Logger } from '../../logger'
+import type { FileSystem } from '../../storage/FileSystem'
+import type * as Indy from 'indy-sdk'
+
+import { AriesFrameworkError, IndySdkError } from '../../error'
+import { isIndyError } from '../../utils/indyError'
+
+import { LedgerError } from './error/LedgerError'
+import { isLedgerRejectResponse } from './ledgerUtil'
+
+export interface IndyPoolConfig {
+  genesisPath?: string
+  genesisTransactions?: string
+  id: string
+  isProduction: boolean
+}
+
+export class IndyPool {
+  private indy: typeof Indy
+  private logger: Logger
+  private fileSystem: FileSystem
+  private poolConfig: IndyPoolConfig
+  private _poolHandle?: number
+  public authorAgreement?: AuthorAgreement | null
+
+  public constructor(agentConfig: AgentConfig, poolConfig: IndyPoolConfig) {
+    this.indy = agentConfig.agentDependencies.indy
+    this.poolConfig = poolConfig
+    this.fileSystem = agentConfig.fileSystem
+    this.logger = agentConfig.logger
+
+    // Listen to stop$ (shutdown) and close pool
+    agentConfig.stop$.subscribe(async () => {
+      if (this._poolHandle) {
+        await this.close()
+      }
+    })
+  }
+
+  public get id() {
+    return this.poolConfig.id
+  }
+
+  public get config() {
+    return this.poolConfig
+  }
+
+  public async close() {
+    const poolHandle = this._poolHandle
+
+    if (!poolHandle) {
+      return
+    }
+
+    this._poolHandle = undefined
+
+    // FIXME: Add type to indy-sdk
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    await this.indy.closePoolLedger(poolHandle)
+  }
+
+  public async delete() {
+    // Close the pool if currently open
+    if (this._poolHandle) {
+      await this.close()
+    }
+
+    // FIXME: Add type to indy-sdk
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    await this.indy.deletePoolLedgerConfig(this.agentConfig.poolName)
+  }
+
+  public async connect() {
+    const poolName = this.poolConfig.id
+    const genesisPath = await this.getGenesisPath()
+
+    if (!genesisPath) {
+      throw new AriesFrameworkError('Cannot connect to ledger without genesis file')
+    }
+
+    this.logger.debug(`Connecting to ledger pool '${poolName}'`, { genesisPath })
+    await this.indy.setProtocolVersion(2)
+
+    try {
+      this._poolHandle = await this.indy.openPoolLedger(poolName)
+      return this._poolHandle
+    } catch (error) {
+      if (!isIndyError(error, 'PoolLedgerNotCreatedError')) {
+        throw isIndyError(error) ? new IndySdkError(error) : error
+      }
+    }
+
+    this.logger.debug(`Pool '${poolName}' does not exist yet, creating.`, {
+      indyError: 'PoolLedgerNotCreatedError',
+    })
+    try {
+      await this.indy.createPoolLedgerConfig(poolName, { genesis_txn: genesisPath })
+      this._poolHandle = await this.indy.openPoolLedger(poolName)
+      return this._poolHandle
+    } catch (error) {
+      throw isIndyError(error) ? new IndySdkError(error) : error
+    }
+  }
+
+  private async submitRequest(request: Indy.LedgerRequest) {
+    return this.indy.submitRequest(await this.getPoolHandle(), request)
+  }
+
+  public async submitReadRequest(request: Indy.LedgerRequest) {
+    const response = await this.submitRequest(request)
+
+    if (isLedgerRejectResponse(response)) {
+      throw new LedgerError(`Ledger '${this.id}' rejected read transaction request: ${response.reason}`)
+    }
+
+    return response as Indy.LedgerReadReplyResponse
+  }
+
+  public async submitWriteRequest(request: Indy.LedgerRequest) {
+    const response = await this.submitRequest(request)
+
+    if (isLedgerRejectResponse(response)) {
+      throw new LedgerError(`Ledger '${this.id}' rejected write transaction request: ${response.reason}`)
+    }
+
+    return response as Indy.LedgerWriteReplyResponse
+  }
+
+  private async getPoolHandle() {
+    if (!this._poolHandle) {
+      return this.connect()
+    }
+
+    return this._poolHandle
+  }
+
+  private async getGenesisPath() {
+    // If the path is already provided return it
+    if (this.poolConfig.genesisPath) return this.poolConfig.genesisPath
+
+    // Determine the genesisPath
+    const genesisPath = this.fileSystem.basePath + `/afj/genesis-${this.poolConfig.id}.txn`
+    // Store genesis data if provided
+    if (this.poolConfig.genesisTransactions) {
+      await this.fileSystem.write(genesisPath, this.poolConfig.genesisTransactions)
+      this.poolConfig.genesisPath = genesisPath
+      return genesisPath
+    }
+
+    // No genesisPath
+    return null
+  }
+}
+
+export interface AuthorAgreement {
+  digest: string
+  version: string
+  text: string
+  ratification_ts: number
+  acceptanceMechanisms: AcceptanceMechanisms
+}
+
+export interface AcceptanceMechanisms {
+  aml: Record<string, string>
+  amlContext: string
+  version: string
+}

--- a/packages/core/src/modules/ledger/__tests__/IndyPoolService.test.ts
+++ b/packages/core/src/modules/ledger/__tests__/IndyPoolService.test.ts
@@ -1,0 +1,225 @@
+import type { IndyPoolConfig } from '../IndyPool'
+
+import { IndyPoolService } from '..'
+import { getAgentConfig } from '../../../../tests/helpers'
+import { AriesFrameworkError } from '../../../error/AriesFrameworkError'
+import { IndyWallet } from '../../../wallet/IndyWallet'
+import { LedgerError } from '../error/LedgerError'
+import { LedgerNotConfiguredError } from '../error/LedgerNotConfiguredError'
+import { LedgerNotFoundError } from '../error/LedgerNotFoundError'
+
+import { getDidResponsesForDid } from './didResponses'
+
+const pools: IndyPoolConfig[] = [
+  {
+    id: 'sovrinMain',
+    isProduction: true,
+    genesisTransactions: 'xxx',
+  },
+  {
+    id: 'sovrinBuilder',
+    isProduction: false,
+    genesisTransactions: 'xxx',
+  },
+
+  {
+    id: 'sovrinStaging',
+    isProduction: false,
+    genesisTransactions: 'xxx',
+  },
+  {
+    id: 'indicioMain',
+    isProduction: true,
+    genesisTransactions: 'xxx',
+  },
+  {
+    id: 'bcovrinTest',
+    isProduction: false,
+    genesisTransactions: 'xxx',
+  },
+]
+
+describe('InyLedgerService', () => {
+  const config = getAgentConfig('IndyLedgerServiceTest', {
+    indyLedgers: pools,
+  })
+  let wallet: IndyWallet
+  let poolService: IndyPoolService
+
+  beforeAll(async () => {
+    wallet = new IndyWallet(config)
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await wallet.initialize(config.walletConfig!)
+  })
+
+  afterAll(async () => {
+    await wallet.delete()
+  })
+
+  beforeEach(async () => {
+    poolService = new IndyPoolService(config)
+  })
+
+  describe('ledgerWritePool', () => {
+    it('should return the first pool', async () => {
+      expect(poolService.ledgerWritePool).toBe(poolService.pools[0])
+    })
+
+    it('should throw a LedgerNotConfiguredError error if no pools are configured on the agent', async () => {
+      const config = getAgentConfig('IndyLedgerServiceTest', { indyLedgers: [] })
+      poolService = new IndyPoolService(config)
+
+      expect(() => poolService.ledgerWritePool).toThrow(LedgerNotConfiguredError)
+    })
+  })
+
+  describe('getPoolForDid', () => {
+    it('should throw a LedgerNotConfiguredError error if no pools are configured on the agent', async () => {
+      const config = getAgentConfig('IndyLedgerServiceTest', { indyLedgers: [] })
+      poolService = new IndyPoolService(config)
+
+      expect(poolService.getPoolForDid('some-did')).rejects.toThrow(LedgerNotConfiguredError)
+    })
+
+    it('should throw a LedgerError if one of the ledger requests throws an error other than NotFoundError', async () => {
+      const did = 'Y5bj4SjCiTM9PgeheKAiXx'
+
+      poolService.pools.forEach((pool) => {
+        const spy = jest.spyOn(pool, 'submitReadRequest')
+        spy.mockImplementationOnce(() => Promise.reject(new AriesFrameworkError('Something went wrong')))
+      })
+
+      expect(poolService.getPoolForDid(did)).rejects.toThrowError(LedgerError)
+    })
+
+    it('should throw a LedgerNotFoundError if all pools did not find the did on the ledger', async () => {
+      const did = 'Y5bj4SjCiTM9PgeheKAiXx'
+      // Not found on any of the ledgers
+      const responses = getDidResponsesForDid(did, pools, {})
+
+      poolService.pools.forEach((pool, index) => {
+        const spy = jest.spyOn(pool, 'submitReadRequest')
+        spy.mockImplementationOnce(responses[index])
+      })
+
+      expect(poolService.getPoolForDid(did)).rejects.toThrowError(LedgerNotFoundError)
+    })
+
+    it('should return the pool if the did was only found on one ledger', async () => {
+      const did = 'TL1EaPFCZ8Si5aUrqScBDt'
+      // Only found on one ledger
+      const responses = getDidResponsesForDid(did, pools, {
+        sovrinMain: {
+          txnTime: 1632680963,
+          verkey: '~43X4NhAFqREffK7eWdKgFH',
+        },
+      })
+
+      poolService.pools.forEach((pool, index) => {
+        const spy = jest.spyOn(pool, 'submitReadRequest')
+        spy.mockImplementationOnce(responses[index])
+      })
+
+      const { pool } = await poolService.getPoolForDid(did)
+
+      expect(pool.config.id).toBe('sovrinMain')
+    })
+
+    it('should return the production pool if the did was found on one production and one non production ledger', async () => {
+      const did = 'V6ty6ttM3EjuCtosH6sGtW'
+      // Found on one production and one non production ledger
+      const responses = getDidResponsesForDid(did, pools, {
+        indicioMain: {
+          txnTime: 1632680963,
+          verkey: '~43X4NhAFqREffK7eWdKgFH',
+        },
+        sovrinBuilder: {
+          txnTime: 1632680963,
+          verkey: '~43X4NhAFqREffK7eWdKgFH',
+        },
+      })
+
+      poolService.pools.forEach((pool, index) => {
+        const spy = jest.spyOn(pool, 'submitReadRequest')
+        spy.mockImplementationOnce(responses[index])
+      })
+
+      const { pool } = await poolService.getPoolForDid(did)
+
+      expect(pool.config.id).toBe('indicioMain')
+    })
+
+    it('should return the pool with the self certified did if the did was found on two production ledgers where one did is self certified', async () => {
+      const did = 'VsKV7grR1BUE29mG2Fm2kX'
+      // Found on two production ledgers. Sovrin is self certified
+      const responses = getDidResponsesForDid(did, pools, {
+        sovrinMain: {
+          txnTime: 1632680963,
+          verkey: '~43X4NhAFqREffK7eWdKgFH',
+        },
+        indicioMain: {
+          txnTime: 1632680963,
+          verkey: 'kqa2HyagzfMAq42H5f9u3UMwnSBPQx2QfrSyXbUPxMn',
+        },
+      })
+
+      poolService.pools.forEach((pool, index) => {
+        const spy = jest.spyOn(pool, 'submitReadRequest')
+        spy.mockImplementationOnce(responses[index])
+      })
+
+      const { pool } = await poolService.getPoolForDid(did)
+
+      expect(pool.config.id).toBe('sovrinMain')
+    })
+
+    it('should return the pool with the did with the earlier txnTime if the did was found on two production ledgers where both DIDs are self certified', async () => {
+      const did = 'JHVT5Zv86TrJUJYysET4ij'
+      // Found on two production ledgers. Indicio txnTime is earlier than
+      // Sovrin txnTime
+      const responses = getDidResponsesForDid(did, pools, {
+        sovrinMain: {
+          txnTime: 1632680963,
+          verkey: '~QTQYRnDeYdbo8NDEkWC2Bt',
+        },
+        indicioMain: {
+          txnTime: 1632680000,
+          verkey: '~QTQYRnDeYdbo8NDEkWC2Bt',
+        },
+      })
+
+      poolService.pools.forEach((pool, index) => {
+        const spy = jest.spyOn(pool, 'submitReadRequest')
+        spy.mockImplementationOnce(responses[index])
+      })
+
+      const { pool } = await poolService.getPoolForDid(did)
+
+      expect(pool.config.id).toBe('indicioMain')
+    })
+
+    it('should return the pool with the self certified did if the did was found on two non production ledgers where one did is self certified', async () => {
+      const did = 'HEi9QViXNThGQaDsQ3ptcw'
+      // Found on two non production ledgers. Sovrin is self certified
+      const responses = getDidResponsesForDid(did, pools, {
+        sovrinBuilder: {
+          txnTime: 1632680963,
+          verkey: '~M9kv2Ez61cur7X39DXWh8W',
+        },
+        bcovrinTest: {
+          txnTime: 1632680963,
+          verkey: '3SeuRm3uYuQDYmHeuMLu1xNHozNTtzS3kbZRFMMCWrX4',
+        },
+      })
+
+      poolService.pools.forEach((pool, index) => {
+        const spy = jest.spyOn(pool, 'submitReadRequest')
+        spy.mockImplementationOnce(responses[index])
+      })
+
+      const { pool } = await poolService.getPoolForDid(did)
+
+      expect(pool.config.id).toBe('sovrinBuilder')
+    })
+  })
+})

--- a/packages/core/src/modules/ledger/__tests__/didResponses.ts
+++ b/packages/core/src/modules/ledger/__tests__/didResponses.ts
@@ -1,0 +1,58 @@
+import type { IndyPoolConfig } from '../IndyPool'
+import type * as Indy from 'indy-sdk'
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+// eslint-disable-next-line import/no-extraneous-dependencies
+import IndyError from 'indy-sdk/src/IndyError'
+
+export function getDidResponse({ did, txnTime, verkey }: { did: string; txnTime: number; verkey: string }) {
+  const response: Indy.LedgerReadReplyResponse = {
+    op: 'REPLY',
+    result: {
+      txnTime: txnTime,
+      reqId: 1632681194706196000,
+      state_proof: {
+        multi_signature: {
+          participants: ['Node3', 'Node4', 'Node2'],
+          value: {
+            state_root_hash: 'AqMNuzJHeHduhggd8URobGyc1W89oGEjmohRXkB66JZo',
+            ledger_id: 1,
+            pool_state_root_hash: 'NCGqbfRWDWtLB2bDuL6TC5BhrRdQMc5MyKdXQqXii44',
+            timestamp: txnTime,
+            txn_root_hash: 'AxqfyyDFuY74kiXcfvkYCWCVrHsrQutKaoi3ao4Vp8K7',
+          },
+          signature:
+            'QwkoPr9pwXyBdtMMUtJ841QjX3pTEQP6bumBpHCWiBCn4AduEW55SQXHjfQZd7EXEjArMfjNyDjgC3Qsvh51WAFGK74C3Tq7k5zYbm7kbVZdUse2i27XiDkMuB6sriroi7XHfnV3Bo55ig3APAFXD7mQrKTGE2ov17CF6yn1ns81vf',
+        },
+        proof_nodes:
+          '+QHS+JygNttWkmVHYjZyCCk0TNJr5l7AJOnuLNU99qWyNhfBuWq4efh3uHV7ImlkZW50aWZpZXIiOiJWNFNHUlU4Nlo1OGQ2VFY3UEJVZTZmIiwicm9sZSI6IjAiLCJzZXFObyI6MTEsInR4blRpbWUiOjE2MzI2ODA5NjMsInZlcmtleSI6In40M1g0TmhBRnFSRWZmSzdlV2RLZ0ZIIn35ATGg09I/bgmxWmztC58rrZwebgwutUGli7VUyVOFwmuLFqOAoNrtARUl8FhzgOfGsZGlm8IVqgH1wB5KaoajR9sA53e2oJqauj70Qf++s0g43b1zvnQEyQJh2lfNqxFRtmaADvkwgKACG8f0w2NsuDibWYibc1TYySAgUKSeIevHF6wVZdMBL6BEAIIJs0un9jVqVEABbCWTkc0rybTVrFgaKU6LD6ciGYCAgICgJHIm3oUOYlDrQlw95UDkRdOc2tGIsE9g2r12AjpJiUKAoH0lXE47VtUlFvwnCC5rgY878m6TpeEZTJIKd4SUxXtqoBvSoTludXD0XkhTPm4YxfCcAdCaiDvkzM8w6O4v5/e1oDs6GXxRL8inD2b3RY1v/ufksDHNqfFKaK2MEIjNIZwagA==',
+        root_hash: 'AqMNuzJHeHduhggd8URobGyc1W89oGEjmohRXkB66JZo',
+      },
+      seqNo: 11,
+      identifier: 'LibindyDid111111111111',
+      dest: did,
+      data: `{"dest":"${did}","identifier":"V4SGRU86Z58d6TV7PBUe6f","role":"0","seqNo":11,"txnTime":${txnTime},"verkey":"${verkey}"}`,
+      type: '105',
+    },
+  }
+
+  return response
+}
+
+export function getDidResponsesForDid(
+  did: string,
+  pools: IndyPoolConfig[],
+  responses: { [key: string]: { txnTime: number; verkey: string } | undefined }
+) {
+  return pools.map((pool) => {
+    const response = responses[pool.id]
+
+    if (response) {
+      return () => Promise.resolve(getDidResponse({ did, verkey: response.verkey, txnTime: response.txnTime }))
+    }
+
+    // LedgerNotFound
+    return () => Promise.reject(new IndyError(309))
+  })
+}

--- a/packages/core/src/modules/ledger/error/LedgerError.ts
+++ b/packages/core/src/modules/ledger/error/LedgerError.ts
@@ -1,0 +1,7 @@
+import { AriesFrameworkError } from '../../../error/AriesFrameworkError'
+
+export class LedgerError extends AriesFrameworkError {
+  public constructor(message: string, { cause }: { cause?: Error } = {}) {
+    super(message, { cause })
+  }
+}

--- a/packages/core/src/modules/ledger/error/LedgerNotConfiguredError.ts
+++ b/packages/core/src/modules/ledger/error/LedgerNotConfiguredError.ts
@@ -1,0 +1,7 @@
+import { LedgerError } from './LedgerError'
+
+export class LedgerNotConfiguredError extends LedgerError {
+  public constructor(message: string, { cause }: { cause?: Error } = {}) {
+    super(message, { cause })
+  }
+}

--- a/packages/core/src/modules/ledger/error/LedgerNotFoundError.ts
+++ b/packages/core/src/modules/ledger/error/LedgerNotFoundError.ts
@@ -1,0 +1,7 @@
+import { LedgerError } from './LedgerError'
+
+export class LedgerNotFoundError extends LedgerError {
+  public constructor(message: string, { cause }: { cause?: Error } = {}) {
+    super(message, { cause })
+  }
+}

--- a/packages/core/src/modules/ledger/ledgerUtil.ts
+++ b/packages/core/src/modules/ledger/ledgerUtil.ts
@@ -1,0 +1,5 @@
+import type * as Indy from 'indy-sdk'
+
+export function isLedgerRejectResponse(response: Indy.LedgerResponse): response is Indy.LedgerRejectResponse {
+  return response.op === 'REJECT'
+}

--- a/packages/core/src/modules/ledger/services/IndyLedgerService.ts
+++ b/packages/core/src/modules/ledger/services/IndyLedgerService.ts
@@ -1,10 +1,9 @@
 import type { Logger } from '../../../logger'
-import type { FileSystem } from '../../../storage/FileSystem'
+import type { AcceptanceMechanisms, AuthorAgreement, IndyPool } from '../IndyPool'
 import type {
   default as Indy,
   CredDef,
   LedgerRequest,
-  PoolHandle,
   Schema,
   LedgerReadReplyResponse,
   LedgerWriteReplyResponse,
@@ -14,99 +13,34 @@ import type {
 import { scoped, Lifecycle } from 'tsyringe'
 
 import { AgentConfig } from '../../../agent/AgentConfig'
-import { AriesFrameworkError } from '../../../error/AriesFrameworkError'
 import { IndySdkError } from '../../../error/IndySdkError'
+import { didFromCredentialDefinitionId, didFromSchemaId } from '../../../utils/did'
 import { isIndyError } from '../../../utils/indyError'
 import { IndyWallet } from '../../../wallet/IndyWallet'
 import { IndyIssuerService } from '../../indy'
+
+import { IndyPoolService } from './IndyPoolService'
 
 @scoped(Lifecycle.ContainerScoped)
 export class IndyLedgerService {
   private wallet: IndyWallet
   private indy: typeof Indy
   private logger: Logger
-  private _poolHandle?: PoolHandle
-  private authorAgreement?: AuthorAgreement | null
-  private indyIssuer: IndyIssuerService
-  private agentConfig: AgentConfig
-  private fileSystem: FileSystem
 
-  public constructor(wallet: IndyWallet, agentConfig: AgentConfig, indyIssuer: IndyIssuerService) {
+  private indyIssuer: IndyIssuerService
+  private indyPoolService: IndyPoolService
+
+  public constructor(
+    wallet: IndyWallet,
+    agentConfig: AgentConfig,
+    indyIssuer: IndyIssuerService,
+    indyPoolService: IndyPoolService
+  ) {
     this.wallet = wallet
-    this.agentConfig = agentConfig
     this.indy = agentConfig.agentDependencies.indy
     this.logger = agentConfig.logger
     this.indyIssuer = indyIssuer
-    this.fileSystem = agentConfig.fileSystem
-
-    // Listen to stop$ (shutdown) and close pool
-    agentConfig.stop$.subscribe(async () => {
-      if (this._poolHandle) {
-        await this.close()
-      }
-    })
-  }
-
-  private async getPoolHandle() {
-    if (!this._poolHandle) {
-      return this.connect()
-    }
-
-    return this._poolHandle
-  }
-
-  public async close() {
-    // FIXME: Add type to indy-sdk
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    await this.indy.closePoolLedger(this._poolHandle)
-    this._poolHandle = undefined
-  }
-
-  public async delete() {
-    // Close the pool if currently open
-    if (this._poolHandle) {
-      await this.close()
-    }
-
-    // FIXME: Add type to indy-sdk
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    await this.indy.deletePoolLedgerConfig(this.agentConfig.poolName)
-  }
-
-  public async connect() {
-    const poolName = this.agentConfig.poolName
-    const genesisPath = await this.getGenesisPath()
-
-    if (!genesisPath) {
-      throw new Error('Cannot connect to ledger without genesis file')
-    }
-
-    this.logger.debug(`Connecting to ledger pool '${poolName}'`, { genesisPath })
-    try {
-      this.logger.debug(`Creating pool '${poolName}'`)
-      await this.indy.createPoolLedgerConfig(poolName, { genesis_txn: genesisPath })
-    } catch (error) {
-      if (isIndyError(error, 'PoolLedgerConfigAlreadyExistsError')) {
-        this.logger.debug(`Pool '${poolName}' already exists`, {
-          indyError: 'PoolLedgerConfigAlreadyExistsError',
-        })
-      } else {
-        throw isIndyError(error) ? new IndySdkError(error) : error
-      }
-    }
-
-    try {
-      this.logger.debug('Setting ledger protocol version to 2')
-      await this.indy.setProtocolVersion(2)
-
-      this.logger.debug(`Opening pool ${poolName}`)
-      this._poolHandle = await this.indy.openPoolLedger(poolName)
-      return this._poolHandle
-    } catch (error) {
-      throw isIndyError(error) ? new IndySdkError(error) : error
-    }
+    this.indyPoolService = indyPoolService
   }
 
   public async registerPublicDid(
@@ -116,27 +50,29 @@ export class IndyLedgerService {
     alias: string,
     role?: NymRole
   ) {
+    const pool = this.indyPoolService.ledgerWritePool
+
     try {
-      this.logger.debug(`Register public did on ledger '${targetDid}'`)
+      this.logger.debug(`Register public did '${targetDid}' on ledger '${pool.id}'`)
 
       const request = await this.indy.buildNymRequest(submitterDid, targetDid, verkey, alias, role || null)
 
-      const response = await this.submitWriteRequest(request, submitterDid)
+      const response = await this.submitWriteRequest(pool, request, submitterDid)
 
-      this.logger.debug(`Registered public did '${targetDid}' on ledger`, {
+      this.logger.debug(`Registered public did '${targetDid}' on ledger '${pool.id}'`, {
         response,
       })
 
       return targetDid
     } catch (error) {
-      this.logger.error(`Error registering public did '${targetDid}' on ledger`, {
+      this.logger.error(`Error registering public did '${targetDid}' on ledger '${pool.id}'`, {
         error,
         submitterDid,
         targetDid,
         verkey,
         alias,
         role,
-        poolHandle: await this.getPoolHandle(),
+        pool,
       })
 
       throw error
@@ -144,38 +80,24 @@ export class IndyLedgerService {
   }
 
   public async getPublicDid(did: string) {
-    try {
-      this.logger.debug(`Get public did '${did}' from ledger`)
-      const request = await this.indy.buildGetNymRequest(null, did)
+    // Getting the pool for a did also retrieves the DID. We can just use that
+    const { did: didResponse } = await this.indyPoolService.getPoolForDid(did)
 
-      this.logger.debug(`Submitting get did request for did '${did}' to ledger`)
-      const response = await this.indy.submitRequest(await this.getPoolHandle(), request)
-
-      const result = await this.indy.parseGetNymResponse(response)
-      this.logger.debug(`Retrieved did '${did}' from ledger`, result)
-
-      return result
-    } catch (error) {
-      this.logger.error(`Error retrieving did '${did}' from ledger`, {
-        error,
-        did,
-        poolHandle: await this.getPoolHandle(),
-      })
-
-      throw isIndyError(error) ? new IndySdkError(error) : error
-    }
+    return didResponse
   }
 
   public async registerSchema(did: string, schemaTemplate: SchemaTemplate): Promise<Schema> {
+    const pool = this.indyPoolService.ledgerWritePool
+
     try {
-      this.logger.debug(`Register schema on ledger with did '${did}'`, schemaTemplate)
+      this.logger.debug(`Register schema on ledger '${pool.id}' with did '${did}'`, schemaTemplate)
       const { name, attributes, version } = schemaTemplate
       const schema = await this.indyIssuer.createSchema({ originDid: did, name, version, attributes })
 
       const request = await this.indy.buildSchemaRequest(did, schema)
 
-      const response = await this.submitWriteRequest(request, did)
-      this.logger.debug(`Registered schema '${schema.id}' on ledger`, {
+      const response = await this.submitWriteRequest(pool, request, did)
+      this.logger.debug(`Registered schema '${schema.id}' on ledger '${pool.id}'`, {
         response,
         schema,
       })
@@ -184,10 +106,9 @@ export class IndyLedgerService {
 
       return schema
     } catch (error) {
-      this.logger.error(`Error registering schema for did '${did}' on ledger:`, {
+      this.logger.error(`Error registering schema for did '${did}' on ledger '${pool.id}'`, {
         error,
         did,
-        poolHandle: await this.getPoolHandle(),
         schemaTemplate,
       })
 
@@ -196,26 +117,28 @@ export class IndyLedgerService {
   }
 
   public async getSchema(schemaId: string) {
+    const did = didFromSchemaId(schemaId)
+    const { pool } = await this.indyPoolService.getPoolForDid(did)
+
     try {
-      this.logger.debug(`Get schema '${schemaId}' from ledger`)
+      this.logger.debug(`Get schema '${schemaId}' from ledger '${pool.id}'`)
 
       const request = await this.indy.buildGetSchemaRequest(null, schemaId)
 
-      this.logger.debug(`Submitting get schema request for schema '${schemaId}' to ledger`)
-      const response = await this.submitReadRequest(request)
+      this.logger.debug(`Submitting get schema request for schema '${schemaId}' to ledger '${pool.id}'`)
+      const response = await this.submitReadRequest(pool, request)
 
       const [, schema] = await this.indy.parseGetSchemaResponse(response)
-      this.logger.debug(`Got schema '${schemaId}' from ledger`, {
+      this.logger.debug(`Got schema '${schemaId}' from ledger '${pool.id}'`, {
         response,
         schema,
       })
 
       return schema
     } catch (error) {
-      this.logger.error(`Error retrieving schema '${schemaId}' from ledger`, {
+      this.logger.error(`Error retrieving schema '${schemaId}' from ledger '${pool.id}'`, {
         error,
         schemaId,
-        poolHandle: await this.getPoolHandle(),
       })
 
       throw isIndyError(error) ? new IndySdkError(error) : error
@@ -226,8 +149,13 @@ export class IndyLedgerService {
     did: string,
     credentialDefinitionTemplate: CredentialDefinitionTemplate
   ): Promise<CredDef> {
+    const pool = this.indyPoolService.ledgerWritePool
+
     try {
-      this.logger.debug(`Register credential definition on ledger with did '${did}'`, credentialDefinitionTemplate)
+      this.logger.debug(
+        `Register credential definition on ledger '${pool.id}' with did '${did}'`,
+        credentialDefinitionTemplate
+      )
       const { schema, tag, signatureType, supportRevocation } = credentialDefinitionTemplate
 
       const credentialDefinition = await this.indyIssuer.createCredentialDefinition({
@@ -240,9 +168,9 @@ export class IndyLedgerService {
 
       const request = await this.indy.buildCredDefRequest(did, credentialDefinition)
 
-      const response = await this.submitWriteRequest(request, did)
+      const response = await this.submitWriteRequest(pool, request, did)
 
-      this.logger.debug(`Registered credential definition '${credentialDefinition.id}' on ledger`, {
+      this.logger.debug(`Registered credential definition '${credentialDefinition.id}' on ledger '${pool.id}'`, {
         response,
         credentialDefinition: credentialDefinition,
       })
@@ -250,11 +178,10 @@ export class IndyLedgerService {
       return credentialDefinition
     } catch (error) {
       this.logger.error(
-        `Error registering credential definition for schema '${credentialDefinitionTemplate.schema.id}' on ledger`,
+        `Error registering credential definition for schema '${credentialDefinitionTemplate.schema.id}' on ledger '${pool.id}'`,
         {
           error,
           did,
-          poolHandle: await this.getPoolHandle(),
           credentialDefinitionTemplate,
         }
       )
@@ -264,60 +191,62 @@ export class IndyLedgerService {
   }
 
   public async getCredentialDefinition(credentialDefinitionId: string) {
+    const did = didFromCredentialDefinitionId(credentialDefinitionId)
+    const { pool } = await this.indyPoolService.getPoolForDid(did)
+
+    this.logger.debug(`Using ledger '${pool.id}' to retrieve credential definition '${credentialDefinitionId}'`)
+
     try {
-      this.logger.debug(`Get credential definition '${credentialDefinitionId}' from ledger`)
+      this.logger.debug(`Get credential definition '${credentialDefinitionId}' from ledger '${pool.id}'`)
 
       const request = await this.indy.buildGetCredDefRequest(null, credentialDefinitionId)
 
       this.logger.debug(
-        `Submitting get credential definition request for credential definition '${credentialDefinitionId}' to ledger`
+        `Submitting get credential definition request for credential definition '${credentialDefinitionId}' to ledger '${pool.id}'`
       )
-      const response = await this.submitReadRequest(request)
+
+      const response = await this.submitReadRequest(pool, request)
 
       const [, credentialDefinition] = await this.indy.parseGetCredDefResponse(response)
-      this.logger.debug(`Got credential definition '${credentialDefinitionId}' from ledger`, {
+      this.logger.debug(`Got credential definition '${credentialDefinitionId}' from ledger '${pool.id}'`, {
         response,
         credentialDefinition,
       })
 
       return credentialDefinition
     } catch (error) {
-      this.logger.error(`Error retrieving credential definition '${credentialDefinitionId}' from ledger`, {
+      this.logger.error(`Error retrieving credential definition '${credentialDefinitionId}' from ledger '${pool.id}'`, {
         error,
-        credentialDefinitionId: credentialDefinitionId,
-        poolHandle: await this.getPoolHandle(),
+        credentialDefinitionId,
+        pool: pool.id,
       })
 
       throw isIndyError(error) ? new IndySdkError(error) : error
     }
   }
 
-  private async submitWriteRequest(request: LedgerRequest, signDid: string): Promise<LedgerWriteReplyResponse> {
+  private async submitWriteRequest(
+    pool: IndyPool,
+    request: LedgerRequest,
+    signDid: string
+  ): Promise<LedgerWriteReplyResponse> {
     try {
-      const requestWithTaa = await this.appendTaa(request)
+      const requestWithTaa = await this.appendTaa(pool, request)
       const signedRequestWithTaa = await this.signRequest(signDid, requestWithTaa)
 
-      const response = await this.indy.submitRequest(await this.getPoolHandle(), signedRequestWithTaa)
+      const response = await pool.submitWriteRequest(signedRequestWithTaa)
 
-      if (response.op === 'REJECT') {
-        throw new AriesFrameworkError(`Ledger rejected transaction request: ${response.reason}`)
-      }
-
-      return response as LedgerWriteReplyResponse
+      return response
     } catch (error) {
       throw isIndyError(error) ? new IndySdkError(error) : error
     }
   }
 
-  private async submitReadRequest(request: LedgerRequest): Promise<LedgerReadReplyResponse> {
+  private async submitReadRequest(pool: IndyPool, request: LedgerRequest): Promise<LedgerReadReplyResponse> {
     try {
-      const response = await this.indy.submitRequest(await this.getPoolHandle(), request)
+      const response = await pool.submitReadRequest(request)
 
-      if (response.op === 'REJECT') {
-        throw Error(`Ledger rejected transaction request: ${response.reason}`)
-      }
-
-      return response as LedgerReadReplyResponse
+      return response
     } catch (error) {
       throw isIndyError(error) ? new IndySdkError(error) : error
     }
@@ -331,9 +260,9 @@ export class IndyLedgerService {
     }
   }
 
-  private async appendTaa(request: LedgerRequest) {
+  private async appendTaa(pool: IndyPool, request: Indy.LedgerRequest) {
     try {
-      const authorAgreement = await this.getTransactionAuthorAgreement()
+      const authorAgreement = await this.getTransactionAuthorAgreement(pool)
 
       // If ledger does not have TAA, we can just send request
       if (authorAgreement == null) {
@@ -357,32 +286,32 @@ export class IndyLedgerService {
     }
   }
 
-  private async getTransactionAuthorAgreement(): Promise<AuthorAgreement | null> {
+  private async getTransactionAuthorAgreement(pool: IndyPool): Promise<AuthorAgreement | null> {
     try {
       // TODO Replace this condition with memoization
-      if (this.authorAgreement !== undefined) {
-        return this.authorAgreement
+      if (pool.authorAgreement !== undefined) {
+        return pool.authorAgreement
       }
 
       const taaRequest = await this.indy.buildGetTxnAuthorAgreementRequest(null)
-      const taaResponse = await this.submitReadRequest(taaRequest)
+      const taaResponse = await this.submitReadRequest(pool, taaRequest)
       const acceptanceMechanismRequest = await this.indy.buildGetAcceptanceMechanismsRequest(null)
-      const acceptanceMechanismResponse = await this.submitReadRequest(acceptanceMechanismRequest)
+      const acceptanceMechanismResponse = await this.submitReadRequest(pool, acceptanceMechanismRequest)
 
       // TAA can be null
       if (taaResponse.result.data == null) {
-        this.authorAgreement = null
+        pool.authorAgreement = null
         return null
       }
 
       // If TAA is not null, we can be sure AcceptanceMechanisms is also not null
       const authorAgreement = taaResponse.result.data as AuthorAgreement
       const acceptanceMechanisms = acceptanceMechanismResponse.result.data as AcceptanceMechanisms
-      this.authorAgreement = {
+      pool.authorAgreement = {
         ...authorAgreement,
         acceptanceMechanisms,
       }
-      return this.authorAgreement
+      return pool.authorAgreement
     } catch (error) {
       throw isIndyError(error) ? new IndySdkError(error) : error
     }
@@ -391,22 +320,6 @@ export class IndyLedgerService {
   private getFirstAcceptanceMechanism(authorAgreement: AuthorAgreement) {
     const [firstMechanism] = Object.keys(authorAgreement.acceptanceMechanisms.aml)
     return firstMechanism
-  }
-
-  private async getGenesisPath() {
-    // If the path is already provided return it
-    if (this.agentConfig.genesisPath) return this.agentConfig.genesisPath
-
-    // Determine the genesisPath
-    const genesisPath = this.fileSystem.basePath + `/afj/genesis-${this.agentConfig.poolName}.txn`
-    // Store genesis data if provided
-    if (this.agentConfig.genesisTransactions) {
-      await this.fileSystem.write(genesisPath, this.agentConfig.genesisTransactions)
-      return genesisPath
-    }
-
-    // No genesisPath
-    return null
   }
 }
 
@@ -421,18 +334,4 @@ export interface CredentialDefinitionTemplate {
   tag: string
   signatureType: 'CL'
   supportRevocation: boolean
-}
-
-interface AuthorAgreement {
-  digest: string
-  version: string
-  text: string
-  ratification_ts: number
-  acceptanceMechanisms: AcceptanceMechanisms
-}
-
-interface AcceptanceMechanisms {
-  aml: Record<string, string>
-  amlContext: string
-  version: string
 }

--- a/packages/core/src/modules/ledger/services/IndyPoolService.ts
+++ b/packages/core/src/modules/ledger/services/IndyPoolService.ts
@@ -1,0 +1,154 @@
+import type { Logger } from '../../../logger/Logger'
+import type * as Indy from 'indy-sdk'
+
+import { Lifecycle, scoped } from 'tsyringe'
+
+import { AgentConfig } from '../../../agent/AgentConfig'
+import { IndySdkError } from '../../../error/IndySdkError'
+import { isSelfCertifiedDid } from '../../../utils/did'
+import { isIndyError } from '../../../utils/indyError'
+import { allSettled, onlyFulfilled, onlyRejected } from '../../../utils/promises'
+import { IndyPool } from '../IndyPool'
+import { LedgerError } from '../error/LedgerError'
+import { LedgerNotConfiguredError } from '../error/LedgerNotConfiguredError'
+import { LedgerNotFoundError } from '../error/LedgerNotFoundError'
+
+@scoped(Lifecycle.ContainerScoped)
+export class IndyPoolService {
+  public readonly pools: IndyPool[]
+  private logger: Logger
+  private indy: typeof Indy
+
+  // TODO: caching
+  public constructor(agentConfig: AgentConfig) {
+    this.pools = agentConfig.indyLedgers.map((poolConfig) => new IndyPool(agentConfig, poolConfig))
+    this.logger = agentConfig.logger
+    this.indy = agentConfig.agentDependencies.indy
+  }
+
+  /**
+   * Get the pool used for writing to the ledger. For now we always use the first pool
+   *  as the pool that writes to the ledger
+   */
+  public get ledgerWritePool() {
+    if (this.pools.length === 0) {
+      throw new LedgerNotConfiguredError(
+        "No indy ledgers configured. Provide at least one pool configuration in the 'indyLedgers' agent configuration"
+      )
+    }
+
+    return this.pools[0]
+  }
+
+  /**
+   * Get the most appropriate pool for the given did. The algorithm is based on the approach as described in this document:
+   * https://docs.google.com/document/d/109C_eMsuZnTnYe2OAd02jAts1vC4axwEKIq7_4dnNVA/edit
+   */
+  public async getPoolForDid(did: string): Promise<{ pool: IndyPool; did: Indy.GetNymResponse }> {
+    const pools = this.pools
+
+    if (pools.length === 0) {
+      throw new LedgerNotConfiguredError(
+        "No indy ledgers configured. Provide at least one pool configuration in the 'indyLedgers' agent configuration"
+      )
+    }
+
+    const { successful, rejected } = await this.getSettledDidResponsesFromPools(did, pools)
+
+    // This means there is a rejected response besides not found.
+    // For now we're really strict, and if one request fails, the whole
+    // request will fail. We may loosen this is the future if we see fit
+    const rejectedOtherThanNotFound = rejected.filter((e) => !(e.reason instanceof LedgerNotFoundError))
+    if (rejectedOtherThanNotFound.length > 0) {
+      throw new LedgerError(
+        `Unknown error retrieving did '${did}' from '${rejectedOtherThanNotFound.length}' of '${pools.length}' ledgers`,
+        { cause: rejectedOtherThanNotFound[0].reason }
+      )
+    }
+
+    // If the successful is empty at this stage, it means all ledgers did not have the did
+    if (successful.length === 0) {
+      throw new LedgerNotFoundError(`Did '${did}' not found on any of the ledgers (total ${this.pools.length}).`)
+    }
+
+    // Split between production and nonProduction ledgers. If there is at least one
+    // successful response from a production ledger, only keep production ledgers
+    // otherwise we only keep the non production ledgers.
+    const production = successful.filter((s) => s.value.pool.config.isProduction)
+    const nonProduction = successful.filter((s) => !s.value.pool.config.isProduction)
+    const remaining = production.length >= 1 ? production : nonProduction
+
+    // If there's only one successful response in this group (production / nonProduction), return it
+    if (remaining.length === 1) {
+      return { pool: remaining[0].value.pool, did: remaining[0].value.did }
+    }
+
+    // If there are multiple successful responses in this group check only one of them is
+    // self-certifying. Return if this is the case
+    const selfCertifying = remaining.filter((response) =>
+      isSelfCertifiedDid(response.value.did.did, response.value.did.verkey)
+    )
+    if (selfCertifying.length === 1) {
+      return { pool: selfCertifying[0].value.pool, did: selfCertifying[0].value.did }
+    }
+
+    // FIXME: ACA-Py doc mentions txnTime, but doc from Stephen mentions that it is not
+    // possible to get when the did was created (it is updated when the did is rotated probably)
+    const sortedByTxnTime = [...remaining].sort(
+      (first, second) =>
+        (first.value.response as Indy.LedgerReadReplyResponse).result.txnTime -
+        (second.value.response as Indy.LedgerReadReplyResponse).result.txnTime
+    )
+    return { pool: sortedByTxnTime[0].value.pool, did: sortedByTxnTime[0].value.did }
+  }
+
+  private async getSettledDidResponsesFromPools(did: string, pools: IndyPool[]) {
+    this.logger.trace(`Retrieving did '${did}' from ${pools.length} ledgers`)
+    const didResponses = await allSettled(pools.map((pool) => this.getDidFromPool(did, pool)))
+
+    const successful = onlyFulfilled(didResponses)
+    this.logger.trace(`Retrieved ${successful.length} responses from ledgers for did '${did}'`)
+
+    const rejected = onlyRejected(didResponses)
+
+    return {
+      rejected,
+      successful,
+    }
+  }
+
+  private async getDidFromPool(did: string, pool: IndyPool): Promise<PublicDidRequest> {
+    try {
+      this.logger.trace(`Get public did '${did}' from ledger '${pool.id}'`)
+      const request = await this.indy.buildGetNymRequest(null, did)
+
+      this.logger.trace(`Submitting get did request for did '${did}' to ledger '${pool.id}'`)
+      const response = await pool.submitReadRequest(request)
+
+      const result = await this.indy.parseGetNymResponse(response)
+      this.logger.trace(`Retrieved did '${did}' from ledger '${pool.id}'`, result)
+
+      return {
+        did: result,
+        pool,
+        response,
+      }
+    } catch (error) {
+      this.logger.trace(`Error retrieving did '${did}' from ledger '${pool.id}'`, {
+        error,
+        did,
+      })
+      if (isIndyError(error, 'LedgerNotFound')) {
+        throw new LedgerNotFoundError(`Did '${did}' not found on ledger ${pool.id}`)
+      } else {
+        throw isIndyError(error) ? new IndySdkError(error) : error
+      }
+    }
+  }
+}
+
+export interface PublicDidRequest {
+  did: Indy.GetNymResponse
+  pool: IndyPool
+  response: Indy.LedgerReadReplyResponse
+}

--- a/packages/core/src/modules/ledger/services/index.ts
+++ b/packages/core/src/modules/ledger/services/index.ts
@@ -1,1 +1,2 @@
 export * from './IndyLedgerService'
+export * from './IndyPoolService'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,7 @@ import type { AgentMessage } from './agent/AgentMessage'
 import type { Logger } from './logger'
 import type { ConnectionRecord, DidCommService } from './modules/connections'
 import type { AutoAcceptCredential } from './modules/credentials/CredentialAutoAcceptType'
+import type { IndyPoolConfig } from './modules/ledger/IndyPool'
 import type { AutoAcceptProof } from './modules/proofs'
 import type { MediatorPickupStrategy } from './modules/routing'
 
@@ -31,13 +32,10 @@ export interface InitConfig {
   autoAcceptConnections?: boolean
   autoAcceptProofs?: AutoAcceptProof
   autoAcceptCredentials?: AutoAcceptCredential
-  poolName?: string
   logger?: Logger
   didCommMimeType?: DidCommMimeType
 
-  // Either path or transactions string can be provided
-  genesisPath?: string
-  genesisTransactions?: string
+  indyLedgers?: IndyPoolConfig[]
 
   autoAcceptMediationRequests?: boolean
   mediatorConnectionsInvite?: string

--- a/packages/core/src/utils/BufferEncoder.ts
+++ b/packages/core/src/utils/BufferEncoder.ts
@@ -1,3 +1,4 @@
+import { decodeFromBase58, encodeToBase58 } from './base58'
 import { base64ToBase64URL } from './base64'
 import { Buffer } from './buffer'
 
@@ -21,12 +22,30 @@ export class BufferEncoder {
   }
 
   /**
+   * Encode buffer into base58 string.
+   *
+   * @param buffer the buffer to encode into base58 string
+   */
+  public static toBase58(buffer: Buffer | Uint8Array) {
+    return encodeToBase58(buffer)
+  }
+
+  /**
    * Decode base64 string into buffer. Also supports base64url
    *
    * @param base64 the base64 or base64url string to decode into buffer format
    */
   public static fromBase64(base64: string) {
     return Buffer.from(base64, 'base64')
+  }
+
+  /**
+   * Decode base58 string into buffer
+   *
+   * @param base58 the base58 string to decode into buffer format
+   */
+  public static fromBase58(base58: string) {
+    return Buffer.from(decodeFromBase58(base58))
   }
 
   /**

--- a/packages/core/src/utils/__tests__/did.test.ts
+++ b/packages/core/src/utils/__tests__/did.test.ts
@@ -1,4 +1,4 @@
-import { isAbbreviatedVerkey, isDid, isDidIdentifier, isFullVerkey, isVerkey } from '../did'
+import { isAbbreviatedVerkey, isDid, isDidIdentifier, isFullVerkey, isSelfCertifiedDid, isVerkey } from '../did'
 
 const validAbbreviatedVerkeys = [
   '~PKAYz8Ev4yoQgr2LaMAWFx',
@@ -81,6 +81,20 @@ const invalidDidIdentifiers = [
 ]
 
 describe('Utils | Did', () => {
+  describe('isSelfCertifiedDid()', () => {
+    test('returns true if the verkey is abbreviated', () => {
+      expect(isSelfCertifiedDid('PW8ZHpNupeWXbmpPWog6Ki', '~QQ5jiH1dgXPAnvHdJvazn9')).toBe(true)
+    })
+
+    test('returns true if the verkey is not abbreviated and the did is generated from the verkey', () => {
+      expect(isSelfCertifiedDid('Y8q4Aq6gRAcmB6jjKk3Z7t', 'HyEoPRNvC7q4jj5joUo8AWYtxbNccbEnTAeuMYkpmNS2')).toBe(true)
+    })
+
+    test('returns false if the verkey is not abbreviated and the did is not generated from the verkey', () => {
+      expect(isSelfCertifiedDid('Y8q4Aq6gRAcmB6jjKk3Z7t', 'AcU7DnRqoXGYATD6VqsRq4eHuz55gdM3uzFBEhFd6rGh')).toBe(false)
+    })
+  })
+
   describe('isAbbreviatedVerkey()', () => {
     test.each(validAbbreviatedVerkeys)('returns true when valid abbreviated verkey "%s" is passed in', (verkey) => {
       expect(isAbbreviatedVerkey(verkey)).toBe(true)

--- a/packages/core/src/utils/base58.ts
+++ b/packages/core/src/utils/base58.ts
@@ -1,0 +1,12 @@
+import base from '@multiformats/base-x'
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+
+const base58Converter = base(BASE58_ALPHABET)
+
+export function decodeFromBase58(base58: string) {
+  return base58Converter.decode(base58)
+}
+
+export function encodeToBase58(buffer: Uint8Array) {
+  return base58Converter.encode(buffer)
+}

--- a/packages/core/src/utils/did.ts
+++ b/packages/core/src/utils/did.ts
@@ -15,11 +15,56 @@
  *  https://github.com/hyperledger/aries-framework-dotnet/blob/f90eaf9db8548f6fc831abea917e906201755763/src/Hyperledger.Aries/Ledger/DefaultLedgerService.cs#L139-L147
  */
 
+import { BufferEncoder } from './BufferEncoder'
+
 export const FULL_VERKEY_REGEX = /^[1-9A-HJ-NP-Za-km-z]{43,44}$/
 export const ABBREVIATED_VERKEY_REGEX = /^~[1-9A-HJ-NP-Za-km-z]{21,22}$/
 export const VERKEY_REGEX = new RegExp(`${FULL_VERKEY_REGEX.source}|${ABBREVIATED_VERKEY_REGEX.source}`)
 export const DID_REGEX = /^did:([a-z]+):([a-zA-z\d]+)/
 export const DID_IDENTIFIER_REGEX = /^[a-zA-z\d-]+$/
+
+/**
+ * Check whether the did is a self certifying did. If the verkey is abbreviated this method
+ * will always return true. Make sure that the verkey you pass in this method belongs to the
+ * did passed in
+ *
+ * @return Boolean indicating whether the did is self certifying
+ */
+export function isSelfCertifiedDid(did: string, verkey: string): boolean {
+  // If the verkey is Abbreviated, it means the full verkey
+  // is the did + the verkey
+  if (isAbbreviatedVerkey(verkey)) {
+    return true
+  }
+
+  const buffer = BufferEncoder.fromBase58(verkey)
+
+  const didFromVerkey = BufferEncoder.toBase58(buffer.slice(0, 16))
+
+  if (didFromVerkey === did) {
+    return true
+  }
+
+  return false
+}
+
+/**
+ * Extract did from credential definition id
+ */
+export function didFromCredentialDefinitionId(credentialDefinitionId: string) {
+  const [did] = credentialDefinitionId.split(':')
+
+  return did
+}
+
+/**
+ * Extract did from schema id
+ */
+export function didFromSchemaId(schemaId: string) {
+  const [did] = schemaId.split(':')
+
+  return did
+}
 
 /**
  * Check a base58 encoded string against a regex expression to determine if it is a full valid verkey

--- a/packages/core/src/utils/promises.ts
+++ b/packages/core/src/utils/promises.ts
@@ -1,0 +1,44 @@
+// This file polyfills the allSettled method introduced in ESNext
+
+export type AllSettledFulfilled<T> = {
+  status: 'fulfilled'
+  value: T
+}
+
+export type AllSettledRejected = {
+  status: 'rejected'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  reason: any
+}
+
+export function allSettled<T>(promises: Promise<T>[]) {
+  return Promise.all(
+    promises.map((p) =>
+      p
+        .then(
+          (value) =>
+            ({
+              status: 'fulfilled',
+              value,
+            } as AllSettledFulfilled<T>)
+        )
+        .catch(
+          (reason) =>
+            ({
+              status: 'rejected',
+              reason,
+            } as AllSettledRejected)
+        )
+    )
+  )
+}
+
+export function onlyFulfilled<T>(entries: Array<AllSettledFulfilled<T> | AllSettledRejected>) {
+  // We filter for only the rejected values, so we can safely cast the type
+  return entries.filter((e) => e.status === 'fulfilled') as AllSettledFulfilled<T>[]
+}
+
+export function onlyRejected<T>(entries: Array<AllSettledFulfilled<T> | AllSettledRejected>) {
+  // We filter for only the rejected values, so we can safely cast the type
+  return entries.filter((e) => e.status === 'rejected') as AllSettledRejected[]
+}

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -67,8 +67,13 @@ export function getBaseConfig(name: string, extraConfig: Partial<InitConfig> = {
     },
     publicDidSeed,
     autoAcceptConnections: true,
-    genesisPath,
-    poolName: `pool-${name.toLowerCase()}`,
+    indyLedgers: [
+      {
+        id: `pool-${name}`,
+        isProduction: false,
+        genesisPath,
+      },
+    ],
     logger: new TestLogger(LogLevel.error, name),
     ...extraConfig,
   }
@@ -514,13 +519,11 @@ export async function setupCredentialTests(
     'rxjs:alice': aliceMessages,
   }
   const faberConfig = getBaseConfig(faberName, {
-    genesisPath,
     endpoints: ['rxjs:faber'],
     autoAcceptCredentials,
   })
 
   const aliceConfig = getBaseConfig(aliceName, {
-    genesisPath,
     endpoints: ['rxjs:alice'],
     autoAcceptCredentials,
   })
@@ -553,13 +556,11 @@ export async function setupProofsTest(faberName: string, aliceName: string, auto
   const unique = uuid().substring(0, 4)
 
   const faberConfig = getBaseConfig(`${faberName}-${unique}`, {
-    genesisPath,
     autoAcceptProofs,
     endpoints: ['rxjs:faber'],
   })
 
   const aliceConfig = getBaseConfig(`${aliceName}-${unique}`, {
-    genesisPath,
     autoAcceptProofs,
     endpoints: ['rxjs:alice'],
   })

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -2,8 +2,9 @@ import { promises } from 'fs'
 import * as indy from 'indy-sdk'
 
 import { Agent } from '../src/agent/Agent'
-import { DID_IDENTIFIER_REGEX, VERKEY_REGEX, isFullVerkey, isAbbreviatedVerkey } from '../src/utils/did'
+import { DID_IDENTIFIER_REGEX, isAbbreviatedVerkey, isFullVerkey, VERKEY_REGEX } from '../src/utils/did'
 import { sleep } from '../src/utils/sleep'
+import { IndyWallet } from '../src/wallet/IndyWallet'
 
 import { genesisPath, getBaseConfig } from './helpers'
 import testLogger from './logger'
@@ -65,12 +66,12 @@ describe('ledger', () => {
       throw new Error('Agent does not have public did.')
     }
 
-    const targetDid = 'PNQm3CwyXbN5e39Rw3dXYx'
-    const targetVerkey = '~AHtGeRXtGjVfXALtXP9WiX'
+    const faberWallet = faberAgent.injectionContainer.resolve(IndyWallet)
+    const didInfo = await faberWallet.createDid()
 
-    const result = await faberAgent.ledger.registerPublicDid(targetDid, targetVerkey, 'alias', 'TRUST_ANCHOR')
+    const result = await faberAgent.ledger.registerPublicDid(didInfo.did, didInfo.verkey, 'alias', 'TRUST_ANCHOR')
 
-    expect(result).toEqual(targetDid)
+    expect(result).toEqual(didInfo.did)
   })
 
   test('register schema on ledger', async () => {
@@ -143,7 +144,13 @@ describe('ledger', () => {
   it('should correctly store the genesis file if genesis transactions is passed', async () => {
     const genesisTransactions = await promises.readFile(genesisPath, { encoding: 'utf-8' })
     const { config, agentDependencies: dependencies } = getBaseConfig('Faber Ledger Genesis Transactions', {
-      genesisTransactions,
+      indyLedgers: [
+        {
+          id: 'pool-Faber Ledger Genesis Transactions',
+          isProduction: false,
+          genesisTransactions,
+        },
+      ],
     })
     const agent = new Agent(config, dependencies)
 

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@aries-framework/core": "*",
     "express": "^4.17.1",
-    "indy-sdk": "^1.16.0-dev-1634",
+    "indy-sdk": "^1.16.0-dev-1636",
     "node-fetch": "^2.6.1",
     "ws": "^7.5.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5236,7 +5236,7 @@ indy-sdk-react-native@^0.1.13:
   dependencies:
     buffer "^6.0.2"
 
-indy-sdk@^1.16.0-dev-1634:
+indy-sdk@^1.16.0-dev-1636:
   version "1.16.0-dev-1636"
   resolved "https://registry.yarnpkg.com/indy-sdk/-/indy-sdk-1.16.0-dev-1636.tgz#e53b719a6ce536459b356dbf32b9a7cb18ca59e8"
   integrity sha512-1SYJWdf0xCr+Yd7zTLzYxS7i/j/H2dmBj9C5muPPSdh5XPkL133L0QxZ0NmVdciUY4J5TAyyCjdDgvji1ZSwAw==


### PR DESCRIPTION
Adds support for using multiple indy ledgers simultaneously. I'd really like some input on the approach before wrapping up and merging.

- Only supports multiple ledgers for reading, writing to the ledger still only supports one pool, which is currently always first configured pool.
- `genesisPath`, `poolName` and `genesisTransactions` in the `InitConfig` are replaced by the `indyLedgers` array property with the following structure: (@MosCD3)
- 
```ts
interface IndyPoolConfig {
  genesisPath?: string
  genesisTransactions?: string
  id: string
  isProduction: boolean
}
```
- caching is not implemented yet, I'll do that after validating the approach/implementation
- Algorithm to decide which ledger to use is based on this google doc by @swcurran: https://docs.google.com/document/d/109C_eMsuZnTnYe2OAd02jAts1vC4axwEKIq7_4dnNVA/edit#heading=h.564c8ed7spl8

Before each read operation in `IndyLedgerService` a new method is called, `IndyPoolService.getPoolForDid`. The method will, if successful, return the pool that should be used for the operation. The process is a follows:

1. If no pools are configured, an error will be thrown immediately
1. loop through all configured pools and performs a getNymRequest.
	1. If one of the responses is not successful, and is other than LedgerNotFound, an error will be thrown immediately. This means if one requests fails with an unknown error, the process fails. This is to prevent an incorrect pool from being returned.
	1. If all pools couldn't find the did, a LedgerNotFoundError will be thrown
1. A divide between production and non production ledgers is made.
	1. If there is one or more successful responses from production ledgers, this is assigned as the `remaining` group
	1. If there are no successful responses from production ledgers, and there are one or more successful responses from non production ledgers, the non production results are assigned as the `remaining` group.
1. If there is only one response in the `remaining` group, return the pool associated with the response
1. Loop through all `remaining` responses and check for each if the did is self certifying.
	1. If exactly one of the DIDs is self certifying, return the pool associated with it.
1. If there's still no pool selected, sort all items in the `remaning` group based on `txnTime`. The pool associated with the earliest `txnTime` will be returned.

@swcurran @shaangill025 I'm not so sure on 6. in the process. From the google document I understand that the txnTime is not the same as the time the DID was registered. In the HackMD document from @shaangill025 (https://hackmd.io/BVye073CTiqgNEMXxDeVdQ) the following step is described: "return production ledger with oldest/min datetime". Where does the oldest/min datetime property come from? I'd rather not have a service that tracks DIDs that are on multiple ledgers, and would be inclined to just throw an error instead that the DID couldn't be resolved.