### PR TITLE
ci: add continuous deployment scripts

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -1,0 +1,87 @@
+name: Continuous Deployment
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-canary:
+    runs-on: ubuntu-20.04
+    name: Release Canary
+    if: "!startsWith(github.event.head_commit.message, 'chore(release): v')"
+    steps:
+      - name: Checkout aries-framework-javascript
+        uses: actions/checkout@v2
+        with:
+          # pulls all commits (needed for lerna to correctly version)
+          fetch-depth: 0
+
+      # setup dependencies
+      - name: Setup Libindy
+        uses: ./.github/actions/setup-libindy
+
+      - name: Setup NodeJS
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # On push to main, release unstable version
+      - name: Release Unstable
+        run: yarn lerna publish --loglevel=verbose --canary minor --exact --force-publish --yes --no-verify-access --dist-tag alpha
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release-stable:
+    runs-on: ubuntu-20.04
+    name: Create Stable Release
+    # Only run if the last pushed commit is a release commit
+    if: "startsWith(github.event.head_commit.message, 'chore(release): v')"
+    steps:
+      - name: Checkout aries-framework-javascript
+        uses: actions/checkout@v2
+
+      # setup dependencies
+      - name: Setup Libindy
+        uses: ./.github/actions/setup-libindy
+
+      - name: Setup NodeJS
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: 16
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Get updated version
+        id: new-version
+        run: |
+          NEW_VERSION=$(node -p "require('./lerna.json').version")
+          echo $NEW_VERSION
+
+          echo "::set-output name=version::$NEW_VERSION"
+
+      - name: Create Tag
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.new-version.outputs.version }}
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.new-version.outputs.version }}
+          body: |
+            Release v${{ steps.new-version.outputs.version }}
+
+            You can find the changelog in the [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) file.
+
+      - name: Release to NPM
+        run: yarn lerna publish from-package --loglevel=verbose --yes --no-verify-access
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,8 +3,10 @@ name: Continuous Integration
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main]
+  workflow_dispatch:
 
 env:
   TEST_AGENT_PUBLIC_DID_SEED: 000000000000000000000000Trustee9
@@ -18,6 +20,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # PRs created by github actions won't trigger CI. Before we can merge a PR we need to run the tests and
+  # validation scripts. To still be able to run the CI we can manually trigger it by adding the 'ci-test'
+  # label to the pull request
+  ci-trigger:
+    runs-on: ubuntu-20.04
+    outputs:
+      triggered: ${{ steps.check.outputs.triggered }}
+    steps:
+      - name: Determine if CI should run
+        id: check
+        run: |
+          if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.label.name }}" == "ci-test" ]]; then
+              export SHOULD_RUN='true'
+          elif [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.label.name }}" != "ci-test" ]]; then
+              export SHOULD_RUN='false'
+          else 
+              export SHOULD_RUN='true'
+          fi
+
+          echo "SHOULD_RUN: ${SHOULD_RUN}"
+          echo "::set-output name=triggered::${SHOULD_RUN}"
+
   validate:
     runs-on: ubuntu-20.04
     name: Validate
@@ -80,11 +104,11 @@ jobs:
       - uses: codecov/codecov-action@v1
         if: always()
 
-  release-canary:
+  version-stable:
     runs-on: ubuntu-20.04
-    name: Release Canary
+    name: Release stable
     needs: [integration-test, validate]
-    if: github.ref == 'refs/heads/main' && github.repository == 'hyperledger/aries-framework-javascript' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.repository == 'TimoGlastra/aries-framework-javascript' && github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout aries-framework-javascript
         uses: actions/checkout@v2
