### PR TITLE
fix(core)!: do not request ping res for connection

### DIFF
--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -162,7 +162,9 @@ export class ConnectionsModule {
    * @returns connection record
    */
   public async acceptResponse(connectionId: string): Promise<ConnectionRecord> {
-    const { message, connectionRecord: connectionRecord } = await this.connectionService.createTrustPing(connectionId)
+    const { message, connectionRecord: connectionRecord } = await this.connectionService.createTrustPing(connectionId, {
+      responseRequested: false,
+    })
 
     const outbound = createOutboundMessage(connectionRecord, message)
     await this.messageSender.sendMessage(outbound)

--- a/packages/core/src/modules/connections/handlers/ConnectionResponseHandler.ts
+++ b/packages/core/src/modules/connections/handlers/ConnectionResponseHandler.ts
@@ -22,7 +22,7 @@ export class ConnectionResponseHandler implements Handler {
     // In AATH we have a separate step to send the ping. So for now we'll only do it
     // if auto accept is enable
     if (connection.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
-      const { message } = await this.connectionService.createTrustPing(connection.id)
+      const { message } = await this.connectionService.createTrustPing(connection.id, { responseRequested: false })
       return createOutboundMessage(connection, message)
     }
   }

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -350,19 +350,25 @@ export class ConnectionService {
   /**
    * Create a trust ping message for the connection with the specified connection id.
    *
+   * By default a trust ping message should elicit a response. If this is not desired the
+   * `config.responseRequested` property can be set to `false`.
+   *
    * @param connectionId the id of the connection for which to create a trust ping message
+   * @param config the config for the trust ping message
    * @returns outbound message containing trust ping message
    */
-  public async createTrustPing(connectionId: string): Promise<ConnectionProtocolMsgReturnType<TrustPingMessage>> {
+  public async createTrustPing(
+    connectionId: string,
+    config: { responseRequested?: boolean; comment?: string } = {}
+  ): Promise<ConnectionProtocolMsgReturnType<TrustPingMessage>> {
     const connectionRecord = await this.connectionRepository.getById(connectionId)
 
     connectionRecord.assertState([ConnectionState.Responded, ConnectionState.Complete])
 
     // TODO:
     //  - create ack message
-    //  - allow for options
     //  - maybe this shouldn't be in the connection service?
-    const trustPing = new TrustPingMessage({})
+    const trustPing = new TrustPingMessage(config)
 
     await this.updateState(connectionRecord, ConnectionState.Complete)
 

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -92,7 +92,9 @@ export class RecipientModule {
   }
 
   private async openMediationWebSocket(mediator: MediationRecord) {
-    const { message, connectionRecord } = await this.connectionService.createTrustPing(mediator.connectionId)
+    const { message, connectionRecord } = await this.connectionService.createTrustPing(mediator.connectionId, {
+      responseRequested: false,
+    })
 
     const websocketSchemes = ['ws', 'wss']
     const hasWebSocketTransport = connectionRecord.theirDidDoc?.didCommServices?.some((s) =>


### PR DESCRIPTION
BREAKING CHANGE: a trust ping response will not be requested anymore after completing a connection. This is not required, and also non-standard behaviour. It was also causing some tests to be flaky as response messages were stil being sent after one of the agents had already shut down.

Signed-off-by: Timo Glastra <timo@animo.id>

Maintainers: Before merging and squashing make sure to copy the `BREAKING CHANGE` entry to the commit message field, this is needed for automatic tracking of breaking changes


Fixes #515 