### PR TITLE
fix: incorrect encoding of services for did:peer

### DIFF
--- a/packages/core/src/modules/dids/methods/peer/__tests__/DidPeer.test.ts
+++ b/packages/core/src/modules/dids/methods/peer/__tests__/DidPeer.test.ts
@@ -9,7 +9,7 @@ import { DidPeer, PeerDidNumAlgo } from '../DidPeer'
 
 import didPeer1zQmR from './__fixtures__/didPeer1zQmR.json'
 import didPeer1zQmZ from './__fixtures__/didPeer1zQmZ.json'
-import didPeer2ez6L from './__fixtures__/didPeer2ez6L.json'
+import didPeer2Ez6L from './__fixtures__/didPeer2Ez6L.json'
 
 describe('DidPeer', () => {
   test('transforms a key correctly into a peer did method 0 did document', async () => {
@@ -28,7 +28,7 @@ describe('DidPeer', () => {
   })
 
   test('transforms a method 2 did correctly into a did document', () => {
-    expect(DidPeer.fromDid(didPeer2ez6L.id).didDocument.toJSON()).toMatchObject(didPeer2ez6L)
+    expect(DidPeer.fromDid(didPeer2Ez6L.id).didDocument.toJSON()).toMatchObject(didPeer2Ez6L)
   })
 
   test('transforms a method 0 did correctly into a did document', () => {
@@ -46,11 +46,11 @@ describe('DidPeer', () => {
 
   test('transforms a did document into a valid method 2 did', () => {
     const didPeer2 = DidPeer.fromDidDocument(
-      JsonTransformer.fromJSON(didPeer2ez6L, DidDocument),
+      JsonTransformer.fromJSON(didPeer2Ez6L, DidDocument),
       PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc
     )
 
-    expect(didPeer2.did).toBe(didPeer2ez6L.id)
+    expect(didPeer2.did).toBe(didPeer2Ez6L.id)
   })
 
   test('transforms a did document into a valid method 1 did', () => {
@@ -90,7 +90,7 @@ describe('DidPeer', () => {
     const peerDidNumAlgo2 =
       'did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0'
     expect(DidPeer.fromDid(peerDidNumAlgo2).numAlgo).toBe(PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc)
-    expect(DidPeer.fromDidDocument(JsonTransformer.fromJSON(didPeer2ez6L, DidDocument)).numAlgo).toBe(
+    expect(DidPeer.fromDidDocument(JsonTransformer.fromJSON(didPeer2Ez6L, DidDocument)).numAlgo).toBe(
       PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc
     )
   })

--- a/packages/core/src/modules/dids/methods/peer/__tests__/__fixtures__/didPeer2Ez6L.json
+++ b/packages/core/src/modules/dids/methods/peer/__tests__/__fixtures__/didPeer2Ez6L.json
@@ -1,5 +1,4 @@
 {
-  "@context": ["https://w3id.org/did/v1"],
   "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0",
   "authentication": [
     {
@@ -25,7 +24,7 @@
   ],
   "service": [
     {
-      "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#service-0",
+      "id": "did:peer:2.Ez6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.Vz6MkgoLTnTypo3tDRwCkZXSccTPHRLhF4ZnjhueYAFpEX6vg.SeyJ0IjoiZG0iLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCIsInIiOlsiZGlkOmV4YW1wbGU6c29tZW1lZGlhdG9yI3NvbWVrZXkiXSwiYSI6WyJkaWRjb21tL3YyIiwiZGlkY29tbS9haXAyO2Vudj1yZmM1ODciXX0#didcommmessaging-0",
       "type": "DIDCommMessaging",
       "serviceEndpoint": "https://example.com/endpoint",
       "routingKeys": ["did:example:somemediator#somekey"],

--- a/packages/core/src/modules/dids/methods/peer/__tests__/__fixtures__/didPeer2Ez6LMoreServices.json
+++ b/packages/core/src/modules/dids/methods/peer/__tests__/__fixtures__/didPeer2Ez6LMoreServices.json
@@ -1,0 +1,34 @@
+{
+  "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
+  "authentication": [
+    {
+      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
+      "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+    }
+  ],
+  "keyAgreement": [
+    {
+      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud",
+      "type": "X25519KeyAgreementKey2019",
+      "controller": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0",
+      "publicKeyBase58": "DmgBSHMqaZiYqwNMEJJuxWzsGGC8jUYADrfSdBrC6L8s"
+    }
+  ],
+  "service": [
+    {
+      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#didcommmessaging-0",
+      "type": "DIDCommMessaging",
+      "serviceEndpoint": "https://example.com/endpoint",
+      "routingKeys": ["did:example:somemediator#somekey"]
+    },
+    {
+      "id": "did:peer:2.Ez6LSpSrLxbAhg2SHwKk7kwpsH7DM7QjFS5iK6qP87eViohud.Vz6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V.SW3sidCI6ImRtIiwicyI6Imh0dHBzOi8vZXhhbXBsZS5jb20vZW5kcG9pbnQiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5Il19LHsidCI6ImV4YW1wbGUiLCJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludDIiLCJyIjpbImRpZDpleGFtcGxlOnNvbWVtZWRpYXRvciNzb21la2V5MiJdLCJhIjpbImRpZGNvbW0vdjIiLCJkaWRjb21tL2FpcDI7ZW52PXJmYzU4NyJdfV0#example-1",
+      "type": "example",
+      "serviceEndpoint": "https://example.com/endpoint2",
+      "routingKeys": ["did:example:somemediator#somekey2"],
+      "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+    }
+  ]
+}

--- a/packages/core/src/modules/dids/methods/peer/__tests__/peerDidNumAlgo2.test.ts
+++ b/packages/core/src/modules/dids/methods/peer/__tests__/peerDidNumAlgo2.test.ts
@@ -2,20 +2,23 @@ import { JsonTransformer } from '../../../../../utils'
 import { DidDocument } from '../../../domain'
 import { didToNumAlgo2DidDocument, didDocumentToNumAlgo2Did } from '../peerDidNumAlgo2'
 
-import didPeer2ez6L from './__fixtures__/didPeer2ez6L.json'
+import didPeer2Ez6L from './__fixtures__/didPeer2Ez6L.json'
+import didPeer2Ez6LMoreServices from './__fixtures__/didPeer2Ez6LMoreServices.json'
 
 describe('peerDidNumAlgo2', () => {
   describe('didDocumentToNumAlgo2Did', () => {
     test('transforms method 2 peer did to a did document', async () => {
-      expect(didToNumAlgo2DidDocument(didPeer2ez6L.id).toJSON()).toMatchObject(didPeer2ez6L)
+      expect(didToNumAlgo2DidDocument(didPeer2Ez6L.id).toJSON()).toMatchObject(didPeer2Ez6L)
+
+      expect(didToNumAlgo2DidDocument(didPeer2Ez6LMoreServices.id).toJSON()).toMatchObject(didPeer2Ez6LMoreServices)
     })
   })
 
   describe('didDocumentToNumAlgo2Did', () => {
     test('transforms method 2 peer did document to a did', async () => {
-      const expectedDid = didPeer2ez6L.id
+      const expectedDid = didPeer2Ez6L.id
 
-      const didDocument = JsonTransformer.fromJSON(didPeer2ez6L, DidDocument)
+      const didDocument = JsonTransformer.fromJSON(didPeer2Ez6L, DidDocument)
 
       expect(didDocumentToNumAlgo2Did(didDocument)).toBe(expectedDid)
     })


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

Fixes for incorrect encoding of services in peer dids. Checked against the [peer-did-python](https://github.com/sicpa-dlab/peer-did-python) implementation.