### PR TITLE
fix(core): log errors if message is undeliverable

### DIFF
--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -85,6 +85,8 @@ export class MessageSender {
     packedMessage: WireMessage
     options?: { transportPriority?: TransportPriorityOptions }
   }) {
+    const errors: Error[] = []
+
     // Try to send to already open session
     const session = this.transportService.findSessionByConnectionId(connection.id)
     if (session?.inboundMessage?.hasReturnRouting()) {
@@ -92,7 +94,8 @@ export class MessageSender {
         await session.send(packedMessage)
         return
       } catch (error) {
-        this.logger.info(`Sending packed message via session failed with error: ${error.message}.`, error)
+        errors.push(error)
+        this.logger.debug(`Sending packed message via session failed with error: ${error.message}.`, error)
       }
     }
 
@@ -140,9 +143,10 @@ export class MessageSender {
     // Message is undeliverable
     this.logger.error(`Message is undeliverable to connection ${connection.id} (${connection.theirLabel})`, {
       message: packedMessage,
+      errors,
       connection,
     })
-    throw new AriesFrameworkError(`Message is undeliverable to connection ${connection.id} (${connection.theirLabel})`)
+    throw new AriesFrameworkError(`Message is undeliverable to connection ${connection.id} (${connection.theirLabel})}`)
   }
 
   public async sendMessage(
@@ -152,6 +156,7 @@ export class MessageSender {
     }
   ) {
     const { connection, payload } = outboundMessage
+    const errors: Error[] = []
 
     this.logger.debug('Send outbound message', {
       message: payload,
@@ -166,7 +171,8 @@ export class MessageSender {
         await this.sendMessageToSession(session, payload)
         return
       } catch (error) {
-        this.logger.info(`Sending an outbound message via session failed with error: ${error.message}.`, error)
+        errors.push(error)
+        this.logger.debug(`Sending an outbound message via session failed with error: ${error.message}.`, error)
       }
     }
 
@@ -188,6 +194,7 @@ export class MessageSender {
         })
         return
       } catch (error) {
+        errors.push(error)
         this.logger.debug(
           `Sending outbound message to service with id ${service.id} failed with the following error:`,
           {
@@ -217,6 +224,7 @@ export class MessageSender {
     // Message is undeliverable
     this.logger.error(`Message is undeliverable to connection ${connection.id} (${connection.theirLabel})`, {
       message: payload,
+      errors,
       connection,
     })
     throw new AriesFrameworkError(`Message is undeliverable to connection ${connection.id} (${connection.theirLabel})`)

--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -146,7 +146,7 @@ export class MessageSender {
       errors,
       connection,
     })
-    throw new AriesFrameworkError(`Message is undeliverable to connection ${connection.id} (${connection.theirLabel})}`)
+    throw new AriesFrameworkError(`Message is undeliverable to connection ${connection.id} (${connection.theirLabel})`)
   }
 
   public async sendMessage(


### PR DESCRIPTION
The error message being logged just indicated that a message is underliverable to a certain connection. It swallowed the underlying errors. This adds an `errors` property to the error log so that it is clear what the underlying errors are when a message is underliverable.

Signed-off-by: Timo Glastra <timo@animo.id>