### PR TITLE
fix(core)!: prefixed internal metadata with _internal/

### DIFF
--- a/packages/core/src/modules/credentials/__tests__/CredentialRecord.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialRecord.test.ts
@@ -17,7 +17,7 @@ describe('CredentialRecord', () => {
         ],
       })
 
-      credentialRecord.metadata.set('indyCredential', {
+      credentialRecord.metadata.set('_internal/indyCredential', {
         credentialDefinitionId: 'Th7MpTaRZVRYnPiabds81Y:3:CL:17:TAG',
         schemaId: 'TL1EaPFCZ8Si5aUrqScBDt:2:test-schema-1599055118161:1.0',
       })
@@ -29,7 +29,7 @@ describe('CredentialRecord', () => {
           age: '25',
         },
         metadata: {
-          indyCredential: {
+          '_internal/indyCredential': {
             credentialDefinitionId: 'Th7MpTaRZVRYnPiabds81Y:3:CL:17:TAG',
             schemaId: 'TL1EaPFCZ8Si5aUrqScBDt:2:test-schema-1599055118161:1.0',
           },

--- a/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
@@ -124,17 +124,17 @@ const mockCredentialRecord = ({
   })
 
   if (metadata?.indyRequest) {
-    credentialRecord.metadata.set('indyRequest', { ...metadata.indyRequest })
+    credentialRecord.metadata.set('_internal/indyRequest', { ...metadata.indyRequest })
   }
 
   if (metadata?.schemaId) {
-    credentialRecord.metadata.add('indyCredential', {
+    credentialRecord.metadata.add('_internal/indyCredential', {
       schemaId: metadata.schemaId,
     })
   }
 
   if (metadata?.credentialDefinitionId) {
-    credentialRecord.metadata.add('indyCredential', {
+    credentialRecord.metadata.add('_interal/indyCredential', {
       credentialDefinitionId: metadata.credentialDefinitionId,
     })
   }
@@ -339,7 +339,7 @@ describe('CredentialService', () => {
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
       const [[updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
       expect(updatedCredentialRecord.toJSON()).toMatchObject({
-        metadata: { indyRequest: { cred_req: 'meta-data' } },
+        metadata: { '_internal/indyRequest': { cred_req: 'meta-data' } },
         state: CredentialState.RequestSent,
       })
     })

--- a/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
@@ -134,7 +134,7 @@ const mockCredentialRecord = ({
   }
 
   if (metadata?.credentialDefinitionId) {
-    credentialRecord.metadata.add('_interal/indyCredential', {
+    credentialRecord.metadata.add('_internal/indyCredential', {
       credentialDefinitionId: metadata.credentialDefinitionId,
     })
   }

--- a/packages/core/src/modules/credentials/services/CredentialService.ts
+++ b/packages/core/src/modules/credentials/services/CredentialService.ts
@@ -108,7 +108,7 @@ export class CredentialService {
     })
 
     // Set the metadata
-    credentialRecord.metadata.set('indyCredential', {
+    credentialRecord.metadata.set('_internal/indyCredential', {
       schemaId: options.schemaId,
       credentialDefinintionId: options.credentialDefinitionId,
     })
@@ -195,7 +195,7 @@ export class CredentialService {
         state: CredentialState.ProposalReceived,
       })
 
-      credentialRecord.metadata.set('indyCredential', {
+      credentialRecord.metadata.set('_internal/indyCredential', {
         schemaId: proposalMessage.schemaId,
         credentialDefinitionId: proposalMessage.credentialDefinitionId,
       })
@@ -257,7 +257,7 @@ export class CredentialService {
 
     credentialRecord.offerMessage = credentialOfferMessage
     credentialRecord.credentialAttributes = preview.attributes
-    credentialRecord.metadata.set('indyCredential', {
+    credentialRecord.metadata.set('_internal/indyCredential', {
       schemaId: credOffer.schema_id,
       credentialDefinitionId: credOffer.cred_def_id,
     })
@@ -321,7 +321,7 @@ export class CredentialService {
       autoAcceptCredential: credentialTemplate.autoAcceptCredential,
     })
 
-    credentialRecord.metadata.set('indyCredential', {
+    credentialRecord.metadata.set('_internal/indyCredential', {
       credentialDefinitionId: credOffer.cred_def_id,
       schemaId: credOffer.schema_id,
     })
@@ -375,7 +375,7 @@ export class CredentialService {
       credentialRecord.offerMessage = credentialOfferMessage
       credentialRecord.linkedAttachments = credentialOfferMessage.attachments?.filter(isLinkedAttachment)
 
-      credentialRecord.metadata.set('indyCredential', {
+      credentialRecord.metadata.set('_internal/indyCredential', {
         schemaId: indyCredentialOffer.schema_id,
         credentialDefinitionId: indyCredentialOffer.cred_def_id,
       })
@@ -391,7 +391,7 @@ export class CredentialService {
         state: CredentialState.OfferReceived,
       })
 
-      credentialRecord.metadata.set('indyCredential', {
+      credentialRecord.metadata.set('_internal/indyCredential', {
         credentialDefinitionId: indyCredentialOffer.cred_def_id,
         schemaId: indyCredentialOffer.schema_id,
       })
@@ -459,7 +459,7 @@ export class CredentialService {
     })
     credentialRequest.setThread({ threadId: credentialRecord.threadId })
 
-    credentialRecord.metadata.set('indyRequest', credReqMetadata)
+    credentialRecord.metadata.set('_internal/indyRequest', credReqMetadata)
     credentialRecord.requestMessage = credentialRequest
     credentialRecord.autoAcceptCredential = options?.autoAcceptCredential ?? credentialRecord.autoAcceptCredential
 
@@ -623,7 +623,7 @@ export class CredentialService {
       previousSentMessage: credentialRecord.requestMessage,
     })
 
-    const credentialRequestMetadata = credentialRecord.metadata.get<CredReqMetadata>('indyRequest')
+    const credentialRequestMetadata = credentialRecord.metadata.get<CredReqMetadata>('_internal/indyRequest')
 
     if (!credentialRequestMetadata) {
       throw new AriesFrameworkError(`Missing required request metadata for credential with id ${credentialRecord.id}`)

--- a/packages/core/src/utils/__tests__/transformers.test.ts
+++ b/packages/core/src/utils/__tests__/transformers.test.ts
@@ -17,10 +17,10 @@ describe('transformers', () => {
     const cr = plainToClass(CredentialRecord, jsonCredentialRecord)
 
     expect(cr.metadata.data).toEqual({
-      indyRequest: {
+      '_internal/indyRequest': {
         cred_req: 'x',
       },
-      indyCredential: {
+      '_internal/indyCredential': {
         schemaId: 'abc:def',
         credentialDefinitionId: 'abc:def:CL',
       },

--- a/packages/core/src/utils/transformers.ts
+++ b/packages/core/src/utils/transformers.ts
@@ -60,12 +60,12 @@ export function MetadataTransformer() {
       const { requestMetadata, schemaId, credentialDefinitionId, ...rest } = value
       const metadata = new Metadata(rest)
 
-      if (requestMetadata) metadata.add('indyRequest', { ...value.requestMetadata })
+      if (requestMetadata) metadata.add('_internal/indyRequest', { ...value.requestMetadata })
 
-      if (schemaId) metadata.add('indyCredential', { schemaId: value.schemaId })
+      if (schemaId) metadata.add('_internal/indyCredential', { schemaId: value.schemaId })
 
       if (credentialDefinitionId)
-        metadata.add('indyCredential', { credentialDefinitionId: value.credentialDefinitionId })
+        metadata.add('_internal/indyCredential', { credentialDefinitionId: value.credentialDefinitionId })
 
       return metadata
     }

--- a/packages/core/tests/connectionless-credentials.test.ts
+++ b/packages/core/tests/connectionless-credentials.test.ts
@@ -125,7 +125,7 @@ describe('credentials', () => {
       requestMessage: expect.any(Object),
       metadata: {
         data: {
-          indyCredential: {
+          '_internal/indyCredential': {
             credentialDefinitionId: credDefId,
           },
         },
@@ -143,7 +143,7 @@ describe('credentials', () => {
       requestMessage: expect.any(Object),
       metadata: {
         data: {
-          indyCredential: {
+          '_internal/indyCredential': {
             credentialDefinitionId: credDefId,
           },
         },
@@ -193,7 +193,7 @@ describe('credentials', () => {
       requestMessage: expect.any(Object),
       metadata: {
         data: {
-          indyCredential: {
+          '_internal/indyCredential': {
             credentialDefinitionId: credDefId,
           },
         },

--- a/packages/core/tests/credentials-auto-accept.test.ts
+++ b/packages/core/tests/credentials-auto-accept.test.ts
@@ -74,8 +74,8 @@ describe('auto accept credentials', () => {
         requestMessage: expect.any(Object),
         metadata: {
           data: {
-            indyRequest: expect.any(Object),
-            indyCredential: {
+            '_internal/indyRequest': expect.any(Object),
+            '_internal/indyCredential': {
               schemaId,
               credentialDefinitionId: credDefId,
             },
@@ -91,7 +91,7 @@ describe('auto accept credentials', () => {
         createdAt: expect.any(Date),
         metadata: {
           data: {
-            indyCredential: {
+            '_internal/indyCredential': {
               schemaId,
               credentialDefinitionId: credDefId,
             },
@@ -131,8 +131,8 @@ describe('auto accept credentials', () => {
         requestMessage: expect.any(Object),
         metadata: {
           data: {
-            indyRequest: expect.any(Object),
-            indyCredential: {
+            '_internal/indyRequest': expect.any(Object),
+            '_internal/indyCredential': {
               schemaId,
               credentialDefinitionId: credDefId,
             },
@@ -207,8 +207,8 @@ describe('auto accept credentials', () => {
         requestMessage: expect.any(Object),
         metadata: {
           data: {
-            indyRequest: expect.any(Object),
-            indyCredential: {
+            '_internal/indyRequest': expect.any(Object),
+            '_internal/indyCredential': {
               schemaId,
               credentialDefinitionId: credDefId,
             },
@@ -224,7 +224,7 @@ describe('auto accept credentials', () => {
         createdAt: expect.any(Date),
         metadata: {
           data: {
-            indyCredential: {
+            '_internal/indyCredential': {
               schemaId,
               credentialDefinitionId: credDefId,
             },
@@ -304,8 +304,8 @@ describe('auto accept credentials', () => {
         requestMessage: expect.any(Object),
         metadata: {
           data: {
-            indyRequest: expect.any(Object),
-            indyCredential: {
+            '_internal/indyRequest': expect.any(Object),
+            '_internal/indyCredential': {
               schemaId,
               credentialDefinitionId: credDefId,
             },


### PR DESCRIPTION
BREAKING CHANGE: internal metadata is now prefixed with `_internal` to avoid clashing and accidental overwriting of internal data.

- All the internal metadata MUST be prefixed with `_internal` to indicate to the framework consumer that this data is internal metadata and is required by the framework.