### PR TITLE
ci: create tag on alpha release

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -110,3 +110,20 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Get version number
+        id: get-version
+        run: |
+          COMMIT_NUMBER=$(git rev-list --count ${{ github.ref }})
+          PACKAGE_NUMBER=$((COMMIT_NUMBER-1))
+
+          echo alpha.$PACKAGE_NUMBER
+
+          echo "::set-output name=version::$PACKAGE_NUMBER"
+
+      - name: Create Tag
+        uses: mathieudutour/github-tag-action@v6.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.get-version.outputs.version }}
+          tag_prefix: 'alpha.'


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

@JamesKEbert I think this should do it. It will create a tag names `alpha.<number>` on each release. I think lerna search for the default `vX.X.X` prefix so should not cause any issues. 

Let's try!