### PR TITLE
feat: find existing connection based on invitation did

### DIFF
--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -260,6 +260,10 @@ export class ConnectionsModule {
     return this.connectionService.findByTheirDid(did)
   }
 
+  public async findByInvitationDid(invitationDid: string): Promise<ConnectionRecord[]> {
+    return this.connectionService.findByInvitationDid(invitationDid)
+  }
+
   private registerHandlers(dispatcher: Dispatcher) {
     dispatcher.registerHandler(
       new ConnectionRequestHandler(

--- a/packages/core/src/modules/connections/DidExchangeProtocol.ts
+++ b/packages/core/src/modules/connections/DidExchangeProtocol.ts
@@ -69,7 +69,11 @@ export class DidExchangeProtocol {
     const { alias, goal, goalCode, routing, autoAcceptConnection } = params
 
     const { did, mediatorId } = routing
-    // const invitationDid = outOfBandMessage.invitationPeerDid
+
+    // TODO: We should store only one did that we'll use to send the request message with success.
+    // We take just the first one for now.
+    const [invitationDid] = outOfBandMessage.invitationDids
+
     const connectionRecord = await this.connectionService.createConnection({
       protocol: HandshakeProtocol.DidExchange,
       role: DidExchangeRole.Requester,
@@ -81,7 +85,7 @@ export class DidExchangeProtocol {
       mediatorId,
       autoAcceptConnection: outOfBandRecord.autoAcceptConnection,
       outOfBandId: outOfBandRecord.id,
-      // invitationDid,
+      invitationDid,
     })
 
     DidExchangeStateMachine.assertCreateMessageState(DidExchangeRequestMessage.type, connectionRecord)

--- a/packages/core/src/modules/connections/DidExchangeProtocol.ts
+++ b/packages/core/src/modules/connections/DidExchangeProtocol.ts
@@ -4,7 +4,6 @@ import type { OutOfBandRecord } from '../oob/repository'
 import type { ConnectionRecord } from './repository'
 import type { Routing } from './services/ConnectionService'
 
-import { convertPublicKeyToX25519 } from '@stablelib/ed25519'
 import { Lifecycle, scoped } from 'tsyringe'
 
 import { AgentConfig } from '../../agent/AgentConfig'
@@ -14,12 +13,10 @@ import { Attachment, AttachmentData } from '../../decorators/attachment/Attachme
 import { AriesFrameworkError } from '../../error'
 import { JsonEncoder } from '../../utils/JsonEncoder'
 import { JsonTransformer } from '../../utils/JsonTransformer'
-import { uuid } from '../../utils/uuid'
-import { DidCommService, DidDocument, DidDocumentBuilder, Key } from '../dids'
+import { DidCommService, DidDocument, Key } from '../dids'
 import { DidDocumentRole } from '../dids/domain/DidDocumentRole'
+import { createDidDocumentFromServices } from '../dids/domain/createPeerDidFromServices'
 import { getKeyDidMappingByVerificationMethod } from '../dids/domain/key-type'
-import { getEd25519VerificationMethod } from '../dids/domain/key-type/ed25519'
-import { getX25519VerificationMethod } from '../dids/domain/key-type/x25519'
 import { DidKey } from '../dids/methods/key/DidKey'
 import { DidPeer, PeerDidNumAlgo } from '../dids/methods/peer/DidPeer'
 import { DidRecord, DidRepository } from '../dids/repository'
@@ -72,6 +69,7 @@ export class DidExchangeProtocol {
     const { alias, goal, goalCode, routing, autoAcceptConnection } = params
 
     const { did, mediatorId } = routing
+    // const invitationDid = outOfBandMessage.invitationPeerDid
     const connectionRecord = await this.connectionService.createConnection({
       protocol: HandshakeProtocol.DidExchange,
       role: DidExchangeRole.Requester,
@@ -83,6 +81,7 @@ export class DidExchangeProtocol {
       mediatorId,
       autoAcceptConnection: outOfBandRecord.autoAcceptConnection,
       outOfBandId: outOfBandRecord.id,
+      // invitationDid,
     })
 
     DidExchangeStateMachine.assertCreateMessageState(DidExchangeRequestMessage.type, connectionRecord)
@@ -374,54 +373,7 @@ export class DidExchangeProtocol {
   }
 
   private async createPeerDidDoc(services: DidCommService[]) {
-    const didDocumentBuilder = new DidDocumentBuilder('')
-
-    // We need to all reciepient and routing keys from all services but we don't want to duplicated items
-    const recipientKeys = new Set(services.map((s) => s.recipientKeys).reduce((acc, curr) => acc.concat(curr), []))
-    const routingKeys = new Set(
-      services
-        .map((s) => s.routingKeys)
-        .filter((r): r is string[] => r !== undefined)
-        .reduce((acc, curr) => acc.concat(curr), [])
-    )
-
-    for (const recipientKey of recipientKeys) {
-      const publicKeyBase58 = recipientKey
-      const ed25519Key = Key.fromPublicKeyBase58(publicKeyBase58, KeyType.Ed25519)
-      const x25519Key = Key.fromPublicKey(convertPublicKeyToX25519(ed25519Key.publicKey), KeyType.X25519)
-
-      const ed25519VerificationMethod = getEd25519VerificationMethod({
-        id: uuid(),
-        key: ed25519Key,
-        controller: '#id',
-      })
-      const x25519VerificationMethod = getX25519VerificationMethod({
-        id: uuid(),
-        key: x25519Key,
-        controller: '#id',
-      })
-
-      // We should not add duplicated keys for services
-      didDocumentBuilder.addAuthentication(ed25519VerificationMethod).addKeyAgreement(x25519VerificationMethod)
-    }
-
-    for (const routingKey of routingKeys) {
-      const publicKeyBase58 = routingKey
-      const ed25519Key = Key.fromPublicKeyBase58(publicKeyBase58, KeyType.Ed25519)
-      const verificationMethod = getEd25519VerificationMethod({
-        id: uuid(),
-        key: ed25519Key,
-        controller: '#id',
-      })
-      didDocumentBuilder.addVerificationMethod(verificationMethod)
-    }
-
-    services.forEach((service) => {
-      didDocumentBuilder.addService(service)
-    })
-
-    const didDocument = didDocumentBuilder.build()
-
+    const didDocument = createDidDocumentFromServices(services)
     const peerDid = DidPeer.fromDidDocument(didDocument, PeerDidNumAlgo.GenesisDoc)
 
     const didRecord = new DidRecord({

--- a/packages/core/src/modules/connections/repository/ConnectionRecord.ts
+++ b/packages/core/src/modules/connections/repository/ConnectionRecord.ts
@@ -24,6 +24,7 @@ export interface ConnectionRecordProps {
   errorMessage?: string
   protocol?: HandshakeProtocol
   outOfBandId?: string
+  invitationDid?: string
 }
 
 export type CustomConnectionTags = TagsBase
@@ -59,6 +60,7 @@ export class ConnectionRecord
   public errorMessage?: string
   public protocol?: HandshakeProtocol
   public outOfBandId?: string
+  public invitationDid?: string
 
   public static readonly type = 'ConnectionRecord'
   public readonly type = ConnectionRecord.type
@@ -70,6 +72,7 @@ export class ConnectionRecord
       this.id = props.id ?? uuid()
       this.createdAt = props.createdAt ?? new Date()
       this.did = props.did
+      this.invitationDid = props.invitationDid
       this.theirDid = props.theirDid
       this.theirLabel = props.theirLabel
       this.state = props.state
@@ -97,6 +100,7 @@ export class ConnectionRecord
       did: this.did,
       theirDid: this.theirDid,
       outOfBandId: this.outOfBandId,
+      invitationDid: this.invitationDid,
     }
   }
 

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -98,7 +98,11 @@ export class ConnectionService {
 
     const { did, mediatorId } = config.routing
     const didDoc = this.createDidDoc(config.routing)
-    // const invitationDid = outOfBandMessage.invitationPeerDid
+
+    // TODO: We should store only one did that we'll use to send the request message with success.
+    // We take just the first one for now.
+    const [invitationDid] = outOfBandMessage.invitationDids
+
     const connectionRecord = await this.createConnection({
       protocol: HandshakeProtocol.Connections,
       role: ConnectionRole.Invitee,
@@ -109,9 +113,9 @@ export class ConnectionService {
       mediatorId,
       autoAcceptConnection: config?.autoAcceptConnection,
       multiUseInvitation: false,
-      // invitationDid,
+      outOfBandId: outOfBandRecord.id,
+      invitationDid,
     })
-    connectionRecord.outOfBandId = outOfBandRecord.id
 
     const routing = config.routing
     const { did: peerDid } = await this.createDid({
@@ -629,6 +633,10 @@ export class ConnectionService {
 
   public async findByOutOfBandId(outOfBandId: string) {
     return this.connectionRepository.findSingleByQuery({ outOfBandId })
+  }
+
+  public async findByInvitationDid(invitationDid: string) {
+    return this.connectionRepository.findByQuery({ invitationDid })
   }
 
   public async createConnection(options: {

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -98,6 +98,7 @@ export class ConnectionService {
 
     const { did, mediatorId } = config.routing
     const didDoc = this.createDidDoc(config.routing)
+    // const invitationDid = outOfBandMessage.invitationPeerDid
     const connectionRecord = await this.createConnection({
       protocol: HandshakeProtocol.Connections,
       role: ConnectionRole.Invitee,
@@ -108,6 +109,7 @@ export class ConnectionService {
       mediatorId,
       autoAcceptConnection: config?.autoAcceptConnection,
       multiUseInvitation: false,
+      // invitationDid,
     })
     connectionRecord.outOfBandId = outOfBandRecord.id
 
@@ -642,6 +644,7 @@ export class ConnectionService {
     imageUrl?: string
     protocol?: HandshakeProtocol
     outOfBandId?: string
+    invitationDid?: string
   }): Promise<ConnectionRecord> {
     const connectionRecord = new ConnectionRecord({
       did: options.did,
@@ -656,6 +659,7 @@ export class ConnectionService {
       mediatorId: options.mediatorId,
       protocol: options.protocol,
       outOfBandId: options.outOfBandId,
+      invitationDid: options.invitationDid,
     })
     await this.connectionRepository.save(connectionRecord)
     return connectionRecord

--- a/packages/core/src/modules/dids/domain/createPeerDidFromServices.ts
+++ b/packages/core/src/modules/dids/domain/createPeerDidFromServices.ts
@@ -1,0 +1,61 @@
+import type { DidCommService } from '.'
+
+import { convertPublicKeyToX25519 } from '@stablelib/ed25519'
+
+import { KeyType } from '../../../crypto'
+import { uuid } from '../../../utils/uuid'
+
+import { getEd25519VerificationMethod } from './key-type/ed25519'
+import { getX25519VerificationMethod } from './key-type/x25519'
+
+import { DidDocumentBuilder, Key } from '.'
+
+export function createDidDocumentFromServices(services: DidCommService[]) {
+  const didDocumentBuilder = new DidDocumentBuilder('')
+
+  // We need to all reciepient and routing keys from all services but we don't want to duplicated items
+  const recipientKeys = new Set(services.map((s) => s.recipientKeys).reduce((acc, curr) => acc.concat(curr), []))
+  const routingKeys = new Set(
+    services
+      .map((s) => s.routingKeys)
+      .filter((r): r is string[] => r !== undefined)
+      .reduce((acc, curr) => acc.concat(curr), [])
+  )
+
+  for (const recipientKey of recipientKeys) {
+    const publicKeyBase58 = recipientKey
+    const ed25519Key = Key.fromPublicKeyBase58(publicKeyBase58, KeyType.Ed25519)
+    const x25519Key = Key.fromPublicKey(convertPublicKeyToX25519(ed25519Key.publicKey), KeyType.X25519)
+
+    const ed25519VerificationMethod = getEd25519VerificationMethod({
+      id: uuid(),
+      key: ed25519Key,
+      controller: '#id',
+    })
+    const x25519VerificationMethod = getX25519VerificationMethod({
+      id: uuid(),
+      key: x25519Key,
+      controller: '#id',
+    })
+
+    // We should not add duplicated keys for services
+    didDocumentBuilder.addAuthentication(ed25519VerificationMethod).addKeyAgreement(x25519VerificationMethod)
+  }
+
+  for (const routingKey of routingKeys) {
+    const publicKeyBase58 = routingKey
+    const ed25519Key = Key.fromPublicKeyBase58(publicKeyBase58, KeyType.Ed25519)
+    const verificationMethod = getEd25519VerificationMethod({
+      id: uuid(),
+      key: ed25519Key,
+      controller: '#id',
+    })
+    didDocumentBuilder.addVerificationMethod(verificationMethod)
+  }
+
+  services.forEach((service) => {
+    didDocumentBuilder.addService(service)
+  })
+
+  return didDocumentBuilder.build()
+}

--- a/packages/core/src/modules/dids/domain/createPeerDidFromServices.ts
+++ b/packages/core/src/modules/dids/domain/createPeerDidFromServices.ts
@@ -5,10 +5,10 @@ import { convertPublicKeyToX25519 } from '@stablelib/ed25519'
 import { KeyType } from '../../../crypto'
 import { uuid } from '../../../utils/uuid'
 
+import { DidDocumentBuilder } from './DidDocumentBuilder'
+import { Key } from './Key'
 import { getEd25519VerificationMethod } from './key-type/ed25519'
 import { getX25519VerificationMethod } from './key-type/x25519'
-
-import { DidDocumentBuilder, Key } from '.'
 
 export function createDidDocumentFromServices(services: DidCommService[]) {
   const didDocumentBuilder = new DidDocumentBuilder('')

--- a/packages/core/src/modules/dids/methods/peer/__tests__/DidPeer.test.ts
+++ b/packages/core/src/modules/dids/methods/peer/__tests__/DidPeer.test.ts
@@ -6,7 +6,9 @@ import didKeyEd25519 from '../../../__tests__/__fixtures__/didKeyEd25519.json'
 import didKeyX25519 from '../../../__tests__/__fixtures__/didKeyX25519.json'
 import { DidDocument, Key } from '../../../domain'
 import { DidPeer, PeerDidNumAlgo } from '../DidPeer'
+import { serviceToNumAlgo2Did } from '../peerDidNumAlgo2'
 
+import didPeer1zQmRDidCommServices from './__fixtures__/didPeer1zQmR-did-comm-service.json'
 import didPeer1zQmR from './__fixtures__/didPeer1zQmR.json'
 import didPeer1zQmZ from './__fixtures__/didPeer1zQmZ.json'
 import didPeer2Ez6L from './__fixtures__/didPeer2Ez6L.json'
@@ -51,6 +53,24 @@ describe('DidPeer', () => {
     )
 
     expect(didPeer2.did).toBe(didPeer2Ez6L.id)
+  })
+
+  test('transforms a did comm service into a valid method 2 did', () => {
+    const didDocument = JsonTransformer.fromJSON(didPeer1zQmRDidCommServices, DidDocument)
+    const peerDid = serviceToNumAlgo2Did(didDocument.didCommServices[0])
+    const peerDidInstance = DidPeer.fromDid(peerDid)
+
+    // TODO the following `console.log` statement throws an error "TypeError: Cannot read property 'toLowerCase'
+    // of undefined" because of this:
+    //
+    // `service.id = `${did}#${service.type.toLowerCase()}-${serviceIndex++}``
+
+    // console.log(peerDidInstance.didDocument)
+
+    expect(peerDid).toBe(
+      'did:peer:2.Ez6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH.SeyJzIjoiaHR0cHM6Ly9leGFtcGxlLmNvbS9lbmRwb2ludCJ9'
+    )
+    expect(peerDid).toBe(peerDidInstance.did)
   })
 
   test('transforms a did document into a valid method 1 did', () => {

--- a/packages/core/src/modules/dids/methods/peer/__tests__/__fixtures__/didPeer1zQmR-did-comm-service.json
+++ b/packages/core/src/modules/dids/methods/peer/__tests__/__fixtures__/didPeer1zQmR-did-comm-service.json
@@ -1,0 +1,21 @@
+{
+  "@context": ["https://w3id.org/did/v1"],
+  "id": "did:peer:1zQmRYBx1pL86DrsxoJ2ZD3w42d7Ng92ErPgFsCSqg8Q1h4i",
+  "keyAgreement": [
+    {
+      "id": "#6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+      "type": "Ed25519VerificationKey2018",
+      "publicKeyBase58": "ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"
+    }
+  ],
+  "service": [
+    {
+      "id": "#service-0",
+      "type": "did-communication",
+      "serviceEndpoint": "https://example.com/endpoint",
+      "recipientKeys": ["did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"],
+      "routingKeys": ["ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7"],
+      "accept": ["didcomm/v2", "didcomm/aip2;env=rfc587"]
+    }
+  ]
+}

--- a/packages/core/src/modules/dids/methods/peer/peerDidNumAlgo2.ts
+++ b/packages/core/src/modules/dids/methods/peer/peerDidNumAlgo2.ts
@@ -1,11 +1,13 @@
 import type { JsonObject } from '../../../../types'
-import type { DidDocument, VerificationMethod } from '../../domain'
+import type { DidCommService, DidDocument, VerificationMethod } from '../../domain'
 
+import { KeyType } from '../../../../crypto'
 import { JsonEncoder, JsonTransformer } from '../../../../utils'
 import { DidDocumentService, Key } from '../../domain'
 import { DidDocumentBuilder } from '../../domain/DidDocumentBuilder'
 import { getKeyDidMappingByKeyType, getKeyDidMappingByVerificationMethod } from '../../domain/key-type'
 import { parseDid } from '../../domain/parse'
+import { DidKey } from '../key'
 
 enum DidPeerPurpose {
   Assertion = 'A',
@@ -138,6 +140,30 @@ export function didDocumentToNumAlgo2Did(didDocument: DidDocument) {
 
     did += `.${DidPeerPurpose.Service}${encodedServices}`
   }
+
+  return did
+}
+
+export function serviceToNumAlgo2Did(service: DidCommService) {
+  let did = 'did:peer:2'
+  let didKey
+  const [recipientKey] = service.recipientKeys
+  if (recipientKey.startsWith('did:key')) {
+    didKey = DidKey.fromDid(recipientKey)
+  } else {
+    const publicKeyBase58 = recipientKey
+    const ed25519Key = Key.fromPublicKeyBase58(publicKeyBase58, KeyType.Ed25519)
+    didKey = new DidKey(ed25519Key)
+  }
+
+  const encoded = `.${DidPeerPurpose.Encryption}${didKey.key.fingerprint}`
+  did += encoded
+
+  const serviceOnlyWithEndpoint = {
+    serviceEndpoint: service.serviceEndpoint,
+  }
+  const encodedServices = JsonEncoder.toBase64URL(abbreviateServiceJson(serviceOnlyWithEndpoint))
+  did += `.${DidPeerPurpose.Service}${encodedServices}`
 
   return did
 }

--- a/packages/core/src/modules/oob/messages/OutOfBandMessage.ts
+++ b/packages/core/src/modules/oob/messages/OutOfBandMessage.ts
@@ -1,6 +1,6 @@
 import type { PlaintextMessage } from '../../../types'
 import type { HandshakeProtocol } from '../../connections'
-import { DidCommService, DidPeer } from '../../dids'
+import type { DidCommService } from '../../dids'
 
 import { Expose, Type } from 'class-transformer'
 import { ArrayNotEmpty, Equals, IsArray, IsInstance, IsOptional, IsUrl, ValidateNested } from 'class-validator'
@@ -12,8 +12,7 @@ import { AriesFrameworkError } from '../../../error'
 import { JsonEncoder } from '../../../utils/JsonEncoder'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
 import { MessageValidator } from '../../../utils/MessageValidator'
-import { createDidDocumentFromServices } from '../../dids/domain/createPeerDidFromServices'
-import { PeerDidNumAlgo } from '../../dids/methods/peer/DidPeer'
+import { serviceToNumAlgo2Did } from '../../dids/methods/peer/peerDidNumAlgo2'
 
 interface OutOfBandMessageOptions {
   id?: string
@@ -86,14 +85,14 @@ export class OutOfBandMessage extends AgentMessage {
     return invitation
   }
 
-  public get invitationPeerDid() {
-    const services = this.services.filter((s): s is DidCommService => typeof s !== 'string')
-    const invitationDidDocument = createDidDocumentFromServices(services)
-    const invitationDidPeer = DidPeer.fromDidDocument(
-      invitationDidDocument,
-      PeerDidNumAlgo.MultipleInceptionKeyWithoutDoc
-    )
-    return invitationDidPeer.did
+  public get invitationDids() {
+    const dids = this.services.map((didOrService) => {
+      if (typeof didOrService === 'string') {
+        return didOrService
+      }
+      return serviceToNumAlgo2Did(didOrService)
+    })
+    return dids
   }
 
   @Equals(OutOfBandMessage.type)

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -252,7 +252,7 @@ export function getMockOutOfBand({
         id: `#inline-0`,
         priority: 0,
         serviceEndpoint: serviceEndpoint ?? 'http://example.com',
-        recipientKeys: recipientKeys || [],
+        recipientKeys: recipientKeys || ['ByHnpUCFb1vAfh9CFZ8ZkmUZguURW8nSw889hy6rD8L7'],
         routingKeys: [],
       }),
     ],


### PR DESCRIPTION
I added a function `serviceToNumAlgo2Did` but I'm testing it in `DidPeer.test`, because I was curious if it's possible to create regular PeerDid and then take `didDocument` from it. As you can see it's not possible right now so I commented the code in the test. 

I described what might be a cause of the problem in issue here [RFC 0434: Ambiguous description of Peer DID numalgo 2 service encoding](https://github.com/hyperledger/aries-rfcs/issues/728).

There is also a simplification of when and what invitation did we store in the connection record. OOB invitation can contain more dids (or service blocks encoded as peer did numalgo2) and we should store only the one we successfully use to send connection request message to.