### PR TITLE
refactor: move methods to get supported protocols to Dispatcher

### DIFF
--- a/packages/core/src/agent/Dispatcher.ts
+++ b/packages/core/src/agent/Dispatcher.ts
@@ -108,7 +108,7 @@ class Dispatcher {
    * Protocol ID format is PIURI specified at https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0003-protocols/README.md#piuri.
    */
   public get supportedProtocols() {
-    return Array.from(new Set(this.supportedMessageTypes.map((m) => m.substring(0, m.lastIndexOf('/') + 1))))
+    return Array.from(new Set(this.supportedMessageTypes.map((m) => m.substring(0, m.lastIndexOf('/')))))
   }
 }
 

--- a/packages/core/src/agent/Dispatcher.ts
+++ b/packages/core/src/agent/Dispatcher.ts
@@ -93,10 +93,22 @@ class Dispatcher {
     }
   }
 
+  /**
+   * Returns array of message types that dispatcher is able to handle.
+   * Message type format is MTURI specified at https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0003-protocols/README.md#mturi.
+   */
   public get supportedMessageTypes() {
     return this.handlers
       .reduce<typeof AgentMessage[]>((all, cur) => [...all, ...cur.supportedMessages], [])
       .map((m) => m.type)
+  }
+
+  /**
+   * Returns array of protocol IDs that dispatcher is able to handle.
+   * Protocol ID format is PIURI specified at https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0003-protocols/README.md#piuri.
+   */
+  public get supportedProtocols() {
+    return Array.from(new Set(this.supportedMessageTypes.map((m) => m.substring(0, m.lastIndexOf('/') + 1))))
   }
 }
 

--- a/packages/core/src/agent/Dispatcher.ts
+++ b/packages/core/src/agent/Dispatcher.ts
@@ -110,6 +110,12 @@ class Dispatcher {
   public get supportedProtocols() {
     return Array.from(new Set(this.supportedMessageTypes.map((m) => m.substring(0, m.lastIndexOf('/')))))
   }
+
+  public filterSupportedProtocolsByMessageFamilies(messageFamilies: string[]) {
+    return this.supportedProtocols.filter((protocolId) =>
+      messageFamilies.find((messageFamily) => protocolId.startsWith(messageFamily))
+    )
+  }
 }
 
 export { Dispatcher }

--- a/packages/core/src/agent/__tests__/Dispatcher.test.ts
+++ b/packages/core/src/agent/__tests__/Dispatcher.test.ts
@@ -1,0 +1,77 @@
+import type { Handler } from '../Handler'
+
+import { getAgentConfig } from '../../../tests/helpers'
+import { AgentMessage } from '../AgentMessage'
+import { Dispatcher } from '../Dispatcher'
+import { EventEmitter } from '../EventEmitter'
+import { MessageSender } from '../MessageSender'
+
+class ConnectionInvitationTestMessage extends AgentMessage {
+  public static readonly type = 'https://didcomm.org/connections/1.0/invitation'
+}
+class ConnectionRequestTestMessage extends AgentMessage {
+  public static readonly type = 'https://didcomm.org/connections/1.0/request'
+}
+
+class ConnectionResponseTestMessage extends AgentMessage {
+  public static readonly type = 'https://didcomm.org/connections/1.0/response'
+}
+
+class NotificationAckTestMessage extends AgentMessage {
+  public static readonly type = 'https://didcomm.org/notification/1.0/ack'
+}
+class CredentialProposalTestMessage extends AgentMessage {
+  public static readonly type = 'https://didcomm.org/issue-credential/1.0/credential-proposal'
+}
+
+class TestHandler implements Handler {
+  public constructor(classes: any[]) {
+    this.supportedMessages = classes
+  }
+
+  public supportedMessages
+
+  // We don't need an implementation in test handler so we can disable lint.
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  public async handle() {}
+}
+
+describe('Dispatcher', () => {
+  const agentConfig = getAgentConfig('DispatcherTest')
+  const MessageSenderMock = MessageSender as jest.Mock<MessageSender>
+  const eventEmitter = new EventEmitter(agentConfig)
+
+  const dispatcher = new Dispatcher(new MessageSenderMock(), eventEmitter, agentConfig)
+
+  dispatcher.registerHandler(
+    new TestHandler([ConnectionInvitationTestMessage, ConnectionRequestTestMessage, ConnectionResponseTestMessage])
+  )
+  dispatcher.registerHandler(new TestHandler([NotificationAckTestMessage]))
+  dispatcher.registerHandler(new TestHandler([CredentialProposalTestMessage]))
+
+  describe('supportedMessageTypes', () => {
+    test('return all supported message types URIs', async () => {
+      const messageTypes = dispatcher.supportedMessageTypes
+
+      expect(messageTypes).toEqual([
+        'https://didcomm.org/connections/1.0/invitation',
+        'https://didcomm.org/connections/1.0/request',
+        'https://didcomm.org/connections/1.0/response',
+        'https://didcomm.org/notification/1.0/ack',
+        'https://didcomm.org/issue-credential/1.0/credential-proposal',
+      ])
+    })
+  })
+
+  describe('supportedProtocols', () => {
+    test('return all supported message protocols URIs', async () => {
+      const messageTypes = dispatcher.supportedProtocols
+
+      expect(messageTypes).toEqual([
+        'https://didcomm.org/connections/1.0/',
+        'https://didcomm.org/notification/1.0/',
+        'https://didcomm.org/issue-credential/1.0/',
+      ])
+    })
+  })
+})

