### PR TITLE
test: minor wallet test changes

### DIFF
--- a/packages/core/tests/wallet.test.ts
+++ b/packages/core/tests/wallet.test.ts
@@ -15,7 +15,7 @@ const aliceConfig = getBaseConfig('wallet-tests-Alice', {
   endpoints: ['rxjs:alice'],
 })
 
-describe('=== wallet', () => {
+describe('wallet', () => {
   let aliceAgent: Agent
 
   beforeEach(async () => {
@@ -51,10 +51,10 @@ describe('=== wallet', () => {
     } catch (error) {
       if (error instanceof WalletNotFoundError) {
         await aliceAgent.wallet.create(walletConfig)
+        await aliceAgent.wallet.open(walletConfig)
       }
     }
 
-    await aliceAgent.wallet.open(walletConfig)
     await aliceAgent.initialize()
 
     expect(aliceAgent.isInitialized).toBe(true)


### PR DESCRIPTION
Removed '===' prefix to one test name, changed scope of wallet open call to prevent multiple open attempts

Signed-off-by: Niall Shaw <niall.shaw@absa.africa>