### PR TITLE
fix: removed check for senderkey for connectionless exchange

### DIFF
--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -475,7 +475,7 @@ export class ConnectionService {
 
       // If message is received unpacked/, we need to make sure it included a ~service decorator
       if (!message.service && !messageContext.recipientVerkey) {
-        throw new AriesFrameworkError('Message without senderKey and recipientKey must have ~service decorator')
+        throw new AriesFrameworkError('Message recipientKey must have ~service decorator')
       }
     }
   }

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -474,7 +474,7 @@ export class ConnectionService {
       }
 
       // If message is received unpacked/, we need to make sure it included a ~service decorator
-      if (!message.service && (!messageContext.senderVerkey || !messageContext.recipientVerkey)) {
+      if (!message.service && !messageContext.recipientVerkey) {
         throw new AriesFrameworkError('Message without senderKey and recipientKey must have ~service decorator')
       }
     }


### PR DESCRIPTION
Trinsic doesn't send the senderVerkey on a connectionless exchange.