### PR TITLE
refactor(core)!: simplify get creds for proof api

### DIFF
--- a/packages/core/tests/connectionless-proofs.test.ts
+++ b/packages/core/tests/connectionless-proofs.test.ts
@@ -12,7 +12,7 @@ import testLogger from './logger'
 
 describe('Present Proof', () => {
   test('Faber starts with connection-less proof requests to Alice', async () => {
-    const { aliceAgent, faberAgent, aliceReplay, credDefId, faberReplay, presentationPreview } = await setupProofsTest(
+    const { aliceAgent, faberAgent, aliceReplay, credDefId, faberReplay } = await setupProofsTest(
       'Faber connection-less Proofs',
       'Alice connection-less Proofs',
       AutoAcceptProof.Never
@@ -59,12 +59,9 @@ describe('Present Proof', () => {
     })
 
     testLogger.test('Alice accepts presentation request from Faber')
-    const indyProofRequest = aliceProofRecord.requestMessage?.indyProofRequest
-    const retrievedCredentials = await aliceAgent.proofs.getRequestedCredentialsForProofRequest(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      indyProofRequest!,
-      presentationPreview
-    )
+    const retrievedCredentials = await aliceAgent.proofs.getRequestedCredentialsForProofRequest(aliceProofRecord.id, {
+      filterByPresentationPreview: true,
+    })
     const requestedCredentials = aliceAgent.proofs.autoSelectCredentialsForProofRequest(retrievedCredentials)
     await aliceAgent.proofs.acceptRequest(aliceProofRecord.id, requestedCredentials)
 

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -469,11 +469,7 @@ export async function presentProof({
     state: ProofState.RequestReceived,
   })
 
-  const indyProofRequest = holderRecord.requestMessage?.indyProofRequest
-  if (!indyProofRequest) {
-    throw new Error('indyProofRequest missing')
-  }
-  const retrievedCredentials = await holderAgent.proofs.getRequestedCredentialsForProofRequest(indyProofRequest)
+  const retrievedCredentials = await holderAgent.proofs.getRequestedCredentialsForProofRequest(holderRecord.id)
   const requestedCredentials = holderAgent.proofs.autoSelectCredentialsForProofRequest(retrievedCredentials)
   await holderAgent.proofs.acceptRequest(holderRecord.id, requestedCredentials)
 

--- a/packages/core/tests/proofs-auto-accept.test.ts
+++ b/packages/core/tests/proofs-auto-accept.test.ts
@@ -188,12 +188,9 @@ describe('Auto accept present proof', () => {
       })
 
       testLogger.test('Alice accepts presentation request from Faber')
-      const indyProofRequest = aliceProofRecord.requestMessage?.indyProofRequest
-      const retrievedCredentials = await aliceAgent.proofs.getRequestedCredentialsForProofRequest(
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        indyProofRequest!,
-        presentationPreview
-      )
+      const retrievedCredentials = await aliceAgent.proofs.getRequestedCredentialsForProofRequest(aliceProofRecord.id, {
+        filterByPresentationPreview: true,
+      })
       const requestedCredentials = aliceAgent.proofs.autoSelectCredentialsForProofRequest(retrievedCredentials)
       await aliceAgent.proofs.acceptRequest(aliceProofRecord.id, requestedCredentials)
 

--- a/packages/core/tests/proofs.test.ts
+++ b/packages/core/tests/proofs.test.ts
@@ -1,4 +1,4 @@
-import type { Agent, ConnectionRecord, PresentationPreview, ProofRequest } from '../src'
+import type { Agent, ConnectionRecord, PresentationPreview } from '../src'
 import type { CredDefId } from 'indy-sdk'
 
 import {
@@ -95,11 +95,9 @@ describe('Present Proof', () => {
 
     // Alice retrieves the requested credentials and accepts the presentation request
     testLogger.test('Alice accepts presentation request from Faber')
-    const indyProofRequest = aliceProofRecord.requestMessage?.indyProofRequest as ProofRequest
-    const retrievedCredentials = await aliceAgent.proofs.getRequestedCredentialsForProofRequest(
-      indyProofRequest,
-      presentationPreview
-    )
+    const retrievedCredentials = await aliceAgent.proofs.getRequestedCredentialsForProofRequest(aliceProofRecord.id, {
+      filterByPresentationPreview: true,
+    })
     const requestedCredentials = aliceAgent.proofs.autoSelectCredentialsForProofRequest(retrievedCredentials)
     await aliceAgent.proofs.acceptRequest(aliceProofRecord.id, requestedCredentials)
 
@@ -254,11 +252,9 @@ describe('Present Proof', () => {
 
     // Alice retrieves the requested credentials and accepts the presentation request
     testLogger.test('Alice accepts presentation request from Faber')
-    const indyProofRequest = aliceProofRecord.requestMessage?.indyProofRequest as ProofRequest
-    const retrievedCredentials = await aliceAgent.proofs.getRequestedCredentialsForProofRequest(
-      indyProofRequest,
-      presentationPreview
-    )
+    const retrievedCredentials = await aliceAgent.proofs.getRequestedCredentialsForProofRequest(aliceProofRecord.id, {
+      filterByPresentationPreview: true,
+    })
     const requestedCredentials = aliceAgent.proofs.autoSelectCredentialsForProofRequest(retrievedCredentials)
     await aliceAgent.proofs.acceptRequest(aliceProofRecord.id, requestedCredentials)
 


### PR DESCRIPTION
BREAKING CHANGE: The `ProofsModule.getRequestedCredentialsForProofRequest` expected some low level message objects as input. This is not in line with the public API of the rest of the framework and has been simplified to only require a proof record id and optionally a boolean whether the retrieved credentials should by filtered based on the proof proposal (if avaiable).

Signed-off-by: Timo Glastra <timo@animo.id>

Maintainers: Before merging and squashing make sure to copy the `BREAKING CHANGE` entry to the commit message field, this is needed for automatic tracking of breaking changes