### PR TITLE
feat: update recursive backoff & trust ping record updates

### DIFF
--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -391,7 +391,10 @@ export class ConnectionService {
     //  - maybe this shouldn't be in the connection service?
     const trustPing = new TrustPingMessage(config)
 
-    await this.updateState(connectionRecord, ConnectionState.Complete)
+    // Only update connection record and emit an event if the state is not already 'Complete'
+    if (connectionRecord.state !== ConnectionState.Complete) {
+      await this.updateState(connectionRecord, ConnectionState.Complete)
+    }
 
     return {
       connectionRecord: connectionRecord,

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -5,8 +5,8 @@ import type { ConnectionRecord } from '../connections'
 import type { MediationStateChangedEvent } from './RoutingEvents'
 import type { MediationRecord } from './index'
 
-import { firstValueFrom, interval, ReplaySubject } from 'rxjs'
-import { filter, first, takeUntil, throttleTime, timeout, delay, tap } from 'rxjs/operators'
+import { firstValueFrom, interval, ReplaySubject, timer } from 'rxjs'
+import { filter, first, takeUntil, throttleTime, timeout, tap, delayWhen } from 'rxjs/operators'
 import { Lifecycle, scoped } from 'tsyringe'
 
 import { AgentConfig } from '../../agent/AgentConfig'
@@ -140,7 +140,7 @@ export class RecipientModule {
         // Increase the interval (recursive back-off)
         tap(() => (interval *= 2)),
         // Wait for interval time before reconnecting
-        delay(interval)
+        delayWhen(() => timer(interval))
       )
       .subscribe(async () => {
         this.logger.warn(


### PR DESCRIPTION
Supersedes #458 and incorporates discussions there.
This PR alters the logic for trust pings so that connection records are not updated and events emitted if the record is already in a 'Complete' state.
Fixes the recursive mediator reconnection backoff behavior

Signed-off-by: James Ebert <jamesebert.k@gmail.com>