### PR TITLE
ci: more node versions to test

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -52,7 +52,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.2]
+        node-version: [12.x, 14.x, 16.x, 17.x]
 
     steps:
       - name: Checkout aries-framework-javascript


### PR DESCRIPTION
- Tests on node 16.x instead of 16.2
- Tests on 17.x for latest compatibility

Marked as draft to check the tests first

Closes #309 

Signed-off-by: Berend Sliedrecht <berend@animo.id>