### PR TITLE
fix(routing): remove sentTime from request message

### DIFF
--- a/packages/core/src/modules/routing/messages/MediationRequestMessage.ts
+++ b/packages/core/src/modules/routing/messages/MediationRequestMessage.ts
@@ -1,5 +1,4 @@
-import { Expose, Type } from 'class-transformer'
-import { Equals, IsDate } from 'class-validator'
+import { Equals } from 'class-validator'
 
 import { AgentMessage } from '../../../agent/AgentMessage'
 
@@ -26,7 +25,6 @@ export class MediationRequestMessage extends AgentMessage {
 
     if (options) {
       this.id = options.id || this.generateId()
-      this.sentTime = options.sentTime || new Date()
       this.addLocale(options.locale || 'en')
     }
   }
@@ -34,9 +32,4 @@ export class MediationRequestMessage extends AgentMessage {
   @Equals(MediationRequestMessage.type)
   public readonly type = MediationRequestMessage.type
   public static readonly type = 'https://didcomm.org/coordinate-mediation/1.0/mediate-request'
-
-  @Expose({ name: 'sent_time' })
-  @Type(() => Date)
-  @IsDate()
-  public sentTime!: Date
 }


### PR DESCRIPTION
This was probably copied by mistake from the basic message, as it is never been part of the mediation request message.

This currently gives an error if ACA-Py requests mediation from AFJ.

Signed-off-by: Timo Glastra <timo@animo.id>