--- a/packages/core/src/agent/__tests__/Dispatcher.test.ts
+++ b/packages/core/src/agent/__tests__/Dispatcher.test.ts
@@ -68,9 +68,9 @@ describe('Dispatcher', () => {
       const messageTypes = dispatcher.supportedProtocols
 
       expect(messageTypes).toEqual([
-        'https://didcomm.org/connections/1.0/',
-        'https://didcomm.org/notification/1.0/',
-        'https://didcomm.org/issue-credential/1.0/',
+        'https://didcomm.org/connections/1.0',
+        'https://didcomm.org/notification/1.0',
+        'https://didcomm.org/issue-credential/1.0',
       ])
     })
   })

--- a/packages/core/src/agent/__tests__/Dispatcher.test.ts
+++ b/packages/core/src/agent/__tests__/Dispatcher.test.ts
@@ -74,4 +74,26 @@ describe('Dispatcher', () => {
       ])
     })
   })
+
+  describe('filterSupportedProtocolsByMessageFamilies', () => {
+    it('should return empty array when input is empty array', async () => {
+      const supportedProtocols = dispatcher.filterSupportedProtocolsByMessageFamilies([])
+      expect(supportedProtocols).toEqual([])
+    })
+
+    it('should return empty array when input contains only unsupported protocol', async () => {
+      const supportedProtocols = dispatcher.filterSupportedProtocolsByMessageFamilies([
+        'https://didcomm.org/unsupported-protocol/1.0',
+      ])
+      expect(supportedProtocols).toEqual([])
+    })
+
+    it('should return array with only supported protocol when input contains supported and unsupported protocol', async () => {
+      const supportedProtocols = dispatcher.filterSupportedProtocolsByMessageFamilies([
+        'https://didcomm.org/connections',
+        'https://didcomm.org/didexchange',
+      ])
+      expect(supportedProtocols).toEqual(['https://didcomm.org/connections/1.0'])
+    })
+  })
 })

