### PR TITLE
feat: Updated initPublicDid method

### DIFF
--- a/packages/core/src/wallet/IndyWallet.ts
+++ b/packages/core/src/wallet/IndyWallet.ts
@@ -354,7 +354,17 @@ export class IndyWallet implements Wallet {
   }
 
   public async initPublicDid(didConfig: DidConfig) {
+    (await this.indy.listMyDidsWithMeta(this.handle)).forEach(element => {
+      if (element.metadata == "Public") {
+        this.publicDidInfo = {
+          element.did,
+          element.verkey,
+        }
+        return
+      }
+    });
     const { did, verkey } = await this.createDid(didConfig)
+    this.indy.setDidMetadata(this.handle, did, "Public")
     this.publicDidInfo = {
       did,
       verkey,

--- a/packages/core/src/wallet/IndyWallet.ts
+++ b/packages/core/src/wallet/IndyWallet.ts
@@ -354,20 +354,25 @@ export class IndyWallet implements Wallet {
   }
 
   public async initPublicDid(didConfig: DidConfig) {
+    let bool = false;
     (await this.indy.listMyDidsWithMeta(this.handle)).forEach(element => {
       if (element.metadata == "Public") {
+        const did = element.did
+        const verkey = element.verkey
         this.publicDidInfo = {
-          element.did,
-          element.verkey,
+          did,
+          verkey,
         }
-        return
+        bool = true
       }
     });
-    const { did, verkey } = await this.createDid(didConfig)
-    this.indy.setDidMetadata(this.handle, did, "Public")
-    this.publicDidInfo = {
-      did,
-      verkey,
+    if (!bool) {
+      const { did, verkey } = await this.createDid(didConfig)
+      this.indy.setDidMetadata(this.handle, did, "Public")
+      this.publicDidInfo = {
+        did,
+        verkey,
+      };
     }
   }
 


### PR DESCRIPTION
This PR reuses the public did instead of generating a new every time the wallet is opened.

Signed-off-by: Dinkar Jain <62498436+dinkar-jain@users.noreply.github.com>