### PR TITLE
fix(core)!: Improved typing on metadata api

### DIFF
--- a/packages/core/src/modules/credentials/__tests__/CredentialRecord.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialRecord.test.ts
@@ -1,8 +1,7 @@
 import { CredentialState } from '../CredentialState'
 import { CredentialPreviewAttribute } from '../messages'
 import { CredentialRecord } from '../repository/CredentialRecord'
-
-import { CredentialMetadataKeys } from '@aries-framework/core'
+import { CredentialMetadataKeys } from '../repository/credentialMetadataTypes'
 
 describe('CredentialRecord', () => {
   describe('getCredentialInfo()', () => {

--- a/packages/core/src/modules/credentials/__tests__/CredentialRecord.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialRecord.test.ts
@@ -2,6 +2,8 @@ import { CredentialState } from '../CredentialState'
 import { CredentialPreviewAttribute } from '../messages'
 import { CredentialRecord } from '../repository/CredentialRecord'
 
+import { CredentialMetadataKeys } from '@aries-framework/core'
+
 describe('CredentialRecord', () => {
   describe('getCredentialInfo()', () => {
     test('creates credential info object from credential record data', () => {
@@ -17,7 +19,7 @@ describe('CredentialRecord', () => {
         ],
       })
 
-      credentialRecord.metadata.set('_internal/indyCredential', {
+      credentialRecord.metadata.set(CredentialMetadataKeys.IndyCredential, {
         credentialDefinitionId: 'Th7MpTaRZVRYnPiabds81Y:3:CL:17:TAG',
         schemaId: 'TL1EaPFCZ8Si5aUrqScBDt:2:test-schema-1599055118161:1.0',
       })

--- a/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
@@ -38,6 +38,8 @@ import { CredentialService } from '../services'
 import { CredentialProblemReportMessage } from './../messages/CredentialProblemReportMessage'
 import { credDef, credOffer, credReq } from './fixtures'
 
+import { CredentialMetadataKeys } from '@aries-framework/core'
+
 // Mock classes
 jest.mock('../repository/CredentialRepository')
 jest.mock('../../../modules/ledger/services/IndyLedgerService')
@@ -126,17 +128,17 @@ const mockCredentialRecord = ({
   })
 
   if (metadata?.indyRequest) {
-    credentialRecord.metadata.set('_internal/indyRequest', { ...metadata.indyRequest })
+    credentialRecord.metadata.set(CredentialMetadataKeys.IndyRequest, { ...metadata.indyRequest })
   }
 
   if (metadata?.schemaId) {
-    credentialRecord.metadata.add('_internal/indyCredential', {
+    credentialRecord.metadata.add(CredentialMetadataKeys.IndyCredential, {
       schemaId: metadata.schemaId,
     })
   }
 
   if (metadata?.credentialDefinitionId) {
-    credentialRecord.metadata.add('_internal/indyCredential', {
+    credentialRecord.metadata.add(CredentialMetadataKeys.IndyCredential, {
       credentialDefinitionId: metadata.credentialDefinitionId,
     })
   }

--- a/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialService.test.ts
@@ -33,12 +33,11 @@ import {
 } from '../messages'
 import { CredentialRecord } from '../repository/CredentialRecord'
 import { CredentialRepository } from '../repository/CredentialRepository'
+import { CredentialMetadataKeys } from '../repository/credentialMetadataTypes'
 import { CredentialService } from '../services'
 
 import { CredentialProblemReportMessage } from './../messages/CredentialProblemReportMessage'
 import { credDef, credOffer, credReq } from './fixtures'
-
-import { CredentialMetadataKeys } from '@aries-framework/core'
 
 // Mock classes
 jest.mock('../repository/CredentialRepository')

--- a/packages/core/src/modules/credentials/repository/CredentialRecord.ts
+++ b/packages/core/src/modules/credentials/repository/CredentialRecord.ts
@@ -1,6 +1,7 @@
 import type { TagsBase } from '../../../storage/BaseRecord'
 import type { AutoAcceptCredential } from '../CredentialAutoAcceptType'
 import type { CredentialState } from '../CredentialState'
+import type { CredentialMetadata } from './credentialMetadataTypes'
 
 import { Type } from 'class-transformer'
 
@@ -44,7 +45,7 @@ export type DefaultCredentialTags = {
   credentialId?: string
 }
 
-export class CredentialRecord extends BaseRecord<DefaultCredentialTags, CustomCredentialTags> {
+export class CredentialRecord extends BaseRecord<DefaultCredentialTags, CustomCredentialTags, CredentialMetadata> {
   public connectionId?: string
   public threadId!: string
   public credentialId?: string
@@ -118,7 +119,7 @@ export class CredentialRecord extends BaseRecord<DefaultCredentialTags, CustomCr
     return new CredentialInfo({
       claims,
       attachments: this.linkedAttachments,
-      metadata: this.metadata.getAll(),
+      metadata: this.metadata.data,
     })
   }
 

--- a/packages/core/src/modules/credentials/repository/credentialMetadataTypes.ts
+++ b/packages/core/src/modules/credentials/repository/credentialMetadataTypes.ts
@@ -1,3 +1,5 @@
+import type { CredReqMetadata } from 'indy-sdk'
+
 export enum CredentialMetadataKeys {
   IndyCredential = '_internal/indyCredential',
   IndyRequest = '_internal/indyRequest',
@@ -8,5 +10,5 @@ export type CredentialMetadata = {
     schemaId?: string
     credentialDefinitionId?: string
   }
-  [CredentialMetadataKeys.IndyRequest]: Record<string, unknown>
+  [CredentialMetadataKeys.IndyRequest]: CredReqMetadata
 }

--- a/packages/core/src/modules/credentials/repository/credentialMetadataTypes.ts
+++ b/packages/core/src/modules/credentials/repository/credentialMetadataTypes.ts
@@ -1,0 +1,12 @@
+export enum CredentialMetadataKeys {
+  IndyCredential = '_internal/indyCredential',
+  IndyRequest = '_internal/indyRequest',
+}
+
+export type CredentialMetadata = {
+  [CredentialMetadataKeys.IndyCredential]: {
+    schemaId?: string
+    credentialDefinitionId?: string
+  }
+  [CredentialMetadataKeys.IndyRequest]: Record<string, unknown>
+}

--- a/packages/core/src/modules/credentials/repository/index.ts
+++ b/packages/core/src/modules/credentials/repository/index.ts
@@ -1,2 +1,3 @@
 export * from './CredentialRecord'
 export * from './CredentialRepository'
+export * from './credentialMetadataTypes'

--- a/packages/core/src/storage/BaseRecord.ts
+++ b/packages/core/src/storage/BaseRecord.ts
@@ -15,7 +15,11 @@ export type Tags<DefaultTags extends TagsBase, CustomTags extends TagsBase> = Cu
 
 export type RecordTags<Record extends BaseRecord> = ReturnType<Record['getTags']>
 
-export abstract class BaseRecord<DefaultTags extends TagsBase = TagsBase, CustomTags extends TagsBase = TagsBase> {
+export abstract class BaseRecord<
+  DefaultTags extends TagsBase = TagsBase,
+  CustomTags extends TagsBase = TagsBase,
+  MetadataValues = undefined
+> {
   protected _tags: CustomTags = {} as CustomTags
 
   public id!: string
@@ -32,7 +36,7 @@ export abstract class BaseRecord<DefaultTags extends TagsBase = TagsBase, Custom
 
   /** @inheritdoc {Metadata#Metadata} */
   @MetadataTransformer()
-  public metadata: Metadata = new Metadata({})
+  public metadata: Metadata<MetadataValues> = new Metadata({})
 
   /**
    * Get all tags. This is includes custom and default tags

--- a/packages/core/src/storage/Metadata.ts
+++ b/packages/core/src/storage/Metadata.ts
@@ -11,7 +11,9 @@ export type MetadataBase = {
  *
  * @example
  *
- * ```ts connectionRecord.metadata.set('foo', { bar: 'baz' }) connectionRepository.update(connectionRecord) ```
+ * ```ts
+ * connectionRecord.metadata.set('foo', { bar: 'baz' }) connectionRepository.update(connectionRecord)
+ * ```
  */
 export class Metadata<MetadataTypes> {
   public readonly data: MetadataBase

--- a/packages/core/src/storage/Repository.ts
+++ b/packages/core/src/storage/Repository.ts
@@ -4,7 +4,7 @@ import type { BaseRecordConstructor, Query, StorageService } from './StorageServ
 import { RecordDuplicateError, RecordNotFoundError } from '../error'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export class Repository<T extends BaseRecord<any, any>> {
+export class Repository<T extends BaseRecord<any, any, any>> {
   private storageService: StorageService<T>
   private recordClass: BaseRecordConstructor<T>
 

--- a/packages/core/src/storage/StorageService.ts
+++ b/packages/core/src/storage/StorageService.ts
@@ -8,7 +8,7 @@ export interface BaseRecordConstructor<T> extends Constructor<T> {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export interface StorageService<T extends BaseRecord<any, any>> {
+export interface StorageService<T extends BaseRecord<any, any, any>> {
   /**
    * Save record in storage
    *

--- a/packages/core/src/storage/__tests__/Metadata.test.ts
+++ b/packages/core/src/storage/__tests__/Metadata.test.ts
@@ -1,7 +1,11 @@
 import { TestRecord } from './TestRecord'
 
 describe('Metadata', () => {
-  const testRecord = new TestRecord()
+  let testRecord: TestRecord
+
+  beforeEach(() => {
+    testRecord = new TestRecord()
+  })
 
   test('set() as create', () => {
     testRecord.metadata.set('bar', { aries: { framework: 'javascript' } })
@@ -12,12 +16,12 @@ describe('Metadata', () => {
   })
 
   test('set() as update ', () => {
+    testRecord.metadata.set('bar', { baz: 'abc' })
     expect(testRecord.toJSON()).toMatchObject({
-      metadata: { bar: { aries: { framework: 'javascript' } } },
+      metadata: { bar: { baz: 'abc' } },
     })
 
     testRecord.metadata.set('bar', { baz: 'foo' })
-
     expect(testRecord.toJSON()).toMatchObject({
       metadata: { bar: { baz: 'foo' } },
     })
@@ -33,12 +37,14 @@ describe('Metadata', () => {
   })
 
   test('get()', () => {
+    testRecord.metadata.set('bar', { baz: 'foo' })
     const record = testRecord.metadata.get<{ baz: 'foo' }>('bar')
 
     expect(record).toMatchObject({ baz: 'foo' })
   })
 
   test('delete()', () => {
+    testRecord.metadata.set('bar', { baz: 'foo' })
     testRecord.metadata.delete('bar')
 
     expect(testRecord.toJSON()).toMatchObject({
@@ -46,17 +52,13 @@ describe('Metadata', () => {
     })
   })
 
-  test('getAll()', () => {
+  test('keys()', () => {
     testRecord.metadata.set('bar', { baz: 'foo' })
     testRecord.metadata.set('bazz', { blub: 'foo' })
     testRecord.metadata.set('test', { abc: { def: 'hij' } })
 
-    const record = testRecord.metadata.getAll()
+    const keys = testRecord.metadata.keys
 
-    expect(record).toMatchObject({
-      bar: { baz: 'foo' },
-      bazz: { blub: 'foo' },
-      test: { abc: { def: 'hij' } },
-    })
+    expect(keys).toMatchObject(['bar', 'bazz', 'test'])
   })
 })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,7 +5,6 @@ import type { AutoAcceptCredential } from './modules/credentials/CredentialAutoA
 import type { IndyPoolConfig } from './modules/ledger/IndyPool'
 import type { AutoAcceptProof } from './modules/proofs'
 import type { MediatorPickupStrategy } from './modules/routing'
-import type { CredReqMetadata } from 'indy-sdk'
 
 export interface WalletConfig {
   id: string
@@ -78,12 +77,3 @@ export interface OutboundPackage {
   endpoint?: string
   connectionId?: string
 }
-
-// Metadata type for `_internal/indyCredential`
-export interface IndyCredentialMetadata {
-  schemaId?: string
-  credentialDefinitionId?: string
-}
-
-// Metadata type for  `_internal/indyRequest`
-export type IndyCredentialRequestMetadata = CredReqMetadata

--- a/packages/core/src/utils/transformers.ts
+++ b/packages/core/src/utils/transformers.ts
@@ -4,6 +4,7 @@ import { Transform, TransformationType } from 'class-transformer'
 import { ValidateBy, buildMessage } from 'class-validator'
 import { DateTime } from 'luxon'
 
+import { CredentialMetadataKeys } from '../modules/credentials/repository/credentialMetadataTypes'
 import { Metadata } from '../storage/Metadata'
 
 import { JsonTransformer } from './JsonTransformer'
@@ -60,12 +61,12 @@ export function MetadataTransformer() {
       const { requestMetadata, schemaId, credentialDefinitionId, ...rest } = value
       const metadata = new Metadata(rest)
 
-      if (requestMetadata) metadata.add('_internal/indyRequest', { ...value.requestMetadata })
+      if (requestMetadata) metadata.add(CredentialMetadataKeys.IndyRequest, { ...value.requestMetadata })
 
-      if (schemaId) metadata.add('_internal/indyCredential', { schemaId: value.schemaId })
+      if (schemaId) metadata.add(CredentialMetadataKeys.IndyCredential, { schemaId: value.schemaId })
 
       if (credentialDefinitionId)
-        metadata.add('_internal/indyCredential', { credentialDefinitionId: value.credentialDefinitionId })
+        metadata.add(CredentialMetadataKeys.IndyCredential, { credentialDefinitionId: value.credentialDefinitionId })
 
       return metadata
     }


### PR DESCRIPTION
BREAKING CHANGE: removed the `getAll()` function.

- Improved typings on the metadata functions. 
- Hidden ugly `_internal/...` and replaced with an enum
- Record metadata stays the same.

Would be nice if we can get this merged before 0.1.0 as it makes the public api quite a bit better
