### PR TITLE
feat: add didcomm message record

### DIFF
--- a/packages/core/src/storage/__tests__/DidCommMessageRecord.test.ts
+++ b/packages/core/src/storage/__tests__/DidCommMessageRecord.test.ts
@@ -15,12 +15,12 @@ describe('DidCommMessageRecord', () => {
     const didCommeMessageRecord = new DidCommMessageRecord({
       message: didCommMessage,
       role: DidCommMessageRole.Receiver,
-      connectionId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
+      associatedRecordId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
     })
 
     expect(didCommeMessageRecord.getTags()).toEqual({
       role: DidCommMessageRole.Receiver,
-      connectionId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
+      associatedRecordId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
 
       // Computed properties based on message id and type
       threadId: 'ea24e14a-4fc4-40f4-85a0-f6fcf02bfc1c',
@@ -45,7 +45,7 @@ describe('DidCommMessageRecord', () => {
     const didCommeMessageRecord = new DidCommMessageRecord({
       message: invitationJson,
       role: DidCommMessageRole.Receiver,
-      connectionId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
+      associatedRecordId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
     })
 
     const invitation = didCommeMessageRecord.getMessageInstance(ConnectionInvitationMessage)

--- a/packages/core/src/storage/__tests__/DidCommMessageRecord.test.ts
+++ b/packages/core/src/storage/__tests__/DidCommMessageRecord.test.ts
@@ -1,0 +1,55 @@
+import { ConnectionInvitationMessage } from '../../modules/connections'
+import { DidCommMessageRecord, DidCommMessageRole } from '../didcomm'
+
+describe('DidCommMessageRecord', () => {
+  it('correctly computes message type tags', () => {
+    const didCommMessage = {
+      '@id': '7eb74118-7f91-4ba9-9960-c709b036aa86',
+      '@type': 'https://didcomm.org/test-protocol/1.0/send-test',
+      some: { other: 'property' },
+      '~thread': {
+        thid: 'ea24e14a-4fc4-40f4-85a0-f6fcf02bfc1c',
+      },
+    }
+
+    const didCommeMessageRecord = new DidCommMessageRecord({
+      message: didCommMessage,
+      role: DidCommMessageRole.Receiver,
+      connectionId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
+    })
+
+    expect(didCommeMessageRecord.getTags()).toEqual({
+      role: DidCommMessageRole.Receiver,
+      connectionId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
+
+      // Computed properties based on message id and type
+      threadId: 'ea24e14a-4fc4-40f4-85a0-f6fcf02bfc1c',
+      protocolName: 'test-protocol',
+      messageName: 'send-test',
+      versionMajor: '1',
+      versionMinor: '0',
+      messageType: 'https://didcomm.org/test-protocol/1.0/send-test',
+      messageId: '7eb74118-7f91-4ba9-9960-c709b036aa86',
+    })
+  })
+
+  it('correctly returns a message class instance', () => {
+    const invitationJson = {
+      '@type': 'https://didcomm.org/connections/1.0/invitation',
+      '@id': '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+      recipientKeys: ['recipientKeyOne', 'recipientKeyTwo'],
+      serviceEndpoint: 'https://example.com',
+      label: 'test',
+    }
+
+    const didCommeMessageRecord = new DidCommMessageRecord({
+      message: invitationJson,
+      role: DidCommMessageRole.Receiver,
+      connectionId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
+    })
+
+    const invitation = didCommeMessageRecord.getMessageInstance(ConnectionInvitationMessage)
+
+    expect(invitation).toBeInstanceOf(ConnectionInvitationMessage)
+  })
+})

--- a/packages/core/src/storage/__tests__/DidCommMessageRepository.test.ts
+++ b/packages/core/src/storage/__tests__/DidCommMessageRepository.test.ts
@@ -30,7 +30,7 @@ describe('Repository', () => {
       id,
       message: invitationJson,
       role: DidCommMessageRole.Receiver,
-      connectionId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
+      associatedRecordId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
     })
   }
 
@@ -41,11 +41,11 @@ describe('Repository', () => {
 
       const invitation = await repository.getAgentMessage({
         messageClass: ConnectionInvitationMessage,
-        threadId: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+        associatedRecordId: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
       })
 
       expect(storageMock.findByQuery).toBeCalledWith(DidCommMessageRecord, {
-        threadId: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+        associatedRecordId: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
         messageType: 'https://didcomm.org/connections/1.0/invitation',
       })
       expect(invitation).toBeInstanceOf(ConnectionInvitationMessage)
@@ -57,12 +57,14 @@ describe('Repository', () => {
       await repository.saveAgentMessage({
         role: DidCommMessageRole.Receiver,
         agentMessage: JsonTransformer.fromJSON(invitationJson, ConnectionInvitationMessage),
+        associatedRecordId: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
       })
 
       expect(storageMock.save).toBeCalledWith(
         expect.objectContaining({
           role: DidCommMessageRole.Receiver,
           message: invitationJson,
+          associatedRecordId: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
         })
       )
     })

--- a/packages/core/src/storage/__tests__/DidCommMessageRepository.test.ts
+++ b/packages/core/src/storage/__tests__/DidCommMessageRepository.test.ts
@@ -1,0 +1,70 @@
+import { mockFunction } from '../../../tests/helpers'
+import { ConnectionInvitationMessage } from '../../modules/connections'
+import { JsonTransformer } from '../../utils/JsonTransformer'
+import { IndyStorageService } from '../IndyStorageService'
+import { DidCommMessageRecord, DidCommMessageRepository, DidCommMessageRole } from '../didcomm'
+
+jest.mock('../IndyStorageService')
+
+const StorageMock = IndyStorageService as unknown as jest.Mock<IndyStorageService<DidCommMessageRecord>>
+
+const invitationJson = {
+  '@type': 'https://didcomm.org/connections/1.0/invitation',
+  '@id': '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+  recipientKeys: ['recipientKeyOne', 'recipientKeyTwo'],
+  serviceEndpoint: 'https://example.com',
+  label: 'test',
+}
+
+describe('Repository', () => {
+  let repository: DidCommMessageRepository
+  let storageMock: IndyStorageService<DidCommMessageRecord>
+
+  beforeEach(async () => {
+    storageMock = new StorageMock()
+    repository = new DidCommMessageRepository(storageMock)
+  })
+
+  const getRecord = ({ id }: { id?: string } = {}) => {
+    return new DidCommMessageRecord({
+      id,
+      message: invitationJson,
+      role: DidCommMessageRole.Receiver,
+      connectionId: '16ca6665-29f6-4333-a80e-d34db6bfe0b0',
+    })
+  }
+
+  describe('getAgentMessage()', () => {
+    it('should get the record using the storage service', async () => {
+      const record = getRecord({ id: 'test-id' })
+      mockFunction(storageMock.findByQuery).mockReturnValue(Promise.resolve([record]))
+
+      const invitation = await repository.getAgentMessage({
+        messageClass: ConnectionInvitationMessage,
+        threadId: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+      })
+
+      expect(storageMock.findByQuery).toBeCalledWith(DidCommMessageRecord, {
+        threadId: '04a2c382-999e-4de9-a1d2-9dec0b2fa5e4',
+        messageType: 'https://didcomm.org/connections/1.0/invitation',
+      })
+      expect(invitation).toBeInstanceOf(ConnectionInvitationMessage)
+    })
+  })
+
+  describe('saveAgentMessage()', () => {
+    it('should transform and save the agent message', async () => {
+      await repository.saveAgentMessage({
+        role: DidCommMessageRole.Receiver,
+        agentMessage: JsonTransformer.fromJSON(invitationJson, ConnectionInvitationMessage),
+      })
+
+      expect(storageMock.save).toBeCalledWith(
+        expect.objectContaining({
+          role: DidCommMessageRole.Receiver,
+          message: invitationJson,
+        })
+      )
+    })
+  })
+})

--- a/packages/core/src/storage/didcomm/DidCommMessageRecord.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRecord.ts
@@ -1,11 +1,11 @@
 import type { AgentMessage } from '../../agent/AgentMessage'
-import type { JsonMap } from '../../types'
+import type { JsonObject } from '../../types'
 import type { DidCommMessageRole } from './DidCommMessageRole'
 
 import { AriesFrameworkError } from '../../error'
 import { JsonTransformer } from '../../utils/JsonTransformer'
 import { rightSplit } from '../../utils/string'
-import { isJsonMap } from '../../utils/type'
+import { isJsonObject } from '../../utils/type'
 import { uuid } from '../../utils/uuid'
 import { BaseRecord } from '../BaseRecord'
 
@@ -25,14 +25,14 @@ export type DefaultDidCommMessageTags = {
 
 export interface DidCommMessageRecordProps {
   role: DidCommMessageRole
-  message: JsonMap
+  message: JsonObject
   id?: string
   createdAt?: Date
   associatedRecordId?: string
 }
 
 export class DidCommMessageRecord extends BaseRecord<DefaultDidCommMessageTags> {
-  public message!: JsonMap
+  public message!: JsonObject
   public role!: DidCommMessageRole
 
   /**
@@ -67,7 +67,7 @@ export class DidCommMessageRecord extends BaseRecord<DefaultDidCommMessageTags> 
     const thread = this.message['~thread']
     let threadId = messageId
 
-    if (isJsonMap(thread) && typeof thread.thid === 'string') {
+    if (isJsonObject(thread) && typeof thread.thid === 'string') {
       threadId = thread.thid
     }
 

--- a/packages/core/src/storage/didcomm/DidCommMessageRecord.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRecord.ts
@@ -1,0 +1,98 @@
+import type { AgentMessage } from '../../agent/AgentMessage'
+import type { JsonMap } from '../../types'
+import type { DidCommMessageRole } from './DidCommMessageRole'
+
+import { AriesFrameworkError } from '../../error'
+import { JsonTransformer } from '../../utils/JsonTransformer'
+import { rightSplit } from '../../utils/string'
+import { uuid } from '../../utils/uuid'
+import { BaseRecord } from '../BaseRecord'
+
+export type DefaultDidCommMessageTags = {
+  role: DidCommMessageRole
+  connectionId?: string
+
+  // Computed
+  protocolName: string
+  messageName: string
+  versionMajor: string
+  versionMinor: string
+  messageType: string
+  messageId: string
+  threadId: string
+}
+
+export interface DidCommMessageRecordProps {
+  role: DidCommMessageRole
+  message: JsonMap
+  id?: string
+  createdAt?: Date
+  connectionId?: string
+}
+
+export class DidCommMessageRecord extends BaseRecord<DefaultDidCommMessageTags> {
+  public message!: JsonMap
+  public role!: DidCommMessageRole
+  public connectionId?: string
+
+  public static readonly type = 'DidCommMessageRecord'
+  public readonly type = DidCommMessageRecord.type
+
+  public constructor(props: DidCommMessageRecordProps) {
+    super()
+
+    if (props) {
+      this.id = props.id ?? uuid()
+      this.createdAt = props.createdAt ?? new Date()
+      this.connectionId = props.connectionId
+      this.role = props.role
+      this.message = props.message
+    }
+  }
+
+  public getTags() {
+    const messageId = this.message['@id'] as string
+    const messageType = this.message['@type'] as string
+    const [, protocolName, protocolVersion, messageName] = rightSplit(messageType, '/', 3)
+    const [versionMajor, versionMinor] = protocolVersion.split('.')
+
+    const thread = this.message['~thread']
+    let threadId = messageId
+
+    // FIXME: make this less verbose
+    if (
+      thread &&
+      typeof thread === 'object' &&
+      thread !== null &&
+      !Array.isArray(thread) &&
+      typeof thread.thid === 'string'
+    ) {
+      threadId = thread.thid
+    }
+
+    return {
+      ...this._tags,
+      role: this.role,
+      connectionId: this.connectionId,
+
+      // Computed properties based on message id and type
+      threadId,
+      protocolName,
+      messageName,
+      versionMajor,
+      versionMinor,
+      messageType,
+      messageId,
+    }
+  }
+
+  public getMessageInstance<MessageClass extends typeof AgentMessage = typeof AgentMessage>(
+    messageClass: MessageClass
+  ): InstanceType<MessageClass> {
+    if (messageClass.type !== this.message['@type']) {
+      throw new AriesFrameworkError('Provided message class type does not match type of stored message')
+    }
+
+    return JsonTransformer.fromJSON(this.message, messageClass) as InstanceType<MessageClass>
+  }
+}

--- a/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
@@ -1,0 +1,14 @@
+import { inject, scoped, Lifecycle } from 'tsyringe'
+
+import { InjectionSymbols } from '../../constants'
+import { Repository } from '../Repository'
+import { StorageService } from '../StorageService'
+
+import { DidCommMessageRecord } from './DidCommMessageRecord'
+
+@scoped(Lifecycle.ContainerScoped)
+export class DidCommMessageRepository extends Repository<DidCommMessageRecord> {
+  public constructor(@inject(InjectionSymbols.StorageService) storageService: StorageService<DidCommMessageRecord>) {
+    super(DidCommMessageRecord, storageService)
+  }
+}

--- a/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
@@ -1,3 +1,7 @@
+import type { AgentMessage } from '../../agent/AgentMessage'
+import type { JsonMap } from '../../types'
+import type { DidCommMessageRole } from './DidCommMessageRole'
+
 import { inject, scoped, Lifecycle } from 'tsyringe'
 
 import { InjectionSymbols } from '../../constants'
@@ -10,5 +14,38 @@ import { DidCommMessageRecord } from './DidCommMessageRecord'
 export class DidCommMessageRepository extends Repository<DidCommMessageRecord> {
   public constructor(@inject(InjectionSymbols.StorageService) storageService: StorageService<DidCommMessageRecord>) {
     super(DidCommMessageRecord, storageService)
+  }
+
+  public async saveAgentMessage({
+    role,
+    agentMessage,
+    connectionId,
+  }: {
+    role: DidCommMessageRole
+    agentMessage: AgentMessage
+    connectionId?: string
+  }) {
+    const didCommMessageRecord = new DidCommMessageRecord({
+      message: agentMessage.toJSON() as JsonMap,
+      role,
+      connectionId,
+    })
+
+    await this.save(didCommMessageRecord)
+  }
+
+  public async getAgentMessage<MessageClass extends typeof AgentMessage = typeof AgentMessage>({
+    threadId,
+    messageClass,
+  }: {
+    threadId: string
+    messageClass: MessageClass
+  }): Promise<InstanceType<MessageClass>> {
+    const record = await this.getSingleByQuery({
+      threadId,
+      messageType: messageClass.type,
+    })
+
+    return record.getMessageInstance(messageClass)
   }
 }

--- a/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
@@ -16,36 +16,36 @@ export class DidCommMessageRepository extends Repository<DidCommMessageRecord> {
     super(DidCommMessageRecord, storageService)
   }
 
-  public async saveAgentMessage({
-    role,
-    agentMessage,
-    connectionId,
-  }: {
-    role: DidCommMessageRole
-    agentMessage: AgentMessage
-    connectionId?: string
-  }) {
+  public async saveAgentMessage({ role, agentMessage, associatedRecordId }: SaveAgentMessageOptions) {
     const didCommMessageRecord = new DidCommMessageRecord({
       message: agentMessage.toJSON() as JsonMap,
       role,
-      connectionId,
+      associatedRecordId,
     })
 
     await this.save(didCommMessageRecord)
   }
 
   public async getAgentMessage<MessageClass extends typeof AgentMessage = typeof AgentMessage>({
-    threadId,
+    associatedRecordId,
     messageClass,
-  }: {
-    threadId: string
-    messageClass: MessageClass
-  }): Promise<InstanceType<MessageClass>> {
+  }: GetAgentMessageOptions<MessageClass>): Promise<InstanceType<MessageClass>> {
     const record = await this.getSingleByQuery({
-      threadId,
+      associatedRecordId,
       messageType: messageClass.type,
     })
 
     return record.getMessageInstance(messageClass)
   }
+}
+
+export interface SaveAgentMessageOptions {
+  role: DidCommMessageRole
+  agentMessage: AgentMessage
+  associatedRecordId: string
+}
+
+export interface GetAgentMessageOptions<MessageClass extends typeof AgentMessage> {
+  associatedRecordId: string
+  messageClass: MessageClass
 }

--- a/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage } from '../../agent/AgentMessage'
-import type { JsonMap } from '../../types'
+import type { JsonObject } from '../../types'
 import type { DidCommMessageRole } from './DidCommMessageRole'
 
 import { inject, scoped, Lifecycle } from 'tsyringe'
@@ -18,7 +18,7 @@ export class DidCommMessageRepository extends Repository<DidCommMessageRecord> {
 
   public async saveAgentMessage({ role, agentMessage, associatedRecordId }: SaveAgentMessageOptions) {
     const didCommMessageRecord = new DidCommMessageRecord({
-      message: agentMessage.toJSON() as JsonMap,
+      message: agentMessage.toJSON() as JsonObject,
       role,
       associatedRecordId,
     })

--- a/packages/core/src/storage/didcomm/DidCommMessageRole.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRole.ts
@@ -1,0 +1,4 @@
+export enum DidCommMessageRole {
+  Sender = 'sender',
+  Receiver = 'receiver',
+}

--- a/packages/core/src/storage/didcomm/index.ts
+++ b/packages/core/src/storage/didcomm/index.ts
@@ -1,0 +1,3 @@
+export * from './DidCommMessageRecord'
+export * from './DidCommMessageRepository'
+export * from './DidCommMessageRole'

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,0 +1,1 @@
+export * from './didcomm'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,8 +79,8 @@ export interface OutboundPackage {
   connectionId?: string
 }
 
-export type AnyJson = boolean | number | string | null | JsonArray | JsonMap
-export interface JsonMap {
-  [key: string]: AnyJson
+export type JsonValue = string | number | boolean | null | JsonObject | JsonArray
+export type JsonArray = Array<JsonValue>
+export interface JsonObject {
+  [property: string]: JsonValue
 }
-export type JsonArray = Array<AnyJson>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -78,3 +78,9 @@ export interface OutboundPackage {
   endpoint?: string
   connectionId?: string
 }
+
+export type AnyJson = boolean | number | string | null | JsonArray | JsonMap
+export interface JsonMap {
+  [key: string]: AnyJson
+}
+export type JsonArray = Array<AnyJson>

--- a/packages/core/src/utils/__tests__/string.test.ts
+++ b/packages/core/src/utils/__tests__/string.test.ts
@@ -1,0 +1,11 @@
+import { rightSplit } from '../string'
+
+describe('string', () => {
+  describe('rightSplit', () => {
+    it('correctly splits a string starting from the right', () => {
+      const messageType = 'https://didcomm.org/connections/1.0/invitation'
+
+      expect(rightSplit(messageType, '/', 3)).toEqual(['https://didcomm.org', 'connections', '1.0', 'invitation'])
+    })
+  })
+})

--- a/packages/core/src/utils/string.ts
+++ b/packages/core/src/utils/string.ts
@@ -1,0 +1,4 @@
+export function rightSplit(string: string, sep: string, limit: number) {
+  const split = string.split(sep)
+  return limit ? [split.slice(0, -limit).join(sep)].concat(split.slice(-limit)) : split
+}

--- a/packages/core/src/utils/type.ts
+++ b/packages/core/src/utils/type.ts
@@ -1,4 +1,4 @@
-import type { JsonMap } from '../types'
+import type { JsonObject } from '../types'
 
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 
@@ -6,6 +6,6 @@ export const isString = (value: unknown): value is string => typeof value === 's
 export const isNumber = (value: unknown): value is number => typeof value === 'number'
 export const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
 
-export const isJsonMap = (value: unknown): value is JsonMap => {
+export const isJsonObject = (value: unknown): value is JsonObject => {
   return value !== undefined && typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/packages/core/src/utils/type.ts
+++ b/packages/core/src/utils/type.ts
@@ -1,5 +1,11 @@
+import type { JsonMap } from '../types'
+
 export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>
 
 export const isString = (value: unknown): value is string => typeof value === 'string'
 export const isNumber = (value: unknown): value is number => typeof value === 'number'
 export const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
+
+export const isJsonMap = (value: unknown): value is JsonMap => {
+  return value !== undefined && typeof value === 'object' && value !== null && !Array.isArray(value)
+}


### PR DESCRIPTION
Adds a `DidCommMessageRecord` that can be used to store didcomm messages.

This can be useful in the OOB protocol, and with the addition of v2 to the credentials and proofs module. This way we don't have to store the messages inside the record class anymore. 

Instead of accessing and storing a message in the record like this:

```ts
// write
credentialRecord.proposalMessage = proposalMessage
await credentialRepository.save(credentialRecord)

// read
credentialRecord.proposalMessage
```

we can use it like this:

```ts
// write
await didcommMessageRepository.saveAgentMessage({ 
    agentMessage: proposalMessage, 
    role: DidCommMessageRole.Receiver,
    associatedRecordId: credentialRecord.id
})

// read
await didcommMessageRepository.getAgentMessage({
   associatedRecordId: credentialRecord.id,
   messageClass: V2CredentialProposalMessage
})
git 

```

The implementation is BETA, but I think it can be useful to already add this to the framework so we can start using it.