### PR TITLE
fix: agent isinitialized on shutdown

### DIFF
--- a/packages/core/src/agent/Agent.ts
+++ b/packages/core/src/agent/Agent.ts
@@ -211,6 +211,7 @@ export class Agent {
     if (this.wallet.isInitialized) {
       await this.wallet.close()
     }
+    this._isInitialized = false
   }
 
   public get publicDid() {

--- a/packages/core/tests/agents.test.ts
+++ b/packages/core/tests/agents.test.ts
@@ -68,4 +68,12 @@ describe('agents', () => {
 
     expect(basicMessage.content).toBe(message)
   })
+
+  test('can shutdown and re-initialize the same agent', async () => {
+    expect(aliceAgent.isInitialized).toBe(true)
+    await aliceAgent.shutdown()
+    expect(aliceAgent.isInitialized).toBe(false)
+    await aliceAgent.initialize()
+    expect(aliceAgent.isInitialized).toBe(true)
+  })
 })


### PR DESCRIPTION
Fixes problem where agent cannot be initialized (again) after shutdown

Signed-off-by: Niall Shaw <niall.shaw@absa.africa>