### PR TITLE
feat: add wallet key derivation method option

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -8,7 +8,7 @@ import type { AutoAcceptProof } from './modules/proofs'
 import type { MediatorPickupStrategy } from './modules/routing'
 
 export const enum KeyDerivationMethod {
-  /** default */
+  /** default value in indy-sdk. Will be used when no value is provided */
   Argon2IMod = 'ARGON2I_MOD',
   /** less secure, but faster */
   Argon2IInt = 'ARGON2I_INT',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,9 +7,19 @@ import type { IndyPoolConfig } from './modules/ledger/IndyPool'
 import type { AutoAcceptProof } from './modules/proofs'
 import type { MediatorPickupStrategy } from './modules/routing'
 
+export const enum KeyDerivationMethod {
+  /** default */
+  Argon2IMod = 'ARGON2I_MOD',
+  /** less secure, but faster */
+  Argon2IInt = 'ARGON2I_INT',
+  /** raw wallet master key */
+  Raw = 'RAW',
+}
+
 export interface WalletConfig {
   id: string
   key: string
+  keyDerivationMethod?: KeyDerivationMethod
 }
 
 export type EncryptedMessage = {

--- a/packages/core/src/wallet/IndyWallet.ts
+++ b/packages/core/src/wallet/IndyWallet.ts
@@ -93,12 +93,12 @@ export class IndyWallet implements Wallet {
     this.logger.debug(`Creating wallet '${walletConfig.id}' using SQLite storage`)
 
     try {
-      await this.indy.createWallet({ id: walletConfig.id }, { key: walletConfig.key })
+      await this.indy.createWallet(
+        { id: walletConfig.id },
+        { key: walletConfig.key, key_derivation_method: walletConfig.keyDerivationMethod }
+      )
 
-      this.walletConfig = {
-        id: walletConfig.id,
-        key: walletConfig.key,
-      }
+      this.walletConfig = walletConfig
 
       // We usually want to create master secret only once, therefore, we can to do so when creating a wallet.
       await this.open(walletConfig)
@@ -141,11 +141,11 @@ export class IndyWallet implements Wallet {
     }
 
     try {
-      this.walletHandle = await this.indy.openWallet({ id: walletConfig.id }, { key: walletConfig.key })
-      this.walletConfig = {
-        id: walletConfig.id,
-        key: walletConfig.key,
-      }
+      this.walletHandle = await this.indy.openWallet(
+        { id: walletConfig.id },
+        { key: walletConfig.key, key_derivation_method: walletConfig.keyDerivationMethod }
+      )
+      this.walletConfig = walletConfig
     } catch (error) {
       if (isIndyError(error, 'WalletNotFoundError')) {
         const errorMessage = `Wallet '${walletConfig.id}' not found`
@@ -192,7 +192,10 @@ export class IndyWallet implements Wallet {
     }
 
     try {
-      await this.indy.deleteWallet({ id: this.walletConfig.id }, { key: this.walletConfig.key })
+      await this.indy.deleteWallet(
+        { id: this.walletConfig.id },
+        { key: this.walletConfig.key, key_derivation_method: this.walletConfig.keyDerivationMethod }
+      )
     } catch (error) {
       if (isIndyError(error, 'WalletNotFoundError')) {
         const errorMessage = `Error deleting wallet: wallet '${this.walletConfig.id}' not found`
@@ -219,7 +222,7 @@ export class IndyWallet implements Wallet {
    */
   public async close(): Promise<void> {
     if (!this.walletHandle) {
-      throw new WalletError('Wallet is in inavlid state, you are trying to close wallet that has no `walletHandle`.')
+      throw new WalletError('Wallet is in invalid state, you are trying to close wallet that has no `walletHandle`.')
     }
 
     try {

--- a/packages/core/tests/wallet.test.ts
+++ b/packages/core/tests/wallet.test.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs'
 import { SubjectInboundTransport } from '../../../tests/transport/SubjectInboundTransport'
 import { SubjectOutboundTransport } from '../../../tests/transport/SubjectOutboundTransport'
 import { Agent } from '../src/agent/Agent'
+import { KeyDerivationMethod } from '../src/types'
 
 import { getBaseConfig } from './helpers'
 
@@ -100,5 +101,18 @@ describe('=== wallet', () => {
     await aliceAgent.shutdown()
 
     await expect(aliceAgent.wallet.open(walletConfig)).resolves.toBeUndefined()
+  })
+
+  test('create wallet with custom key derivation method', async () => {
+    const walletConfig = {
+      id: 'mywallet',
+      key: 'mysecretwalletkey',
+      keyDerivationMethod: KeyDerivationMethod.Argon2IInt,
+    }
+
+    await aliceAgent.wallet.create(walletConfig)
+    await aliceAgent.wallet.open(walletConfig)
+
+    expect(aliceAgent.wallet.isInitialized).toBe(true)
   })
 })


### PR DESCRIPTION
Adds key derivation option as documented in the indy-sdk: https://github.com/hyperledger/indy-sdk/tree/master/wrappers/nodejs#createwallet--config-credentials----void

Also tested to work in React Native