### PR TITLE
fix: do not use basic message id as record id

### DIFF
--- a/packages/core/src/modules/basic-messages/__tests__/BasicMessageService.test.ts
+++ b/packages/core/src/modules/basic-messages/__tests__/BasicMessageService.test.ts
@@ -69,7 +69,7 @@ describe('BasicMessageService', () => {
         payload: {
           basicMessageRecord: expect.objectContaining({
             connectionId: mockConnectionRecord.id,
-            id: basicMessage.id,
+            id: expect.any(String),
             sentTime: basicMessage.sentTime.toISOString(),
             content: basicMessage.content,
             role: BasicMessageRole.Receiver,

--- a/packages/core/src/modules/basic-messages/services/BasicMessageService.ts
+++ b/packages/core/src/modules/basic-messages/services/BasicMessageService.ts
@@ -26,7 +26,6 @@ export class BasicMessageService {
     const basicMessage = new BasicMessage({ content: message })
 
     const basicMessageRecord = new BasicMessageRecord({
-      id: basicMessage.id,
       sentTime: basicMessage.sentTime.toISOString(),
       content: basicMessage.content,
       connectionId: connectionRecord.id,
@@ -47,7 +46,6 @@ export class BasicMessageService {
    */
   public async save({ message }: InboundMessageContext<BasicMessage>, connection: ConnectionRecord) {
     const basicMessageRecord = new BasicMessageRecord({
-      id: message.id,
       sentTime: message.sentTime.toISOString(),
       content: message.content,
       connectionId: connection.id,


### PR DESCRIPTION
This makes it impossible to send a basic message to yourself