### PR TITLE
feat(core): update agent label and imageUrl plus per connection label and imageUrl

### DIFF
--- a/packages/core/src/agent/Agent.ts
+++ b/packages/core/src/agent/Agent.ts
@@ -215,4 +215,8 @@ export class Agent {
   public get injectionContainer() {
     return this.container
   }
+
+  public get config() {
+    return this.agentConfig
+  }
 }

--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -15,6 +15,7 @@ import { DidCommMimeType } from '../types'
 
 export class AgentConfig {
   private initConfig: InitConfig
+  public label: string
   public logger: Logger
   public readonly agentDependencies: AgentDependencies
   public readonly fileSystem: FileSystem
@@ -24,6 +25,7 @@ export class AgentConfig {
 
   public constructor(initConfig: InitConfig, agentDependencies: AgentDependencies) {
     this.initConfig = initConfig
+    this.label = initConfig.label
     this.logger = initConfig.logger ?? new ConsoleLogger(LogLevel.off)
     this.agentDependencies = agentDependencies
     this.fileSystem = new agentDependencies.FileSystem()
@@ -36,10 +38,6 @@ export class AgentConfig {
         `Only one of 'mediatorConnectionsInvite', 'clearDefaultMediator' and 'defaultMediatorId' can be set as they negate each other`
       )
     }
-  }
-
-  public get label() {
-    return this.initConfig.label
   }
 
   public get publicDidSeed() {

--- a/packages/core/src/agent/__tests__/Agent.test.ts
+++ b/packages/core/src/agent/__tests__/Agent.test.ts
@@ -94,6 +94,21 @@ describe('Agent', () => {
     })
   })
 
