### PR TITLE
ci: get last alpha package version from npm

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -39,12 +39,9 @@ jobs:
       - name: Get version number
         id: get-version
         run: |
-          COMMIT_NUMBER=$(git rev-list --count ${{ github.ref }})
-          PACKAGE_NUMBER=$((COMMIT_NUMBER-1))
+          LAST_RELEASED_VERSION=$(npm view @aries-framework/core@alpha version)
 
-          echo alpha.$PACKAGE_NUMBER
-
-          echo "::set-output name=version::$PACKAGE_NUMBER"
+          echo "::set-output name=version::$LAST_RELEASED_VERSION"
 
       - name: Setup git user
         run: |
@@ -53,8 +50,8 @@ jobs:
 
       - name: Set git tag
         run: |
-          git tag alpha.${{ steps.get-version.outputs.version }}
-          git push origin alpha.${{ steps.get-version.outputs.version }} --no-verify
+          git tag ${{ steps.get-version.outputs.version }}
+          git push origin ${{ steps.get-version.outputs.version }} --no-verify
 
   release-stable:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
We currently use the commit number, but this is incorrect as the number will be reset to 0 again when the next minor version is released.

E.g. instead of the tag `alpha.347` it will now be `0.2.0-alpha.12`.

Signed-off-by: Timo Glastra <timo@animo.id>