### PR TITLE
build: add arm test ledger setup

### DIFF
--- a/DEVREADME.md
+++ b/DEVREADME.md
@@ -26,6 +26,9 @@ For testing we've added a setup to this repo that allows you to quickly setup an
 # Build indy pool
 docker build -f network/indy-pool.dockerfile -t indy-pool . --platform linux/amd64
 
+# NOTE: If you are on an ARM (M1) mac use the `network/indy-pool-arm.dockerfile` instead
+# docker build -f network/indy-pool-arm.dockerfile -t indy-pool . --platform linux/arm64/v8
+
 # Start indy pool
 docker run -d --rm --name indy-pool -p 9701-9708:9701-9708 indy-pool
 

--- a/network/indy-pool-arm.dockerfile
+++ b/network/indy-pool-arm.dockerfile
@@ -1,0 +1,67 @@
+FROM snel/von-image:node-1.12-4-arm64
+
+USER root
+
+# Install environment
+RUN apt-get update -y && apt-get install -y supervisor
+
+# It is imporatnt the the lines are not indented. Some autformatters
+# Indent the supervisord parameters. THIS WILL BREAK THE SETUP
+RUN echo "[supervisord]\n\
+logfile = /tmp/supervisord.log\n\
+logfile_maxbytes = 50MB\n\
+logfile_backups=10\n\
+logLevel = error\n\
+pidfile = /tmp/supervisord.pid\n\
+nodaemon = true\n\
+minfds = 1024\n\
+minprocs = 200\n\
+umask = 022\n\
+user = indy\n\
+identifier = supervisor\n\
+directory = /tmp\n\
+nocleanup = true\n\
+childlogdir = /tmp\n\
+strip_ansi = false\n\
+\n\
+[program:node1]\n\
+command=start_indy_node Node1 0.0.0.0 9701 0.0.0.0 9702\n\
+directory=/home/indy\n\
+stdout_logfile=/tmp/node1.log\n\
+stderr_logfile=/tmp/node1.log\n\
+\n\
+[program:node2]\n\
+command=start_indy_node Node2 0.0.0.0 9703 0.0.0.0 9704\n\
+directory=/home/indy\n\
+stdout_logfile=/tmp/node2.log\n\
+stderr_logfile=/tmp/node2.log\n\
+\n\
+[program:node3]\n\
+command=start_indy_node Node3 0.0.0.0 9705 0.0.0.0 9706\n\
+directory=/home/indy\n\
+stdout_logfile=/tmp/node3.log\n\
+stderr_logfile=/tmp/node3.log\n\
+\n\
+[program:node4]\n\
+command=start_indy_node Node4 0.0.0.0 9707 0.0.0.0 9708\n\
+directory=/home/indy\n\
+stdout_logfile=/tmp/node4.log\n\
+stderr_logfile=/tmp/node4.log\n"\
+>> /etc/supervisord.conf
+
+USER indy
+
+COPY --chown=indy:indy network/indy_config.py /etc/indy/indy_config.py
+
+ARG pool_ip=127.0.0.1
+RUN generate_indy_pool_transactions --nodes 4 --clients 5 --nodeNum 1 2 3 4 --ips="$pool_ip,$pool_ip,$pool_ip,$pool_ip"
+
+COPY network/add-did.sh /usr/bin/add-did
+COPY network/indy-cli-setup.sh /usr/bin/indy-cli-setup
+COPY network/add-did-from-seed.sh /usr/bin/add-did-from-seed
+COPY network/genesis/local-genesis.txn /etc/indy/genesis.txn
+COPY network/indy-cli-config.json /etc/indy/indy-cli-config.json
+
+EXPOSE 9701 9702 9703 9704 9705 9706 9707 9708
+
+CMD ["/usr/bin/supervisord"]

--- a/network/indy_config.py
+++ b/network/indy_config.py
@@ -1,0 +1,12 @@
+NETWORK_NAME = 'sandbox'
+
+LEDGER_DIR = '/home/indy/ledger'
+LOG_DIR = '/home/indy/log'
+KEYS_DIR = LEDGER_DIR
+GENESIS_DIR = LEDGER_DIR
+BACKUP_DIR = '/home/indy/backup'
+PLUGINS_DIR = '/home/indy/plugins'
+NODE_INFO_DIR = LEDGER_DIR
+
+CLI_BASE_DIR = '/home/indy/.indy-cli/'
+CLI_NETWORK_DIR = '/home/indy/.indy-cli/networks'


### PR DESCRIPTION
Ledger setup didn't fully work for ARM baed macs. This PR adds an extra dockerfile that can be used to set up the test ledger on ARM macs.