### PR TITLE
fix(core): remove isPositive validation decorators

### DIFF
--- a/packages/core/src/decorators/thread/ThreadDecorator.ts
+++ b/packages/core/src/decorators/thread/ThreadDecorator.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer'
-import { IsInt, IsOptional, IsPositive, Matches } from 'class-validator'
+import { IsInt, IsOptional, Matches } from 'class-validator'
 
 import { MessageIdRegExp } from '../../agent/BaseMessage'
 
@@ -37,7 +37,6 @@ export class ThreadDecorator {
   @Expose({ name: 'sender_order' })
   @IsOptional()
   @IsInt()
-  @IsPositive()
   public senderOrder?: number
 
   /**

--- a/packages/core/src/modules/proofs/models/ProofAttribute.ts
+++ b/packages/core/src/modules/proofs/models/ProofAttribute.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer'
-import { IsInt, IsPositive, IsString } from 'class-validator'
+import { IsInt, IsString } from 'class-validator'
 
 export class ProofAttribute {
   public constructor(options: ProofAttribute) {
@@ -12,7 +12,6 @@ export class ProofAttribute {
 
   @Expose({ name: 'sub_proof_index' })
   @IsInt()
-  @IsPositive()
   public subProofIndex!: number
 
   @IsString()

--- a/packages/core/src/modules/proofs/models/RequestedAttribute.ts
+++ b/packages/core/src/modules/proofs/models/RequestedAttribute.ts
@@ -1,5 +1,5 @@
 import { Exclude, Expose } from 'class-transformer'
-import { IsBoolean, IsInt, IsOptional, IsPositive, IsString } from 'class-validator'
+import { IsBoolean, IsInt, IsOptional, IsString } from 'class-validator'
 
 import { IndyCredentialInfo } from '../../credentials'
 
@@ -21,7 +21,6 @@ export class RequestedAttribute {
   public credentialId!: string
 
   @Expose({ name: 'timestamp' })
-  @IsPositive()
   @IsInt()
   @IsOptional()
   public timestamp?: number

--- a/packages/core/src/modules/proofs/models/RequestedPredicate.ts
+++ b/packages/core/src/modules/proofs/models/RequestedPredicate.ts
@@ -1,5 +1,5 @@
 import { Exclude, Expose } from 'class-transformer'
-import { IsInt, IsOptional, IsPositive, IsString } from 'class-validator'
+import { IsInt, IsOptional, IsString } from 'class-validator'
 
 import { IndyCredentialInfo } from '../../credentials'
 
@@ -20,7 +20,6 @@ export class RequestedPredicate {
   public credentialId!: string
 
   @Expose({ name: 'timestamp' })
-  @IsPositive()
   @IsInt()
   @IsOptional()
   public timestamp?: number

--- a/packages/core/src/modules/routing/messages/BatchPickupMessage.ts
+++ b/packages/core/src/modules/routing/messages/BatchPickupMessage.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer'
-import { Equals, IsInt, IsPositive } from 'class-validator'
+import { Equals, IsInt } from 'class-validator'
 
 import { AgentMessage } from '../../../agent/AgentMessage'
 
@@ -34,6 +34,5 @@ export class BatchPickupMessage extends AgentMessage {
 
   @IsInt()
   @Expose({ name: 'batch_size' })
-  @IsPositive()
   public batchSize!: number
 }


### PR DESCRIPTION
Assumption was that isPositive would check for >= 0, but not negative,
but in reality it checks for >= 1

Signed-off-by: Timo Glastra <timo@animo.id>