### PR TITLE
chore!: update indy-sdk-react-native version to 0.2.0

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -31,7 +31,7 @@
   "devDependencies": {
     "@types/indy-sdk-react-native": "npm:@types/indy-sdk@^1.16.16",
     "@types/react-native": "^0.64.10",
-    "indy-sdk-react-native": "^0.1.21",
+    "indy-sdk-react-native": "^0.2.0",
     "react": "17.0.1",
     "react-native": "0.64.2",
     "react-native-fs": "^2.18.0",
@@ -40,7 +40,7 @@
     "typescript": "~4.3.0"
   },
   "peerDependencies": {
-    "indy-sdk-react-native": "^0.1.21",
+    "indy-sdk-react-native": "^0.2.0",
     "react-native-fs": "^2.18.0",
     "react-native-get-random-values": "^1.7.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5504,10 +5504,10 @@ indent-string@^4.0.0:
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-4.0.0.tgz#624f8f4497d619b2d9768531d58f4122854d7251"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-indy-sdk-react-native@^0.1.21:
-  version "0.1.21"
-  resolved "https://registry.yarnpkg.com/indy-sdk-react-native/-/indy-sdk-react-native-0.1.21.tgz#19f8cfd2afbe10775cef4f48682499dd963b9e02"
-  integrity sha512-AvOle3xfY3xWfwQe4fit2Pxmx0dKAuamm1L+nOoLRMVzNQNvdMdH8oxXs8eSUWh/7F6raL+ghAG3B4OEEeH3DA==
+indy-sdk-react-native@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/indy-sdk-react-native/-/indy-sdk-react-native-0.2.0.tgz#9f02dc29726b22b5f90aa602b6a0d15cbd26b48b"
+  integrity sha512-eipyH5GzQFjTf89sMCSMy5axbl3uVDln79LOH2rpqN2cb+80Pzb3tMFYWb9TaU4jMKYzlaEE0RsuQoS151g2jQ==
   dependencies:
     buffer "^6.0.2"
 


### PR DESCRIPTION
Signed-off-by: Amit <amit@northernblock.io>

Update indy-sdk-react-native version to 0.2.0 to support

- chore!: update indy SDK version to 1.16 for android
- chore(deps): bump plist from 3.0.4 to 3.0.5
- chore(deps): bump async from 2.6.3 to 2.6.4
- chore: update indy framework source link
- 

Issue - https://github.com/hyperledger/aries-framework-javascript/issues/752

