### PR TITLE
feat: delete events

### DIFF
--- a/packages/core/src/modules/connections/ConnectionEvents.ts
+++ b/packages/core/src/modules/connections/ConnectionEvents.ts
@@ -4,6 +4,7 @@ import type { ConnectionRecord } from './repository/ConnectionRecord'
 
 export enum ConnectionEventTypes {
   ConnectionStateChanged = 'ConnectionStateChanged',
+  ConnectionDeleted = 'ConnectionDeleted',
 }
 
 export interface ConnectionStateChangedEvent extends BaseEvent {
@@ -11,5 +12,11 @@ export interface ConnectionStateChangedEvent extends BaseEvent {
   payload: {
     connectionRecord: ConnectionRecord
     previousState: ConnectionState | null
+  }
+}
+export interface ConnectionDeletedEvent extends BaseEvent {
+  type: typeof ConnectionEventTypes.ConnectionDeleted
+  payload: {
+    connectionRecord: ConnectionRecord
   }
 }

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -2,7 +2,7 @@ import type { AgentMessage } from '../../../agent/AgentMessage'
 import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
 import type { Logger } from '../../../logger'
 import type { AckMessage } from '../../common'
-import type { ConnectionStateChangedEvent } from '../ConnectionEvents'
+import type { ConnectionStateChangedEvent, ConnectionDeletedEvent } from '../ConnectionEvents'
 import type { ConnectionProblemReportMessage } from '../messages'
 import type { CustomConnectionTags } from '../repository/ConnectionRecord'
 
@@ -595,7 +595,14 @@ export class ConnectionService {
    */
   public async deleteById(connectionId: string) {
     const connectionRecord = await this.getById(connectionId)
-    return this.connectionRepository.delete(connectionRecord)
+    await this.connectionRepository.delete(connectionRecord)
+
+    this.eventEmitter.emit<ConnectionDeletedEvent>({
+      type: ConnectionEventTypes.ConnectionDeleted,
+      payload: {
+        connectionRecord,
+      },
+    })
   }
 
   /**

--- a/packages/core/src/modules/credentials/CredentialEvents.ts
+++ b/packages/core/src/modules/credentials/CredentialEvents.ts
@@ -4,8 +4,10 @@ import type { CredentialRecord } from './repository/CredentialRecord'
 
 export enum CredentialEventTypes {
   CredentialStateChanged = 'CredentialStateChanged',
+  CredentialDeleted = 'CredentialDeleted',
   RevocationNotificationReceived = 'RevocationNotificationReceived',
 }
+
 export interface CredentialStateChangedEvent extends BaseEvent {
   type: typeof CredentialEventTypes.CredentialStateChanged
   payload: {
@@ -13,7 +15,12 @@ export interface CredentialStateChangedEvent extends BaseEvent {
     previousState: CredentialState | null
   }
 }
-
+export interface CredentialDeletedEvent extends BaseEvent {
+  type: typeof CredentialEventTypes.CredentialDeleted
+  payload: {
+    credentialRecord: CredentialRecord
+  }
+}
 export interface RevocationNotificationReceivedEvent extends BaseEvent {
   type: typeof CredentialEventTypes.RevocationNotificationReceived
   payload: {

--- a/packages/core/src/modules/credentials/services/CredentialService.ts
+++ b/packages/core/src/modules/credentials/services/CredentialService.ts
@@ -4,7 +4,7 @@ import type { Logger } from '../../../logger'
 import type { LinkedAttachment } from '../../../utils/LinkedAttachment'
 import type { ConnectionRecord } from '../../connections'
 import type { AutoAcceptCredential } from '../CredentialAutoAcceptType'
-import type { CredentialStateChangedEvent } from '../CredentialEvents'
+import type { CredentialStateChangedEvent, CredentialDeletedEvent } from '../CredentialEvents'
 import type { CredentialProblemReportMessage, ProposeCredentialMessageOptions } from '../messages'
 
 import { Lifecycle, scoped } from 'tsyringe'
@@ -826,6 +826,13 @@ export class CredentialService {
     if (options?.deleteAssociatedCredential && credentialRecord.credentialId) {
       await this.indyHolderService.deleteCredential(credentialRecord.credentialId)
     }
+
+    this.eventEmitter.emit<CredentialDeletedEvent>({
+      type: CredentialEventTypes.CredentialDeleted,
+      payload: {
+        credentialRecord,
+      },
+    })
   }
 
   /**

--- a/packages/core/src/modules/proofs/ProofEvents.ts
+++ b/packages/core/src/modules/proofs/ProofEvents.ts
@@ -4,6 +4,7 @@ import type { ProofRecord } from './repository'
 
 export enum ProofEventTypes {
   ProofStateChanged = 'ProofStateChanged',
+  ProofDeleted = 'ProofDeleted',
 }
 
 export interface ProofStateChangedEvent extends BaseEvent {
@@ -11,5 +12,11 @@ export interface ProofStateChangedEvent extends BaseEvent {
   payload: {
     proofRecord: ProofRecord
     previousState: ProofState | null
+  }
+}
+export interface ProofDeletedEvent extends BaseEvent {
+  type: typeof ProofEventTypes.ProofDeleted
+  payload: {
+    proofRecord: ProofRecord
   }
 }

--- a/packages/core/src/modules/proofs/services/ProofService.ts
+++ b/packages/core/src/modules/proofs/services/ProofService.ts
@@ -3,7 +3,7 @@ import type { InboundMessageContext } from '../../../agent/models/InboundMessage
 import type { Logger } from '../../../logger'
 import type { ConnectionRecord } from '../../connections'
 import type { AutoAcceptProof } from '../ProofAutoAcceptType'
-import type { ProofStateChangedEvent } from '../ProofEvents'
+import type { ProofStateChangedEvent, ProofDeletedEvent } from '../ProofEvents'
 import type { PresentationPreview, PresentationPreviewAttribute } from '../messages'
 import type { PresentationProblemReportMessage } from './../messages/PresentationProblemReportMessage'
 import type { CredDef, IndyProof, Schema } from 'indy-sdk'
@@ -974,7 +974,14 @@ export class ProofService {
    */
   public async deleteById(proofId: string) {
     const proofRecord = await this.getById(proofId)
-    return this.proofRepository.delete(proofRecord)
+    await this.proofRepository.delete(proofRecord)
+
+    this.eventEmitter.emit<ProofDeletedEvent>({
+      type: ProofEventTypes.ProofDeleted,
+      payload: {
+        proofRecord,
+      },
+    })
   }
 
   /**


### PR DESCRIPTION
Added delete events to `Connection`, `Credential` and `Proof` services so that they notify about deletion in similar way to state change events.