### PR TITLE
test: reuse connection create and process request tests

### DIFF
--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -84,9 +84,9 @@ export class ConnectionsModule {
       })
     } else if (protocol === HandshakeProtocol.Connections) {
       result = await this.connectionService.protocolCreateRequest(outOfBandRecord, {
-        myLabel: label,
+        label,
         alias,
-        myImageUrl: imageUrl,
+        imageUrl,
         routing,
         autoAcceptConnection,
       })

--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -83,7 +83,7 @@ export class ConnectionsModule {
         autoAcceptConnection,
       })
     } else if (protocol === HandshakeProtocol.Connections) {
-      result = await this.connectionService.protocolCreateRequest(outOfBandRecord, {
+      result = await this.connectionService.createRequest(outOfBandRecord, {
         label,
         alias,
         imageUrl,

--- a/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -66,7 +66,7 @@ describe('ConnectionService', () => {
       const outOfBand = getMockOutOfBand()
       const config = { routing: myRouting }
 
-      const { connectionRecord, message } = await connectionService.protocolCreateRequest(outOfBand, config)
+      const { connectionRecord, message } = await connectionService.createRequest(outOfBand, config)
 
       expect(connectionRecord.state).toBe(ConnectionState.Requested)
       expect(message.label).toBe(agentConfig.label)
@@ -81,7 +81,7 @@ describe('ConnectionService', () => {
       const outOfBand = getMockOutOfBand()
       const config = { label: 'Custom label', routing: myRouting }
 
-      const { message } = await connectionService.protocolCreateRequest(outOfBand, config)
+      const { message } = await connectionService.createRequest(outOfBand, config)
 
       expect(message.label).toBe('Custom label')
     })
@@ -92,7 +92,7 @@ describe('ConnectionService', () => {
       const outOfBand = getMockOutOfBand()
       const config = { imageUrl: 'custom-image-url', routing: myRouting }
 
-      const { message } = await connectionService.protocolCreateRequest(outOfBand, config)
+      const { message } = await connectionService.createRequest(outOfBand, config)
 
       expect(message.imageUrl).toBe('custom-image-url')
     })
@@ -106,7 +106,7 @@ describe('ConnectionService', () => {
       mockFunction(connectionRepository.getById).mockReturnValue(
         Promise.resolve(getMockConnection({ role: ConnectionRole.Inviter }))
       )
-      return expect(connectionService.protocolCreateRequest(outOfBand, config)).rejects.toThrowError(
+      return expect(connectionService.createRequest(outOfBand, config)).rejects.toThrowError(
         `Invalid out-of-band record role ${OutOfBandRole.Sender}, expected is ${OutOfBandRole.Receiver}.`
       )
     })
@@ -123,11 +123,8 @@ describe('ConnectionService', () => {
         const outOfBand = getMockOutOfBand({ state })
         const config = { routing: myRouting }
 
-        return expect(connectionService.protocolCreateRequest(outOfBand, config)).rejects.toThrowError(
-          `Invalid out-of-band record state ${state}. Valid states are: ${[
-            OutOfBandState.Initial,
-            OutOfBandState.PrepareResponse,
-          ]}.`
+        return expect(connectionService.createRequest(outOfBand, config)).rejects.toThrowError(
+          `Invalid out-of-band record state ${state}, valid states are: ${OutOfBandState.Initial}, ${OutOfBandState.PrepareResponse}.`
         )
       }
     )
@@ -165,7 +162,7 @@ describe('ConnectionService', () => {
       })
 
       const outOfBand = getMockOutOfBand({ role: OutOfBandRole.Sender })
-      const processedConnection = await connectionService.protocolProcessRequest(messageContext, outOfBand, myRouting)
+      const processedConnection = await connectionService.processRequest(messageContext, outOfBand, myRouting)
 
       expect(processedConnection.state).toBe(ConnectionState.Requested)
       expect(processedConnection.theirDid).toBe(theirDid)
@@ -216,7 +213,7 @@ describe('ConnectionService', () => {
       })
 
       const outOfBand = getMockOutOfBand({ role: OutOfBandRole.Sender })
-      const processedConnection = await connectionService.protocolProcessRequest(messageContext, outOfBand, myRouting)
+      const processedConnection = await connectionService.processRequest(messageContext, outOfBand, myRouting)
 
       expect(processedConnection.state).toBe(ConnectionState.Requested)
       expect(processedConnection.theirDid).toBe(theirDid)
@@ -246,9 +243,9 @@ describe('ConnectionService', () => {
 
       const outOfBand = getMockOutOfBand({ role: OutOfBandRole.Sender })
 
-      return expect(
-        connectionService.protocolProcessRequest(messageContext, outOfBand, myRouting)
-      ).rejects.toThrowError(`Public DIDs are not supported yet`)
+      return expect(connectionService.processRequest(messageContext, outOfBand, myRouting)).rejects.toThrowError(
+        `Public DIDs are not supported yet`
+      )
     })
 
     it(`throws an error when out-of-band role is not ${OutOfBandRole.Sender}`, async () => {
@@ -261,9 +258,7 @@ describe('ConnectionService', () => {
 
       const outOfBand = getMockOutOfBand({ role: OutOfBandRole.Receiver })
 
-      return expect(
-        connectionService.protocolProcessRequest(inboundMessage, outOfBand, myRouting)
-      ).rejects.toThrowError(
+      return expect(connectionService.processRequest(inboundMessage, outOfBand, myRouting)).rejects.toThrowError(
         `Invalid out-of-band record role ${OutOfBandRole.Receiver}, expected is ${OutOfBandRole.Sender}.`
       )
     })
@@ -280,13 +275,8 @@ describe('ConnectionService', () => {
         })
         const outOfBand = getMockOutOfBand({ role: OutOfBandRole.Sender, state })
 
-        return expect(
-          connectionService.protocolProcessRequest(inboundMessage, outOfBand, myRouting)
-        ).rejects.toThrowError(
-          `Invalid out-of-band record state ${state}. Valid states are: ${[
-            OutOfBandState.Initial,
-            OutOfBandState.AwaitResponse,
-          ]}.`
+        return expect(connectionService.processRequest(inboundMessage, outOfBand, myRouting)).rejects.toThrowError(
+          `Invalid out-of-band record state ${state}, valid states are: ${OutOfBandState.Initial}, ${OutOfBandState.AwaitResponse}.`
         )
       }
     )

--- a/packages/core/src/modules/connections/handlers/ConnectionRequestHandler.ts
+++ b/packages/core/src/modules/connections/handlers/ConnectionRequestHandler.ts
@@ -40,11 +40,7 @@ export class ConnectionRequestHandler implements Handler {
     }
 
     const oobRouting = await this.mediationRecipientService.getRouting()
-    const connectionRecord = await this.connectionService.protocolProcessRequest(
-      messageContext,
-      outOfBandRecord,
-      oobRouting
-    )
+    const connectionRecord = await this.connectionService.processRequest(messageContext, outOfBandRecord, oobRouting)
 
     if (connectionRecord?.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
       const { message } = await this.connectionService.createResponse(connectionRecord, outOfBandRecord)

--- a/packages/core/src/modules/connections/repository/ConnectionRecord.ts
+++ b/packages/core/src/modules/connections/repository/ConnectionRecord.ts
@@ -173,7 +173,7 @@ export class ConnectionRecord
     }
   }
 
-  public assertRole(expectedRole: ConnectionRole | undefined) {
+  public assertRole(expectedRole: ConnectionRole) {
     if (this.role !== expectedRole) {
       throw new AriesFrameworkError(`Connection record has invalid role ${this.role}. Expected role ${expectedRole}.`)
     }

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -75,21 +75,13 @@ export class ConnectionService {
    * @param config config for creation of connection request
    * @returns outbound message containing connection request
    */
-  public async protocolCreateRequest(
+  public async createRequest(
     outOfBandRecord: OutOfBandRecord,
     config: ConnectionRequestParams
   ): Promise<ConnectionProtocolMsgReturnType<ConnectionRequestMessage>> {
-    if (outOfBandRecord.role !== OutOfBandRole.Receiver) {
-      throw new AriesFrameworkError(
-        `Invalid out-of-band record role ${outOfBandRecord.role}, expected is ${OutOfBandRole.Receiver}.`
-      )
-    }
-
-    const state = outOfBandRecord.state
-    const expectedStates = [OutOfBandState.Initial, OutOfBandState.PrepareResponse]
-    if (state && !expectedStates.includes(state)) {
-      throw new AriesFrameworkError(`Invalid out-of-band record state ${state}. Valid states are: ${[expectedStates]}.`)
-    }
+    this.logger.debug(`Create message ${ConnectionRequestMessage.type} start`, outOfBandRecord)
+    outOfBandRecord.assertRole(OutOfBandRole.Receiver)
+    outOfBandRecord.assertState([OutOfBandState.Initial, OutOfBandState.PrepareResponse])
 
     // TODO check there is no connection record for particular oob record
 
@@ -128,24 +120,14 @@ export class ConnectionService {
     }
   }
 
-  public async protocolProcessRequest(
+  public async processRequest(
     messageContext: InboundMessageContext<ConnectionRequestMessage>,
     outOfBandRecord: OutOfBandRecord,
     routing: Routing
   ): Promise<ConnectionRecord> {
     this.logger.debug(`Process message ${ConnectionRequestMessage.type} start`, messageContext)
-
-    if (outOfBandRecord.role !== OutOfBandRole.Sender) {
-      throw new AriesFrameworkError(
-        `Invalid out-of-band record role ${outOfBandRecord.role}, expected is ${OutOfBandRole.Sender}.`
-      )
-    }
-
-    const state = outOfBandRecord.state
-    const expectedStates = [OutOfBandState.Initial, OutOfBandState.AwaitResponse]
-    if (state && !expectedStates.includes(state)) {
-      throw new AriesFrameworkError(`Invalid out-of-band record state ${state}. Valid states are: ${[expectedStates]}.`)
-    }
+    outOfBandRecord.assertRole(OutOfBandRole.Sender)
+    outOfBandRecord.assertState([OutOfBandState.Initial, OutOfBandState.AwaitResponse])
 
     // TODO check there is no connection record for particular oob record
 

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -81,7 +81,7 @@ export class ConnectionService {
   ): Promise<ConnectionProtocolMsgReturnType<ConnectionRequestMessage>> {
     this.logger.debug(`Create message ${ConnectionRequestMessage.type} start`, outOfBandRecord)
     outOfBandRecord.assertRole(OutOfBandRole.Receiver)
-    outOfBandRecord.assertState([OutOfBandState.Initial, OutOfBandState.PrepareResponse])
+    outOfBandRecord.assertState(OutOfBandState.PrepareResponse)
 
     // TODO check there is no connection record for particular oob record
 
@@ -127,7 +127,7 @@ export class ConnectionService {
   ): Promise<ConnectionRecord> {
     this.logger.debug(`Process message ${ConnectionRequestMessage.type} start`, messageContext)
     outOfBandRecord.assertRole(OutOfBandRole.Sender)
-    outOfBandRecord.assertState([OutOfBandState.Initial, OutOfBandState.AwaitResponse])
+    outOfBandRecord.assertState(OutOfBandState.AwaitResponse)
 
     // TODO check there is no connection record for particular oob record
 

--- a/packages/core/src/modules/oob/OutOfBandModule.ts
+++ b/packages/core/src/modules/oob/OutOfBandModule.ts
@@ -152,6 +152,8 @@ export class OutOfBandModule {
 
     const options = {
       label,
+      goal: config.goal,
+      goalCode: config.goalCode,
       imageUrl,
       accept: didCommProfiles,
       services,
@@ -288,7 +290,7 @@ export class OutOfBandModule {
 
     const outOfBandRecord = new OutOfBandRecord({
       role: OutOfBandRole.Receiver,
-      state: OutOfBandState.PrepareResponse,
+      state: OutOfBandState.Initial,
       outOfBandMessage: outOfBandMessage,
       autoAcceptConnection,
     })
@@ -340,6 +342,8 @@ export class OutOfBandModule {
     const messages = outOfBandMessage.getRequests()
 
     const existingConnection = await this.findExistingConnection(services)
+
+    await this.outOfBandService.updateState(outOfBandRecord, OutOfBandState.PrepareResponse)
 
     if (handshakeProtocols) {
       this.logger.debug('Out of band message contains handshake protocols.')

--- a/packages/core/src/modules/oob/repository/OutOfBandRecord.ts
+++ b/packages/core/src/modules/oob/repository/OutOfBandRecord.ts
@@ -67,7 +67,7 @@ export class OutOfBandRecord extends BaseRecord<TagsBase> {
       .reduce((acc, curr) => [...acc, ...curr], [])
   }
 
-  public assertRole(expectedRole: OutOfBandRole | undefined) {
+  public assertRole(expectedRole: OutOfBandRole) {
     if (this.role !== expectedRole) {
       throw new AriesFrameworkError(`Invalid out-of-band record role ${this.role}, expected is ${expectedRole}.`)
     }

--- a/packages/core/src/modules/oob/repository/OutOfBandRecord.ts
+++ b/packages/core/src/modules/oob/repository/OutOfBandRecord.ts
@@ -67,6 +67,12 @@ export class OutOfBandRecord extends BaseRecord<TagsBase> {
       .reduce((acc, curr) => [...acc, ...curr], [])
   }
 
+  public assertRole(expectedRole: OutOfBandRole | undefined) {
+    if (this.role !== expectedRole) {
+      throw new AriesFrameworkError(`Invalid out-of-band record role ${this.role}, expected is ${expectedRole}.`)
+    }
+  }
+
   public assertState(expectedStates: OutOfBandState | OutOfBandState[]) {
     if (!Array.isArray(expectedStates)) {
       expectedStates = [expectedStates]
@@ -74,7 +80,7 @@ export class OutOfBandRecord extends BaseRecord<TagsBase> {
 
     if (!expectedStates.includes(this.state)) {
       throw new AriesFrameworkError(
-        `OutOfBand record is in invalid state ${this.state}. Valid states are: ${expectedStates.join(', ')}.`
+        `Invalid out-of-band record state ${this.state}, valid states are: ${expectedStates.join(', ')}.`
       )
     }
   }

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -259,7 +259,15 @@ export function getMockOutOfBand({
   label,
   serviceEndpoint,
   recipientKeys,
-}: { label?: string; serviceEndpoint?: string; recipientKeys?: string[] } = {}) {
+  role,
+  state,
+}: {
+  label?: string
+  serviceEndpoint?: string
+  recipientKeys?: string[]
+  role?: OutOfBandRole
+  state?: OutOfBandState
+} = {}) {
   const options = {
     label: label ?? 'label',
     accept: ['didcomm/aip1', 'didcomm/aip2;env=rfc19'],
@@ -276,8 +284,8 @@ export function getMockOutOfBand({
   }
   const outOfBandMessage = new OutOfBandMessage(options)
   const outOfBandRecord = new OutOfBandRecord({
-    role: OutOfBandRole.Sender,
-    state: OutOfBandState.AwaitResponse,
+    role: role || OutOfBandRole.Receiver,
+    state: state || OutOfBandState.Initial,
     outOfBandMessage: outOfBandMessage,
   })
   return outOfBandRecord


### PR DESCRIPTION
Just small PR adding ConnectionService tests I removed in the previous PR. I also added some checks for the OOB role and state.