--- a/packages/core/src/modules/discover-features/__tests__/DiscoverFeaturesService.test.ts
+++ b/packages/core/src/modules/discover-features/__tests__/DiscoverFeaturesService.test.ts
@@ -4,9 +4,9 @@ import { QueryMessage } from '../messages'
 import { DiscoverFeaturesService } from '../services/DiscoverFeaturesService'
 
 const supportedProtocols = [
-  'https://didcomm.org/connections/1.0/',
-  'https://didcomm.org/notification/1.0/',
-  'https://didcomm.org/issue-credential/1.0/',
+  'https://didcomm.org/connections/1.0',
+  'https://didcomm.org/notification/1.0',
+  'https://didcomm.org/issue-credential/1.0',
 ]
 
 describe('DiscoverFeaturesService', () => {
@@ -21,20 +21,20 @@ describe('DiscoverFeaturesService', () => {
       const message = await discoverFeaturesService.createDisclose(queryMessage)
 
       expect(message.protocols.map((p) => p.protocolId)).toStrictEqual([
-        'https://didcomm.org/connections/1.0/',
-        'https://didcomm.org/notification/1.0/',
-        'https://didcomm.org/issue-credential/1.0/',
+        'https://didcomm.org/connections/1.0',
+        'https://didcomm.org/notification/1.0',
+        'https://didcomm.org/issue-credential/1.0',
       ])
     })
 
     it('should return only one protocol if the query specifies a specific protocol', async () => {
       const queryMessage = new QueryMessage({
-        query: 'https://didcomm.org/connections/1.0/',
+        query: 'https://didcomm.org/connections/1.0',
       })
 
       const message = await discoverFeaturesService.createDisclose(queryMessage)
 
-      expect(message.protocols.map((p) => p.protocolId)).toStrictEqual(['https://didcomm.org/connections/1.0/'])
+      expect(message.protocols.map((p) => p.protocolId)).toStrictEqual(['https://didcomm.org/connections/1.0'])
     })
 
     it('should respect a wild card at the end of the query', async () => {
@@ -44,7 +44,7 @@ describe('DiscoverFeaturesService', () => {
 
       const message = await discoverFeaturesService.createDisclose(queryMessage)
 
-      expect(message.protocols.map((p) => p.protocolId)).toStrictEqual(['https://didcomm.org/connections/1.0/'])
+      expect(message.protocols.map((p) => p.protocolId)).toStrictEqual(['https://didcomm.org/connections/1.0'])
     })
   })
 

--- a/packages/core/src/modules/discover-features/__tests__/DiscoverFeaturesService.test.ts
+++ b/packages/core/src/modules/discover-features/__tests__/DiscoverFeaturesService.test.ts
@@ -3,16 +3,14 @@ import type { Dispatcher } from '../../../agent/Dispatcher'
 import { DiscoverFeaturesQueryMessage } from '../messages'
 import { DiscoverFeaturesService } from '../services/DiscoverFeaturesService'
 
-const supportedMessageTypes = [
-  'https://didcomm.org/connections/1.0/invitation',
-  'https://didcomm.org/connections/1.0/request',
-  'https://didcomm.org/connections/1.0/response',
-  'https://didcomm.org/notification/1.0/ack',
-  'https://didcomm.org/issue-credential/1.0/credential-proposal',
+const supportedProtocols = [
+  'https://didcomm.org/connections/1.0/',
+  'https://didcomm.org/notification/1.0/',
+  'https://didcomm.org/issue-credential/1.0/',
 ]
 
 describe('DiscoverFeaturesService', () => {
-  const discoverFeaturesService = new DiscoverFeaturesService({ supportedMessageTypes } as Dispatcher)
+  const discoverFeaturesService = new DiscoverFeaturesService({ supportedProtocols } as Dispatcher)
 
   describe('createDisclose', () => {
     it('should return all protocols when query is *', async () => {

--- a/packages/core/src/modules/discover-features/__tests__/DiscoverFeaturesService.test.ts
+++ b/packages/core/src/modules/discover-features/__tests__/DiscoverFeaturesService.test.ts
@@ -1,6 +1,6 @@
 import type { Dispatcher } from '../../../agent/Dispatcher'
 
-import { DiscoverFeaturesQueryMessage } from '../messages'
+import { QueryMessage } from '../messages'
 import { DiscoverFeaturesService } from '../services/DiscoverFeaturesService'
 
 const supportedProtocols = [
@@ -14,7 +14,7 @@ describe('DiscoverFeaturesService', () => {
 
   describe('createDisclose', () => {
     it('should return all protocols when query is *', async () => {
-      const queryMessage = new DiscoverFeaturesQueryMessage({
+      const queryMessage = new QueryMessage({
         query: '*',
       })
 
@@ -28,7 +28,7 @@ describe('DiscoverFeaturesService', () => {
     })
 
     it('should return only one protocol if the query specifies a specific protocol', async () => {
-      const queryMessage = new DiscoverFeaturesQueryMessage({
+      const queryMessage = new QueryMessage({
         query: 'https://didcomm.org/connections/1.0/',
       })
 
@@ -38,7 +38,7 @@ describe('DiscoverFeaturesService', () => {
     })
 
     it('should respect a wild card at the end of the query', async () => {
-      const queryMessage = new DiscoverFeaturesQueryMessage({
+      const queryMessage = new QueryMessage({
         query: 'https://didcomm.org/connections/*',
       })
 

--- a/packages/core/src/modules/discover-features/handlers/DiscloseMessageHandler.ts
+++ b/packages/core/src/modules/discover-features/handlers/DiscloseMessageHandler.ts
@@ -1,9 +1,9 @@
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 
-import { DiscoverFeaturesDiscloseMessage } from '../messages'
+import { DiscloseMessage } from '../messages'
 
 export class DiscloseMessageHandler implements Handler {
-  public supportedMessages = [DiscoverFeaturesDiscloseMessage]
+  public supportedMessages = [DiscloseMessage]
 
   public async handle(inboundMessage: HandlerInboundMessage<DiscloseMessageHandler>) {
     // We don't really need to do anything with this at the moment

--- a/packages/core/src/modules/discover-features/handlers/QueryMessageHandler.ts
+++ b/packages/core/src/modules/discover-features/handlers/QueryMessageHandler.ts
@@ -2,11 +2,11 @@ import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { DiscoverFeaturesService } from '../services/DiscoverFeaturesService'
 
 import { createOutboundMessage } from '../../../agent/helpers'
-import { DiscoverFeaturesQueryMessage } from '../messages'
+import { QueryMessage } from '../messages'
 
 export class QueryMessageHandler implements Handler {
   private discoverFeaturesService: DiscoverFeaturesService
-  public supportedMessages = [DiscoverFeaturesQueryMessage]
+  public supportedMessages = [QueryMessage]
 
   public constructor(discoverFeaturesService: DiscoverFeaturesService) {
     this.discoverFeaturesService = discoverFeaturesService

--- a/packages/core/src/modules/discover-features/messages/DiscloseMessage.ts
+++ b/packages/core/src/modules/discover-features/messages/DiscloseMessage.ts
@@ -31,7 +31,7 @@ export interface DiscoverFeaturesDiscloseMessageOptions {
   protocols: DiscloseProtocolOptions[]
 }
 
-export class DiscoverFeaturesDiscloseMessage extends AgentMessage {
+export class DiscloseMessage extends AgentMessage {
   public constructor(options: DiscoverFeaturesDiscloseMessageOptions) {
     super()
 
@@ -44,8 +44,8 @@ export class DiscoverFeaturesDiscloseMessage extends AgentMessage {
     }
   }
 
-  @Equals(DiscoverFeaturesDiscloseMessage.type)
-  public readonly type = DiscoverFeaturesDiscloseMessage.type
+  @Equals(DiscloseMessage.type)
+  public readonly type = DiscloseMessage.type
   public static readonly type = 'https://didcomm.org/discover-features/1.0/disclose'
 
   @IsInstance(DiscloseProtocol, { each: true })

--- a/packages/core/src/modules/discover-features/messages/QueryMessage.ts
+++ b/packages/core/src/modules/discover-features/messages/QueryMessage.ts
@@ -8,7 +8,7 @@ export interface DiscoverFeaturesQueryMessageOptions {
   comment?: string
 }
 
-export class DiscoverFeaturesQueryMessage extends AgentMessage {
+export class QueryMessage extends AgentMessage {
   public constructor(options: DiscoverFeaturesQueryMessageOptions) {
     super()
 
@@ -19,8 +19,8 @@ export class DiscoverFeaturesQueryMessage extends AgentMessage {
     }
   }
 
-  @Equals(DiscoverFeaturesQueryMessage.type)
-  public readonly type = DiscoverFeaturesQueryMessage.type
+  @Equals(QueryMessage.type)
+  public readonly type = QueryMessage.type
   public static readonly type = 'https://didcomm.org/discover-features/1.0/query'
 
   @IsString()

--- a/packages/core/src/modules/discover-features/messages/index.ts
+++ b/packages/core/src/modules/discover-features/messages/index.ts
@@ -1,2 +1,2 @@
-export * from './DiscoverFeaturesDiscloseMessage'
-export * from './DiscoverFeaturesQueryMessage'
+export * from './DiscloseMessage'
+export * from './QueryMessage'

--- a/packages/core/src/modules/discover-features/services/DiscoverFeaturesService.ts
+++ b/packages/core/src/modules/discover-features/services/DiscoverFeaturesService.ts
@@ -20,8 +20,8 @@ export class DiscoverFeaturesService {
   public async createDisclose(queryMessage: DiscoverFeaturesQueryMessage) {
     const { query } = queryMessage
 
-    const messageTypes = this.dispatcher.supportedMessageTypes
-    const messageFamilies = Array.from(new Set(messageTypes.map((m) => m.substring(0, m.lastIndexOf('/') + 1))))
+    const messageFamilies = this.dispatcher.supportedProtocols
+
     let protocols: string[] = []
 
     if (query === '*') {

--- a/packages/core/src/modules/discover-features/services/DiscoverFeaturesService.ts
+++ b/packages/core/src/modules/discover-features/services/DiscoverFeaturesService.ts
@@ -1,7 +1,7 @@
 import { Lifecycle, scoped } from 'tsyringe'
 
 import { Dispatcher } from '../../../agent/Dispatcher'
-import { DiscoverFeaturesQueryMessage, DiscoverFeaturesDiscloseMessage } from '../messages'
+import { QueryMessage, DiscloseMessage } from '../messages'
 
 @scoped(Lifecycle.ContainerScoped)
 export class DiscoverFeaturesService {
@@ -12,12 +12,12 @@ export class DiscoverFeaturesService {
   }
 
   public async createQuery(options: { query: string; comment?: string }) {
-    const queryMessage = new DiscoverFeaturesQueryMessage(options)
+    const queryMessage = new QueryMessage(options)
 
     return queryMessage
   }
 
-  public async createDisclose(queryMessage: DiscoverFeaturesQueryMessage) {
+  public async createDisclose(queryMessage: QueryMessage) {
     const { query } = queryMessage
 
     const messageFamilies = this.dispatcher.supportedProtocols
@@ -33,7 +33,7 @@ export class DiscoverFeaturesService {
       protocols = [query]
     }
 
-    const discloseMessage = new DiscoverFeaturesDiscloseMessage({
+    const discloseMessage = new DiscloseMessage({
       threadId: queryMessage.threadId,
       protocols: protocols.map((protocolId) => ({ protocolId })),
     })


### PR DESCRIPTION
It's mainly about refactoring. I will use the "Add filter of protocols by message families" (86f336c) in #531. 

However, I'm not sure about the "Remove slash from protocol ID to be aligned with spec" (ee5a3a4). It seems like spec https://github.com/hyperledger/aries-rfcs/blob/main/concepts/0003-protocols/README.md#piuri defines protocol URI without the last `/` character, so I removed that. Let me know If you think it's dangerous breaking change or incorrect change :)