### PR TITLE
ci: run ci on -pre branches

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,10 +2,10 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, '**-pre']
     types: [opened, synchronize, reopened, labeled]
   push:
-    branches: [main]
+    branches: [main, '**-pre']
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Run ci on pre branches so we also have this enabled for the 0.3.0-pre (and others in the future) branches