### PR TITLE
fix: add BBS context to DidDoc

### DIFF
--- a/packages/core/src/modules/dids/__tests__/__fixtures__/didKeyBls12381g1.json
+++ b/packages/core/src/modules/dids/__tests__/__fixtures__/didKeyBls12381g1.json
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://w3id.org/did/v1"],
+  "@context": ["https://w3id.org/did/v1", "https://w3id.org/security/bbs/v1"],
   "id": "did:key:z3tEFALUKUzzCAvytMHX8X4SnsNsq6T5tC5Zb18oQEt1FqNcJXqJ3AA9umgzA9yoqPBeWA",
   "verificationMethod": [
     {

--- a/packages/core/src/modules/dids/__tests__/__fixtures__/didKeyBls12381g1g2.json
+++ b/packages/core/src/modules/dids/__tests__/__fixtures__/didKeyBls12381g1g2.json
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://w3id.org/did/v1"],
+  "@context": ["https://w3id.org/did/v1", "https://w3id.org/security/bbs/v1"],
   "id": "did:key:z5TcESXuYUE9aZWYwSdrUEGK1HNQFHyTt4aVpaCTVZcDXQmUheFwfNZmRksaAbBneNm5KyE52SdJeRCN1g6PJmF31GsHWwFiqUDujvasK3wTiDr3vvkYwEJHt7H5RGEKYEp1ErtQtcEBgsgY2DA9JZkHj1J9HZ8MRDTguAhoFtR4aTBQhgnkP4SwVbxDYMEZoF2TMYn3s",
   "verificationMethod": [
     {

--- a/packages/core/src/modules/dids/__tests__/__fixtures__/didKeyBls12381g2.json
+++ b/packages/core/src/modules/dids/__tests__/__fixtures__/didKeyBls12381g2.json
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://w3id.org/did/v1"],
+  "@context": ["https://w3id.org/did/v1", "https://w3id.org/security/bbs/v1"],
   "id": "did:key:zUC71nmwvy83x1UzNKbZbS7N9QZx8rqpQx3Ee3jGfKiEkZngTKzsRoqobX6wZdZF5F93pSGYYco3gpK9tc53ruWUo2tkBB9bxPCFBUjq2th8FbtT4xih6y6Q1K9EL4Th86NiCGT",
   "verificationMethod": [
     {

--- a/packages/core/src/modules/dids/__tests__/__fixtures__/didKeyX25519.json
+++ b/packages/core/src/modules/dids/__tests__/__fixtures__/didKeyX25519.json
@@ -1,5 +1,5 @@
 {
-  "@context": ["https://w3id.org/did/v1"],
+  "@context": ["https://w3id.org/did/v1", "https://w3id.org/security/suites/x25519-2019/v1"],
   "id": "did:key:z6LShLeXRTzevtwcfehaGEzCMyL3bNsAeKCwcqwJxyCo63yE",
   "keyAgreement": [
     {

--- a/packages/core/src/modules/dids/domain/keyDidDocument.ts
+++ b/packages/core/src/modules/dids/domain/keyDidDocument.ts
@@ -31,7 +31,9 @@ function getBls12381g1DidDoc(did: string, key: Key) {
     did,
     key,
     verificationMethod,
-  }).build()
+  })
+    .addContext('https://w3id.org/security/bbs/v1')
+    .build()
 }
 
 function getBls12381g1g2DidDoc(did: string, key: Key) {
@@ -48,7 +50,7 @@ function getBls12381g1g2DidDoc(did: string, key: Key) {
       .addCapabilityInvocation(verificationMethod.id)
   }
 
-  return didDocumentBuilder.build()
+  return didDocumentBuilder.addContext('https://w3id.org/security/bbs/v1').build()
 }
 
 function getEd25519DidDoc(did: string, key: Key) {
@@ -87,7 +89,9 @@ function getBls12381g2DidDoc(did: string, key: Key) {
     did,
     key,
     verificationMethod,
-  }).build()
+  })
+    .addContext('https://w3id.org/security/bbs/v1')
+    .build()
 }
 
 function getSignatureKeyBase({

--- a/packages/core/src/modules/dids/domain/keyDidDocument.ts
+++ b/packages/core/src/modules/dids/domain/keyDidDocument.ts
@@ -77,7 +77,10 @@ function getEd25519DidDoc(did: string, key: Key) {
 function getX25519DidDoc(did: string, key: Key) {
   const verificationMethod = getX25519VerificationMethod({ id: `${did}#${key.fingerprint}`, key, controller: did })
 
-  const document = new DidDocumentBuilder(did).addKeyAgreement(verificationMethod).build()
+  const document = new DidDocumentBuilder(did)
+    .addKeyAgreement(verificationMethod)
+    .addContext('https://w3id.org/security/suites/x25519-2019/v1')
+    .build()
 
   return document
 }

--- a/packages/core/src/modules/dids/methods/key/__tests__/DidKey.test.ts
+++ b/packages/core/src/modules/dids/methods/key/__tests__/DidKey.test.ts
@@ -13,6 +13,7 @@ describe('DidKey', () => {
 
     for (const documentType of documentTypes) {
       const didKey = DidKey.fromDid(documentType.id)
+
       expect(didKey.didDocument.toJSON()).toMatchObject(documentType)
     }
   })


### PR DESCRIPTION
BBS context was missing in the DidDocumentBuilder, resulting in some value being dropped during frameing. This PR adds the context.

Signed-off-by: Karim <karim@animo.id>
