### PR TITLE
fix: allow to set tags in MediationRecord constructor

### DIFF
--- a/packages/core/src/modules/routing/repository/MediationRecord.ts
+++ b/packages/core/src/modules/routing/repository/MediationRecord.ts
@@ -61,6 +61,7 @@ export class MediationRecord
       this.role = props.role
       this.endpoint = props.endpoint ?? undefined
       this.pickupStrategy = props.pickupStrategy
+      this._tags = props.tags ?? {}
     }
   }
 


### PR DESCRIPTION
Allow to optionally set tags for MediationRecord in class constructor (as it is in other records such as ConnectionRecord, ProofRecord, etc.). This is not currently used in regular flows but could be useful when mocking framework records.

Signed-off-by: Ariel Gentile <gentilester@gmail.com>