### PR TITLE
fix: disallow usage of global buffer

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,23 @@ module.exports = {
   },
   overrides: [
     {
+      files: ['packages/core/**'],
+      rules: {
+        'no-restricted-globals': [
+          'error',
+          {
+            name: 'Buffer',
+            message: 'Global buffer is not supported on all platforms. Import buffer from `src/utils/buffer`',
+          },
+          {
+            name: 'AbortController',
+            message:
+              "Global AbortController is not supported on all platforms. Use `import { AbortController } from 'abort-controller'`",
+          },
+        ],
+      },
+    },
+    {
       files: ['jest.config.ts', '.eslintrc.js'],
       env: {
         node: true,

--- a/packages/core/src/utils/__tests__/HashlinkEncoder.test.ts
+++ b/packages/core/src/utils/__tests__/HashlinkEncoder.test.ts
@@ -1,4 +1,5 @@
 import { HashlinkEncoder } from '../HashlinkEncoder'
+import { Buffer } from '../buffer'
 
 const validData = {
   data: Buffer.from('Hello World!'),

--- a/packages/core/src/utils/__tests__/MultibaseEncoder.test.ts
+++ b/packages/core/src/utils/__tests__/MultibaseEncoder.test.ts
@@ -1,5 +1,6 @@
 import { BufferEncoder } from '../BufferEncoder'
 import { MultiBaseEncoder } from '../MultiBaseEncoder'
+import { Buffer } from '../buffer'
 
 const validData = Buffer.from('Hello World!')
 const validMultiBase = 'zKWfinQuRQ3ekD1danFHqvKRg9koFp8vpokUeREEgjSyHwweeKDFaxVHi'

--- a/packages/core/src/utils/__tests__/MultihashEncoder.test.ts
+++ b/packages/core/src/utils/__tests__/MultihashEncoder.test.ts
@@ -1,5 +1,6 @@
 import { BufferEncoder } from '../BufferEncoder'
 import { MultiHashEncoder } from '../MultiHashEncoder'
+import { Buffer } from '../buffer'
 
 const validData = Buffer.from('Hello World!')
 const validMultiHash = new Uint8Array([18, 12, 72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33])

--- a/packages/core/src/utils/did.ts
+++ b/packages/core/src/utils/did.ts
@@ -16,6 +16,7 @@
  */
 
 import { BufferEncoder } from './BufferEncoder'
+import { Buffer } from './buffer'
 
 export const FULL_VERKEY_REGEX = /^[1-9A-HJ-NP-Za-km-z]{43,44}$/
 export const ABBREVIATED_VERKEY_REGEX = /^~[1-9A-HJ-NP-Za-km-z]{21,22}$/


### PR DESCRIPTION
Disallow usage of global `Buffer`, require it to be imported. `Buffer` is available globally in Node.JS and I can't seem to make TS think we're not in a NodeJS env. I just discovered this eslint rule that takes care of it (and also fixed one usage of global buffer outside of the tests 🎉 )