@@ -104,9 +128,35 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      # On push to main, release unstable version
-      - name: Release Unstable
-        run: yarn lerna publish --loglevel=verbose --canary minor --exact --force-publish --yes --no-verify-access --dist-tag latest
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Git config
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Update version
+        run: yarn lerna version --conventional-commits --no-git-tag-version --no-push --yes --exact
+
+      - name: Format lerna changes
+        run: yarn format
+
+      - name: Get updated version
+        id: new-version
+        run: |
+          NEW_VERSION=$(node -p "require('./lerna.json').version")
+          echo $NEW_VERSION
+
+          echo "::set-output name=version::$NEW_VERSION"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: |
+            chore(release): v${{ steps.new-version.outputs.version }}
+          author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          branch: lerna-release
+          signoff: true
+          title: |
+            chore(release): v${{ steps.new-version.outputs.version }}
+          body: |
+            Release version ${{ steps.new-version.outputs.version }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-20.04
     name: Release stable
     needs: [integration-test, validate]
-    if: github.ref == 'refs/heads/main' && github.repository == 'TimoGlastra/aries-framework-javascript' && github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout aries-framework-javascript
         uses: actions/checkout@v2

--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -1,0 +1,21 @@
+name: 'Lint PR'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      # Please look up the latest version from
+      # https://github.com/amannn/action-semantic-pull-request/releases
+      - uses: amannn/action-semantic-pull-request@v3.4.6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          validateSingleCommit: true

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,31 @@
+<p align="center">
+  <br />
+  <img
+    alt="Hyperledger Aries logo"
+    src="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript/aa31131825e3331dc93694bc58414d955dcb1129/images/aries-logo.png"
+    height="250px"
+  />
+</p>
+<h1 align="center"><b>Aries Framework JavaScript - Core</b></h1>
+<p align="center">
+  <a
+    href="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript/main/LICENSE"
+    ><img
+      alt="License"
+      src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"
+  /></a>
+  <a href="https://www.typescriptlang.org/"
+    ><img
+      alt="typescript"
+      src="https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg"
+  /></a>
+    <a href="https://www.npmjs.com/package/@aries-framework/redux-store"
+    ><img
+      alt="@aries-framework/core version"
+      src="https://img.shields.io/npm/v/@aries-framework/core"
+  /></a>
+
+</p>
+<br />
+
+Aries Framework JavaScript Core provides the core functionality of Aries Framework JavaScript. See the [Getting Started Guide](https://github.com/hyperledger/aries-framework-javascript#getting-started) for installation instructions.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,7 +19,7 @@
       alt="typescript"
       src="https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg"
   /></a>
-    <a href="https://www.npmjs.com/package/@aries-framework/redux-store"
+    <a href="https://www.npmjs.com/package/@aries-framework/core"
     ><img
       alt="@aries-framework/core version"
       src="https://img.shields.io/npm/v/@aries-framework/core"

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -1,0 +1,31 @@
+<p align="center">
+  <br />
+  <img
+    alt="Hyperledger Aries logo"
+    src="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript/aa31131825e3331dc93694bc58414d955dcb1129/images/aries-logo.png"
+    height="250px"
+  />
+</p>
+<h1 align="center"><b>Aries Framework JavaScript - Node</b></h1>
+<p align="center">
+  <a
+    href="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript/main/LICENSE"
+    ><img
+      alt="License"
+      src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"
+  /></a>
+  <a href="https://www.typescriptlang.org/"
+    ><img
+      alt="typescript"
+      src="https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg"
+  /></a>
+    <a href="https://www.npmjs.com/package/@aries-framework/redux-store"
+    ><img
+      alt="@aries-framework/node version"
+      src="https://img.shields.io/npm/v/@aries-framework/node"
+  /></a>
+
+</p>
+<br />
+
+Aries Framework JavaScript Node provides platform specific dependencies to run Aries Framework JavaScript in [Node.JS](https://nodejs.org). See the [Getting Started Guide](https://github.com/hyperledger/aries-framework-javascript#getting-started) for installation instructions.

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -19,7 +19,7 @@
       alt="typescript"
       src="https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg"
   /></a>
-    <a href="https://www.npmjs.com/package/@aries-framework/redux-store"
+    <a href="https://www.npmjs.com/package/@aries-framework/node"
     ><img
       alt="@aries-framework/node version"
       src="https://img.shields.io/npm/v/@aries-framework/node"

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -19,7 +19,7 @@
       alt="typescript"
       src="https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg"
   /></a>
-    <a href="https://www.npmjs.com/package/@aries-framework/redux-store"
+    <a href="https://www.npmjs.com/package/@aries-framework/react-native"
     ><img
       alt="@aries-framework/react-native version"
       src="https://img.shields.io/npm/v/@aries-framework/react-native"

--- a/packages/react-native/README.md
+++ b/packages/react-native/README.md
@@ -1,0 +1,31 @@
+<p align="center">
+  <br />
+  <img
+    alt="Hyperledger Aries logo"
+    src="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript/aa31131825e3331dc93694bc58414d955dcb1129/images/aries-logo.png"
+    height="250px"
+  />
+</p>
+<h1 align="center"><b>Aries Framework JavaScript - React Native</b></h1>
+<p align="center">
+  <a
+    href="https://raw.githubusercontent.com/hyperledger/aries-framework-javascript/main/LICENSE"
+    ><img
+      alt="License"
+      src="https://img.shields.io/badge/License-Apache%202.0-blue.svg"
+  /></a>
+  <a href="https://www.typescriptlang.org/"
+    ><img
+      alt="typescript"
+      src="https://img.shields.io/badge/%3C%2F%3E-TypeScript-%230074c1.svg"
+  /></a>
+    <a href="https://www.npmjs.com/package/@aries-framework/redux-store"
+    ><img
+      alt="@aries-framework/react-native version"
+      src="https://img.shields.io/npm/v/@aries-framework/react-native"
+  /></a>
+
+</p>
+<br />
+
+Aries Framework JavaScript React Native provides platform specific dependencies to run Aries Framework JavaScript in [React Native](https://reactnative.dev). See the [Getting Started Guide](https://github.com/hyperledger/aries-framework-javascript#getting-started) for installation instructions.


### PR DESCRIPTION
Adds continuous deployment scripts for stable releases. We can now run a manual `workflow_dispatch` action on the `Continuous Integration` pipeline and it will create a PR for the next release. 

Once that PR is merged it will automatically tag, create a github release and release to NPM. This is in preparation for the 0.1.0 release I want to do.