+  describe('Change label', () => {
+    let agent: Agent
+
+    it('should return new label after setter is called', async () => {
+      expect.assertions(2)
+      const newLabel = 'Agent: Agent Class Test 2'
+
+      agent = new Agent(config, dependencies)
+      expect(agent.config.label).toBe(config.label)
+
+      agent.config.label = newLabel
+      expect(agent.config.label).toBe(newLabel)
+    })
+  })
+
   describe('Dependency Injection', () => {
     it('should be able to resolve registered instances', () => {
       const agent = new Agent(config, dependencies)

--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -49,6 +49,7 @@ export class ConnectionsModule {
     mediatorId?: string
     multiUseInvitation?: boolean
     myLabel?: string
+    myImageUrl?: string
   }): Promise<{
     invitation: ConnectionInvitationMessage
     connectionRecord: ConnectionRecord
@@ -62,6 +63,7 @@ export class ConnectionsModule {
       routing: myRouting,
       multiUseInvitation: config?.multiUseInvitation,
       myLabel: config?.myLabel,
+      myImageUrl: config?.myImageUrl,
     })
 
     return { connectionRecord, invitation }

--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -48,6 +48,7 @@ export class ConnectionsModule {
     alias?: string
     mediatorId?: string
     multiUseInvitation?: boolean
+    myLabel?: string
   }): Promise<{
     invitation: ConnectionInvitationMessage
     connectionRecord: ConnectionRecord
@@ -60,6 +61,7 @@ export class ConnectionsModule {
       alias: config?.alias,
       routing: myRouting,
       multiUseInvitation: config?.multiUseInvitation,
+      myLabel: config?.myLabel,
     })
 
     return { connectionRecord, invitation }

--- a/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -151,6 +151,24 @@ describe('ConnectionService', () => {
       // Defaults to false
       expect(multiUseUndefined.multiUseInvitation).toBe(false)
     })
+
+    it('returns a connection record with the custom label from the config', async () => {
+      expect.assertions(1)
+
+      const { message: invitation } = await connectionService.createInvitation({
+        routing: myRouting,
+        myLabel: 'custom-label',
+      })
+
+      expect(invitation).toEqual(
+        expect.objectContaining({
+          label: 'custom-label',
+          recipientKeys: [expect.any(String)],
+          routingKeys: [],
+          serviceEndpoint: config.endpoints[0],
+        })
+      )
+    })
   })
 
   describe('processInvitation', () => {
@@ -246,6 +264,17 @@ describe('ConnectionService', () => {
       expect(message.connection.did).toBe('test-did')
       expect(message.connection.didDoc).toEqual(connection.didDoc)
       expect(message.imageUrl).toBe(connectionImageUrl)
+    })
+
+    it('returns a connection request message containing a custom label', async () => {
+      expect.assertions(1)
+
+      const connection = getMockConnection()
+      mockFunction(connectionRepository.getById).mockReturnValue(Promise.resolve(connection))
+
+      const { message } = await connectionService.createRequest('test', 'custom-label')
+
+      expect(message.label).toBe('custom-label')
     })
 
     it(`throws an error when connection role is ${ConnectionRole.Inviter} and not ${ConnectionRole.Invitee}`, async () => {

--- a/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -169,6 +169,25 @@ describe('ConnectionService', () => {
         })
       )
     })
+
+    it('returns a connection record with the custom image url from the config', async () => {
+      expect.assertions(1)
+
+      const { message: invitation } = await connectionService.createInvitation({
+        routing: myRouting,
+        myImageUrl: 'custom-image-url',
+      })
+
+      expect(invitation).toEqual(
+        expect.objectContaining({
+          label: config.label,
+          imageUrl: 'custom-image-url',
+          recipientKeys: [expect.any(String)],
+          routingKeys: [],
+          serviceEndpoint: config.endpoints[0],
+        })
+      )
+    })
   })
 
   describe('processInvitation', () => {
@@ -272,9 +291,20 @@ describe('ConnectionService', () => {
       const connection = getMockConnection()
       mockFunction(connectionRepository.getById).mockReturnValue(Promise.resolve(connection))
 
-      const { message } = await connectionService.createRequest('test', 'custom-label')
+      const { message } = await connectionService.createRequest('test', { myLabel: 'custom-label' })
 
       expect(message.label).toBe('custom-label')
+    })
+
+    it('returns a connection request message containing a custom image url', async () => {
+      expect.assertions(1)
+
+      const connection = getMockConnection()
+      mockFunction(connectionRepository.getById).mockReturnValue(Promise.resolve(connection))
+
+      const { message } = await connectionService.createRequest('test', { myImageUrl: 'custom-image-url' })
+
+      expect(message.imageUrl).toBe('custom-image-url')
     })
 
     it(`throws an error when connection role is ${ConnectionRole.Inviter} and not ${ConnectionRole.Invitee}`, async () => {

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -70,6 +70,7 @@ export class ConnectionService {
     alias?: string
     multiUseInvitation?: boolean
     myLabel?: string
+    myImageUrl?: string
   }): Promise<ConnectionProtocolMsgReturnType<ConnectionInvitationMessage>> {
     // TODO: public did
     const connectionRecord = await this.createConnection({
@@ -88,7 +89,7 @@ export class ConnectionService {
       recipientKeys: service.recipientKeys,
       serviceEndpoint: service.serviceEndpoint,
       routingKeys: service.routingKeys,
-      imageUrl: this.config.connectionImageUrl,
+      imageUrl: config?.myImageUrl ?? this.config.connectionImageUrl,
     })
 
     connectionRecord.invitation = invitation
@@ -153,11 +154,15 @@ export class ConnectionService {
    * Create a connection request message for the connection with the specified connection id.
    *
    * @param connectionId the id of the connection for which to create a connection request
+   * @param config config for creation of connection request
    * @returns outbound message containing connection request
    */
   public async createRequest(
     connectionId: string,
-    myLabel?: string
+    config?: {
+      myLabel?: string
+      myImageUrl?: string
+    }
   ): Promise<ConnectionProtocolMsgReturnType<ConnectionRequestMessage>> {
     const connectionRecord = await this.connectionRepository.getById(connectionId)
 
@@ -165,10 +170,10 @@ export class ConnectionService {
     connectionRecord.assertRole(ConnectionRole.Invitee)
 
     const connectionRequest = new ConnectionRequestMessage({
-      label: myLabel ?? this.config.label,
+      label: config?.myLabel ?? this.config.label,
       did: connectionRecord.did,
       didDoc: connectionRecord.didDoc,
-      imageUrl: this.config.connectionImageUrl,
+      imageUrl: config?.myImageUrl ?? this.config.connectionImageUrl,
     })
 
     await this.updateState(connectionRecord, ConnectionState.Requested)

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -69,6 +69,7 @@ export class ConnectionService {
     autoAcceptConnection?: boolean
     alias?: string
     multiUseInvitation?: boolean
+    myLabel?: string
   }): Promise<ConnectionProtocolMsgReturnType<ConnectionInvitationMessage>> {
     // TODO: public did
     const connectionRecord = await this.createConnection({
@@ -83,7 +84,7 @@ export class ConnectionService {
     const { didDoc } = connectionRecord
     const [service] = didDoc.didCommServices
     const invitation = new ConnectionInvitationMessage({
-      label: this.config.label,
+      label: config?.myLabel ?? this.config.label,
       recipientKeys: service.recipientKeys,
       serviceEndpoint: service.serviceEndpoint,
       routingKeys: service.routingKeys,
@@ -154,14 +155,17 @@ export class ConnectionService {
    * @param connectionId the id of the connection for which to create a connection request
    * @returns outbound message containing connection request
    */
-  public async createRequest(connectionId: string): Promise<ConnectionProtocolMsgReturnType<ConnectionRequestMessage>> {
+  public async createRequest(
+    connectionId: string,
+    myLabel?: string
+  ): Promise<ConnectionProtocolMsgReturnType<ConnectionRequestMessage>> {
     const connectionRecord = await this.connectionRepository.getById(connectionId)
 
     connectionRecord.assertState(ConnectionState.Invited)
     connectionRecord.assertRole(ConnectionRole.Invitee)
 
     const connectionRequest = new ConnectionRequestMessage({
-      label: this.config.label,
+      label: myLabel ?? this.config.label,
       did: connectionRecord.did,
       didDoc: connectionRecord.didDoc,
       imageUrl: this.config.connectionImageUrl,


### PR DESCRIPTION
#506 

This pr contains:

- Support for updating agent label
- Support for custom label on connection/invitation

I would also like to add support for a custom imageUrl on connection/label, but before that i would like some feedback on this draft.


