### PR TITLE
fix: process ws return route messages serially

### DIFF
--- a/packages/core/src/transport/WsOutboundTransport.ts
+++ b/packages/core/src/transport/WsOutboundTransport.ts
@@ -1,5 +1,5 @@
-import type { AgentMessageReceivedEvent } from '..'
 import type { Agent } from '../agent/Agent'
+import type { AgentMessageReceivedEvent } from '../agent/Events'
 import type { Logger } from '../logger'
 import type { OutboundPackage } from '../types'
 import type { OutboundTransport } from './OutboundTransport'

--- a/packages/core/src/transport/WsOutboundTransport.ts
+++ b/packages/core/src/transport/WsOutboundTransport.ts
@@ -1,3 +1,4 @@
+import type { AgentMessageReceivedEvent } from '..'
 import type { Agent } from '../agent/Agent'
 import type { Logger } from '../logger'
 import type { OutboundPackage } from '../types'
@@ -7,6 +8,7 @@ import type WebSocket from 'ws'
 
 import { AgentConfig } from '../agent/AgentConfig'
 import { EventEmitter } from '../agent/EventEmitter'
+import { AgentEventTypes } from '../agent/Events'
 import { AriesFrameworkError } from '../error/AriesFrameworkError'
 import { isValidJweStructure, JsonEncoder } from '../utils'
 import { Buffer } from '../utils/buffer'
@@ -109,7 +111,12 @@ export class WsOutboundTransport implements OutboundTransport {
       )
     }
     this.logger.debug('Payload received from mediator:', payload)
-    void this.agent.receiveMessage(payload)
+    this.eventEmitter.emit<AgentMessageReceivedEvent>({
+      type: AgentEventTypes.AgentMessageReceived,
+      payload: {
+        message: payload,
+      },
+    })
   }
 
   private listenOnWebSocketMessages(socket: WebSocket) {

--- a/packages/core/src/utils/__tests__/indyProofRequest.test.ts
+++ b/packages/core/src/utils/__tests__/indyProofRequest.test.ts
@@ -1,4 +1,4 @@
-import { checkProofRequestForDuplicates } from '..'
+import { checkProofRequestForDuplicates } from '../indyProofRequest'
 
 import {
   AriesFrameworkError,


### PR DESCRIPTION
We were already processing messages serially for pickup v1 and v2. This pr updates to also use this for websocket inbound transport. This can help prevent some race conditions and is consistent with the other pickup approaches