### PR TITLE
fix(core): fix empty error log in console logger

### DIFF
--- a/packages/core/src/logger/ConsoleLogger.ts
+++ b/packages/core/src/logger/ConsoleLogger.ts
@@ -3,6 +3,24 @@
 import { BaseLogger } from './BaseLogger'
 import { LogLevel } from './Logger'
 
+/*
+ * The replacer parameter allows you to specify a function that replaces values with your own. We can use it to control what gets stringified.
+ */
+function replaceError(_: unknown, value: unknown) {
+  if (value instanceof Error) {
+    const newValue = Object.getOwnPropertyNames(value).reduce(
+      (obj, propName) => {
+        obj[propName] = (value as unknown as Record<string, unknown>)[propName]
+        return obj
+      },
+      { name: value.name } as Record<string, unknown>
+    )
+    return newValue
+  }
+
+  return value
+}
+
 export class ConsoleLogger extends BaseLogger {
   // Map our log levels to console levels
   private consoleLogMap = {
@@ -27,7 +45,7 @@ export class ConsoleLogger extends BaseLogger {
 
     // Log, with or without data
     if (data) {
-      console[consoleLevel](`${prefix}: ${message}`, JSON.stringify(data, null, 2))
+      console[consoleLevel](`${prefix}: ${message}`, JSON.stringify(data, replaceError, 2))
     } else {
       console[consoleLevel](`${prefix}: ${message}`)
     }


### PR DESCRIPTION
The console logger stringified the data object. Appereantly the Error class has no enumerable properties which means it will be stringified as an empty object. This fix checks if a (top level) value being transformed is an error and will transform the non-enumerable properties of the error.

Signed-off-by: Timo Glastra <timo@animo.id>