### PR TITLE
feat: Updated initPublicDid method

### DIFF
--- a/packages/core/src/wallet/IndyWallet.ts
+++ b/packages/core/src/wallet/IndyWallet.ts
@@ -353,13 +353,23 @@ export class IndyWallet implements Wallet {
     }
   }
 
-  public async initPublicDid(didConfig: DidConfig) {
+public async initPublicDid(didConfig: DidConfig) {
+    (await this.indy.listMyDidsWithMeta(this.handle)).forEach(element => {
+        if (element.metadata == "Public") {
+            this.publicDidInfo = {
+                element.did,
+                element.verkey,
+            }
+            return
+        }
+    });
     const { did, verkey } = await this.createDid(didConfig)
+    this.indy.setDidMetadata(this.handle, did, "Public")
     this.publicDidInfo = {
-      did,
-      verkey,
+        did,
+        verkey,
     }
-  }
+}
 
   public async createDid(didConfig?: DidConfig): Promise<DidInfo> {
     try {


### PR DESCRIPTION
This PR reuses the public did instead of generating a new every time the wallet is opened.

Signed-off-by: Dinkar Jain <62498436+dinkar-jain@users.noreply.github.com>