### PR TITLE
fix(oob): check service is string instance

### DIFF
--- a/packages/core/src/modules/oob/messages/OutOfBandInvitation.ts
+++ b/packages/core/src/modules/oob/messages/OutOfBandInvitation.ts
@@ -103,7 +103,7 @@ export class OutOfBandInvitation extends AgentMessage {
   // TODO: this only takes into account inline didcomm services, won't work for public dids
   public getRecipientKeys(): Key[] {
     return this.services
-      .filter((s): s is OutOfBandDidCommService => typeof s !== 'string')
+      .filter((s): s is OutOfBandDidCommService => typeof s !== 'string' && !(s instanceof String))
       .map((s) => s.recipientKeys)
       .reduce((acc, curr) => [...acc, ...curr], [])
       .map((didKey) => DidKey.fromDid(didKey).key)


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

Adds a check whether the service is instanceof String as mentioned in  #812. this is needed due to the class-validator logic sadly.