### PR TITLE
fix: leading zeros in credential value encoding

### DIFF
--- a/packages/core/src/modules/credentials/CredentialUtils.ts
+++ b/packages/core/src/modules/credentials/CredentialUtils.ts
@@ -153,7 +153,7 @@ export class CredentialUtils {
 
     // If value is an int32 number string return as number string
     if (isString(value) && !isEmpty(value) && !isNaN(Number(value)) && this.isInt32(Number(value))) {
-      return value
+      return Number(value).toString()
     }
 
     if (isNumber(value)) {

--- a/packages/core/src/modules/credentials/__tests__/CredentialUtils.test.ts
+++ b/packages/core/src/modules/credentials/__tests__/CredentialUtils.test.ts
@@ -74,6 +74,10 @@ const testEncodings: { [key: string]: { raw: string | number | boolean | null; e
     raw: '0.1',
     encoded: '9382477430624249591204401974786823110077201914483282671737639310288175260432',
   },
+  'leading zero number string': {
+    raw: '012345',
+    encoded: '12345',
+  },
   'chr 0': {
     raw: String.fromCharCode(0),
     encoded: '49846369543417741186729467304575255505141344055555831574636310663216789168157',


### PR DESCRIPTION
This PR resolves an interop issue between ACA-Py & AFJ—in credential issuance we verify that the credential did not change between what was offered and what is actually being issued. 

If the credential attribute value to be encoded (as described [here](https://github.com/hyperledger/aries-rfcs/blob/be4ad0a6fb2823bb1fc109364c96f077d5d8dffa/features/0036-issue-credential/README.md#encoding-claims-for-indy-based-verifiable-credentials)) is a string of numbers that contains a leading zero, such as an account number like: `08888`, then ACA-Py removes the leading zero (`8888`), while AFJ instead encodes it with the zero (`08888`). This PR adjusts AFJ’s behavior to bring it in line with ACA-Py’s implementation.

Signed-off-by: James Ebert <jamesebert.k@gmail.com>