### PR TITLE
fix: clone record before emitting event

### DIFF
--- a/packages/core/src/modules/basic-messages/services/BasicMessageService.ts
+++ b/packages/core/src/modules/basic-messages/services/BasicMessageService.ts
@@ -6,6 +6,7 @@ import type { BasicMessageTags } from '../repository'
 import { Lifecycle, scoped } from 'tsyringe'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
+import { JsonTransformer } from '../../../utils'
 import { BasicMessageEventTypes } from '../BasicMessageEvents'
 import { BasicMessageRole } from '../BasicMessageRole'
 import { BasicMessage } from '../messages'
@@ -33,10 +34,7 @@ export class BasicMessageService {
     })
 
     await this.basicMessageRepository.save(basicMessageRecord)
-    this.eventEmitter.emit<BasicMessageStateChangedEvent>({
-      type: BasicMessageEventTypes.BasicMessageStateChanged,
-      payload: { message: basicMessage, basicMessageRecord },
-    })
+    this.emitStateChangedEvent(basicMessageRecord, basicMessage)
 
     return basicMessage
   }
@@ -53,9 +51,14 @@ export class BasicMessageService {
     })
 
     await this.basicMessageRepository.save(basicMessageRecord)
+    this.emitStateChangedEvent(basicMessageRecord, message)
+  }
+
+  private emitStateChangedEvent(basicMessageRecord: BasicMessageRecord, basicMessage: BasicMessage) {
+    const clonedBasicMessageRecord = JsonTransformer.clone(basicMessageRecord)
     this.eventEmitter.emit<BasicMessageStateChangedEvent>({
       type: BasicMessageEventTypes.BasicMessageStateChanged,
-      payload: { message, basicMessageRecord },
+      payload: { message: basicMessage, basicMessageRecord: clonedBasicMessageRecord },
     })
   }
 

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -181,13 +181,7 @@ export class ConnectionService {
     })
 
     await this.connectionRepository.update(connectionRecord)
-    this.eventEmitter.emit<ConnectionStateChangedEvent>({
-      type: ConnectionEventTypes.ConnectionStateChanged,
-      payload: {
-        connectionRecord,
-        previousState: null,
-      },
-    })
+    this.emitStateChangedEvent(connectionRecord, null)
 
     this.logger.debug(`Process message ${ConnectionRequestMessage.type} end`, connectionRecord)
     return connectionRecord
@@ -509,10 +503,17 @@ export class ConnectionService {
     connectionRecord.state = newState
     await this.connectionRepository.update(connectionRecord)
 
+    this.emitStateChangedEvent(connectionRecord, previousState)
+  }
+
+  private emitStateChangedEvent(connectionRecord: ConnectionRecord, previousState: DidExchangeState | null) {
+    // Connection record in event should be static
+    const clonedConnection = JsonTransformer.clone(connectionRecord)
+
     this.eventEmitter.emit<ConnectionStateChangedEvent>({
       type: ConnectionEventTypes.ConnectionStateChanged,
       payload: {
-        connectionRecord,
+        connectionRecord: clonedConnection,
         previousState,
       },
     })

--- a/packages/core/src/modules/credentials/protocol/v1/V1CredentialService.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/V1CredentialService.ts
@@ -3,7 +3,6 @@ import type { HandlerInboundMessage } from '../../../../agent/Handler'
 import type { InboundMessageContext } from '../../../../agent/models/InboundMessageContext'
 import type { Attachment } from '../../../../decorators/attachment/Attachment'
 import type { ConnectionRecord } from '../../../connections'
-import type { CredentialStateChangedEvent } from '../../CredentialEvents'
 import type {
   ServiceAcceptCredentialOptions,
   CredentialOfferTemplate,
@@ -36,7 +35,6 @@ import { ConnectionService } from '../../../connections/services'
 import { DidResolverService } from '../../../dids'
 import { MediationRecipientService } from '../../../routing'
 import { AutoAcceptCredential } from '../../CredentialAutoAcceptType'
-import { CredentialEventTypes } from '../../CredentialEvents'
 import { CredentialProtocolVersion } from '../../CredentialProtocolVersion'
 import { CredentialState } from '../../CredentialState'
 import { CredentialUtils } from '../../CredentialUtils'
@@ -177,13 +175,7 @@ export class V1CredentialService extends CredentialService {
       associatedRecordId: credentialRecord.id,
     })
 
-    this.eventEmitter.emit<CredentialStateChangedEvent>({
-      type: CredentialEventTypes.CredentialStateChanged,
-      payload: {
-        credentialRecord,
-        previousState: null,
-      },
-    })
+    this.emitStateChangedEvent(credentialRecord, null)
 
     return { credentialRecord, message }
   }
@@ -360,13 +352,8 @@ export class V1CredentialService extends CredentialService {
 
       // Save record
       await this.credentialRepository.save(credentialRecord)
-      this.eventEmitter.emit<CredentialStateChangedEvent>({
-        type: CredentialEventTypes.CredentialStateChanged,
-        payload: {
-          credentialRecord,
-          previousState: null,
-        },
-      })
+      this.emitStateChangedEvent(credentialRecord, null)
+
       await this.didCommMessageRepository.saveAgentMessage({
         agentMessage: proposalMessage,
         role: DidCommMessageRole.Receiver,
@@ -536,13 +523,8 @@ export class V1CredentialService extends CredentialService {
     const { credentialRecord, message } = await this.createOfferProcessing(template, credentialOptions.connection)
 
     await this.credentialRepository.save(credentialRecord)
-    this.eventEmitter.emit<CredentialStateChangedEvent>({
-      type: CredentialEventTypes.CredentialStateChanged,
-      payload: {
-        credentialRecord,
-        previousState: null,
-      },
-    })
+    this.emitStateChangedEvent(credentialRecord, null)
+
     await this.didCommMessageRepository.saveAgentMessage({
       agentMessage: message,
       role: DidCommMessageRole.Sender,
@@ -643,13 +625,7 @@ export class V1CredentialService extends CredentialService {
         role: DidCommMessageRole.Receiver,
         associatedRecordId: credentialRecord.id,
       })
-      this.eventEmitter.emit<CredentialStateChangedEvent>({
-        type: CredentialEventTypes.CredentialStateChanged,
-        payload: {
-          credentialRecord,
-          previousState: null,
-        },
-      })
+      this.emitStateChangedEvent(credentialRecord, null)
     }
 
     return credentialRecord

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v1credentials-auto-accept.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v1credentials-auto-accept.test.ts
@@ -148,7 +148,7 @@ describe('credentials', () => {
             credentialRecordId: expect.any(String),
           },
         ],
-        state: CredentialState.Done,
+        state: CredentialState.CredentialReceived,
       })
       expect(faberCredentialRecord).toMatchObject({
         type: CredentialExchangeRecord.type,
@@ -249,7 +249,7 @@ describe('credentials', () => {
             credentialRecordId: expect.any(String),
           },
         ],
-        state: CredentialState.Done,
+        state: CredentialState.CredentialReceived,
       })
 
       expect(faberCredentialExchangeRecord).toMatchObject({
@@ -344,7 +344,7 @@ describe('credentials', () => {
               credentialRecordId: expect.any(String),
             },
           ],
-          state: CredentialState.Done,
+          state: CredentialState.CredentialReceived,
         })
 
         expect(faberCredentialExchangeRecord).toMatchObject({

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2credentials-auto-accept.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2credentials-auto-accept.test.ts
@@ -150,7 +150,7 @@ describe('credentials', () => {
             },
           },
         },
-        state: CredentialState.Done,
+        state: CredentialState.CredentialReceived,
       })
       expect(faberCredentialRecord).toMatchObject({
         type: CredentialExchangeRecord.type,
@@ -244,7 +244,7 @@ describe('credentials', () => {
             },
           },
         },
-        state: CredentialState.Done,
+        state: CredentialState.CredentialReceived,
       })
 
       expect(faberCredentialRecord).toMatchObject({
@@ -332,7 +332,7 @@ describe('credentials', () => {
               },
             },
           },
-          state: CredentialState.Done,
+          state: CredentialState.CredentialReceived,
         })
 
         expect(faberCredentialRecord).toMatchObject({

--- a/packages/core/src/modules/credentials/services/CredentialService.ts
+++ b/packages/core/src/modules/credentials/services/CredentialService.ts
@@ -41,6 +41,8 @@ import type { V2RequestCredentialMessage } from './../protocol/v2/messages/V2Req
 import type { CredentialExchangeRecord, CredentialRepository } from './../repository'
 import type { RevocationService } from './RevocationService'
 
+import { JsonTransformer } from '../../../utils'
+
 import { CredentialEventTypes } from './../CredentialEvents'
 import { CredentialState } from './../CredentialState'
 
@@ -210,14 +212,21 @@ export abstract class CredentialService {
     credentialRecord.state = newState
     await this.credentialRepository.update(credentialRecord)
 
+    this.emitStateChangedEvent(credentialRecord, previousState)
+  }
+
+  protected emitStateChangedEvent(credentialRecord: CredentialExchangeRecord, previousState: CredentialState | null) {
+    const clonedCredential = JsonTransformer.clone(credentialRecord)
+
     this.eventEmitter.emit<CredentialStateChangedEvent>({
       type: CredentialEventTypes.CredentialStateChanged,
       payload: {
-        credentialRecord,
+        credentialRecord: clonedCredential,
         previousState: previousState,
       },
     })
   }
+
   /**
    * Retrieve a credential record by id
    *

--- a/packages/core/src/modules/oob/OutOfBandModule.ts
+++ b/packages/core/src/modules/oob/OutOfBandModule.ts
@@ -4,7 +4,7 @@ import type { Logger } from '../../logger'
 import type { ConnectionRecord, Routing } from '../../modules/connections'
 import type { PlaintextMessage } from '../../types'
 import type { Key } from '../dids'
-import type { HandshakeReusedEvent, OutOfBandStateChangedEvent } from './domain/OutOfBandEvents'
+import type { HandshakeReusedEvent } from './domain/OutOfBandEvents'
 
 import { parseUrl } from 'query-string'
 import { catchError, EmptyError, first, firstValueFrom, map, of, timeout } from 'rxjs'
@@ -207,13 +207,7 @@ export class OutOfBandModule {
     })
 
     await this.outOfBandService.save(outOfBandRecord)
-    this.eventEmitter.emit<OutOfBandStateChangedEvent>({
-      type: OutOfBandEventTypes.OutOfBandStateChanged,
-      payload: {
-        outOfBandRecord,
-        previousState: null,
-      },
-    })
+    this.outOfBandService.emitStateChangedEvent(outOfBandRecord, null)
 
     return outOfBandRecord
   }
@@ -358,13 +352,7 @@ export class OutOfBandModule {
       autoAcceptConnection,
     })
     await this.outOfBandService.save(outOfBandRecord)
-    this.eventEmitter.emit<OutOfBandStateChangedEvent>({
-      type: OutOfBandEventTypes.OutOfBandStateChanged,
-      payload: {
-        outOfBandRecord,
-        previousState: null,
-      },
-    })
+    this.outOfBandService.emitStateChangedEvent(outOfBandRecord, null)
 
     if (autoAcceptInvitation) {
       return await this.acceptInvitation(outOfBandRecord.id, {

--- a/packages/core/src/modules/oob/OutOfBandService.ts
+++ b/packages/core/src/modules/oob/OutOfBandService.ts
@@ -8,6 +8,7 @@ import { scoped, Lifecycle } from 'tsyringe'
 
 import { EventEmitter } from '../../agent/EventEmitter'
 import { AriesFrameworkError } from '../../error'
+import { JsonTransformer } from '../../utils'
 
 import { OutOfBandEventTypes } from './domain/OutOfBandEvents'
 import { OutOfBandRole } from './domain/OutOfBandRole'
@@ -132,10 +133,16 @@ export class OutOfBandService {
     outOfBandRecord.state = newState
     await this.outOfBandRepository.update(outOfBandRecord)
 
+    this.emitStateChangedEvent(outOfBandRecord, previousState)
+  }
+
+  public emitStateChangedEvent(outOfBandRecord: OutOfBandRecord, previousState: OutOfBandState | null) {
+    const clonedOutOfBandRecord = JsonTransformer.clone(outOfBandRecord)
+
     this.eventEmitter.emit<OutOfBandStateChangedEvent>({
       type: OutOfBandEventTypes.OutOfBandStateChanged,
       payload: {
-        outOfBandRecord,
+        outOfBandRecord: clonedOutOfBandRecord,
         previousState,
       },
     })

--- a/packages/core/src/modules/oob/repository/__tests__/OutOfBandRecord.test.ts
+++ b/packages/core/src/modules/oob/repository/__tests__/OutOfBandRecord.test.ts
@@ -1,3 +1,4 @@
+import { JsonTransformer } from '../../../../utils'
 import { OutOfBandDidCommService } from '../../domain/OutOfBandDidCommService'
 import { OutOfBandRole } from '../../domain/OutOfBandRole'
 import { OutOfBandState } from '../../domain/OutOfBandState'
@@ -29,6 +30,44 @@ describe('OutOfBandRecord', () => {
         invitationId: 'a-message-id',
         recipientKeyFingerprints: ['z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th'],
       })
+    })
+  })
+
+  describe('clone', () => {
+    test('should correctly clone the record', () => {
+      const jsonRecord = {
+        _tags: {},
+        metadata: {},
+        id: 'd565b4d8-3e5d-42da-a87c-4454fdfbaff0',
+        createdAt: '2022-06-02T18:35:06.374Z',
+        outOfBandInvitation: {
+          '@type': 'https://didcomm.org/out-of-band/1.1/invitation',
+          '@id': '5d57ca2d-80ed-432c-8def-c40c75e8ab09',
+          label: 'Faber College',
+          goalCode: 'p2p-messaging',
+          goal: 'To make a connection',
+          accept: ['didcomm/aip1', 'didcomm/aip2;env=rfc19'],
+          handshake_protocols: ['https://didcomm.org/didexchange/1.0', 'https://didcomm.org/connections/1.0'],
+          services: [
+            {
+              id: '#inline-0',
+              serviceEndpoint: 'rxjs:faber',
+              type: 'did-communication',
+              recipientKeys: ['did:key:z6MkhngxtGfzTvGVbFjVVqBHvniY1f2XrTMZLM5BZvPh31Dc'],
+              routingKeys: [],
+            },
+          ],
+        },
+        role: 'sender',
+        state: 'await-response',
+        autoAcceptConnection: true,
+        reusable: false,
+      }
+
+      const oobRecord = JsonTransformer.fromJSON(jsonRecord, OutOfBandRecord)
+      const oobRecordClone = JsonTransformer.clone(oobRecord)
+
+      expect(oobRecord.toJSON()).toMatchObject(oobRecordClone.toJSON())
     })
   })
 })

--- a/packages/core/src/modules/proofs/services/ProofService.ts
+++ b/packages/core/src/modules/proofs/services/ProofService.ts
@@ -129,10 +129,7 @@ export class ProofService {
       autoAcceptProof: config?.autoAcceptProof,
     })
     await this.proofRepository.save(proofRecord)
-    this.eventEmitter.emit<ProofStateChangedEvent>({
-      type: ProofEventTypes.ProofStateChanged,
-      payload: { proofRecord, previousState: null },
-    })
+    this.emitStateChangedEvent(proofRecord, null)
 
     return { message: proposalMessage, proofRecord }
   }
@@ -229,13 +226,7 @@ export class ProofService {
 
       // Save record
       await this.proofRepository.save(proofRecord)
-      this.eventEmitter.emit<ProofStateChangedEvent>({
-        type: ProofEventTypes.ProofStateChanged,
-        payload: {
-          proofRecord,
-          previousState: null,
-        },
-      })
+      this.emitStateChangedEvent(proofRecord, null)
     }
 
     return proofRecord
@@ -335,10 +326,7 @@ export class ProofService {
     })
 
     await this.proofRepository.save(proofRecord)
-    this.eventEmitter.emit<ProofStateChangedEvent>({
-      type: ProofEventTypes.ProofStateChanged,
-      payload: { proofRecord, previousState: null },
-    })
+    this.emitStateChangedEvent(proofRecord, null)
 
     return { message: requestPresentationMessage, proofRecord }
   }
@@ -403,10 +391,7 @@ export class ProofService {
 
       // Save in repository
       await this.proofRepository.save(proofRecord)
-      this.eventEmitter.emit<ProofStateChangedEvent>({
-        type: ProofEventTypes.ProofStateChanged,
-        payload: { proofRecord, previousState: null },
-      })
+      this.emitStateChangedEvent(proofRecord, null)
     }
 
     return proofRecord
@@ -1093,9 +1078,18 @@ export class ProofService {
     proofRecord.state = newState
     await this.proofRepository.update(proofRecord)
 
+    this.emitStateChangedEvent(proofRecord, previousState)
+  }
+
+  private emitStateChangedEvent(proofRecord: ProofRecord, previousState: ProofState | null) {
+    const clonedProof = JsonTransformer.clone(proofRecord)
+
     this.eventEmitter.emit<ProofStateChangedEvent>({
       type: ProofEventTypes.ProofStateChanged,
-      payload: { proofRecord, previousState: previousState },
+      payload: {
+        proofRecord: clonedProof,
+        previousState: previousState,
+      },
     })
   }
 

--- a/packages/core/src/modules/routing/services/MediationRecipientService.ts
+++ b/packages/core/src/modules/routing/services/MediationRecipientService.ts
@@ -25,6 +25,7 @@ import { createOutboundMessage } from '../../../agent/helpers'
 import { InjectionSymbols } from '../../../constants'
 import { KeyType } from '../../../crypto'
 import { AriesFrameworkError } from '../../../error'
+import { JsonTransformer } from '../../../utils'
 import { Wallet } from '../../../wallet/Wallet'
 import { ConnectionService } from '../../connections/services/ConnectionService'
 import { Key } from '../../dids'
@@ -97,13 +98,7 @@ export class MediationRecipientService {
       connectionId: connection.id,
     })
     await this.mediationRepository.save(mediationRecord)
-    this.eventEmitter.emit<MediationStateChangedEvent>({
-      type: RoutingEventTypes.MediationStateChanged,
-      payload: {
-        mediationRecord,
-        previousState: null,
-      },
-    })
+    this.emitStateChangedEvent(mediationRecord, null)
 
     return { mediationRecord, message }
   }
@@ -337,14 +332,19 @@ export class MediationRecipientService {
     mediationRecord.state = newState
     await this.mediationRepository.update(mediationRecord)
 
+    this.emitStateChangedEvent(mediationRecord, previousState)
+    return mediationRecord
+  }
+
+  private emitStateChangedEvent(mediationRecord: MediationRecord, previousState: MediationState | null) {
+    const clonedMediationRecord = JsonTransformer.clone(mediationRecord)
     this.eventEmitter.emit<MediationStateChangedEvent>({
       type: RoutingEventTypes.MediationStateChanged,
       payload: {
-        mediationRecord,
+        mediationRecord: clonedMediationRecord,
         previousState,
       },
     })
-    return mediationRecord
   }
 
   public async getById(id: string): Promise<MediationRecord> {

--- a/packages/core/src/modules/routing/services/MediatorService.ts
+++ b/packages/core/src/modules/routing/services/MediatorService.ts
@@ -9,6 +9,7 @@ import { AgentConfig } from '../../../agent/AgentConfig'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InjectionSymbols } from '../../../constants'
 import { AriesFrameworkError } from '../../../error'
+import { JsonTransformer } from '../../../utils/JsonTransformer'
 import { Wallet } from '../../../wallet/Wallet'
 import { RoutingEventTypes } from '../RoutingEvents'
 import {
@@ -163,13 +164,7 @@ export class MediatorService {
     })
 
     await this.mediationRepository.save(mediationRecord)
-    this.eventEmitter.emit<MediationStateChangedEvent>({
-      type: RoutingEventTypes.MediationStateChanged,
-      payload: {
-        mediationRecord,
-        previousState: null,
-      },
-    })
+    this.emitStateChangedEvent(mediationRecord, null)
 
     return mediationRecord
   }
@@ -193,11 +188,16 @@ export class MediatorService {
 
     await this.mediationRepository.update(mediationRecord)
 
+    this.emitStateChangedEvent(mediationRecord, previousState)
+  }
+
+  private emitStateChangedEvent(mediationRecord: MediationRecord, previousState: MediationState | null) {
+    const clonedMediationRecord = JsonTransformer.clone(mediationRecord)
     this.eventEmitter.emit<MediationStateChangedEvent>({
       type: RoutingEventTypes.MediationStateChanged,
       payload: {
-        mediationRecord,
-        previousState: previousState,
+        mediationRecord: clonedMediationRecord,
+        previousState,
       },
     })
   }

--- a/packages/core/src/utils/JsonTransformer.ts
+++ b/packages/core/src/utils/JsonTransformer.ts
@@ -1,4 +1,4 @@
-import { instanceToPlain, plainToInstance } from 'class-transformer'
+import { instanceToPlain, plainToInstance, instanceToInstance } from 'class-transformer'
 
 export class JsonTransformer {
   public static toJSON<T>(classInstance: T) {
@@ -10,6 +10,15 @@ export class JsonTransformer {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public static fromJSON<T>(json: any, Class: { new (...args: any[]): T }): T {
     return plainToInstance(Class, json, { exposeDefaultValues: true })
+  }
+
+  public static clone<T>(classInstance: T): T {
+    return instanceToInstance(classInstance, {
+      exposeDefaultValues: true,
+      enableCircularCheck: true,
+      enableImplicitConversion: true,
+      ignoreDecorators: true,
+    })
   }
 
   public static serialize<T>(classInstance: T): string {


### PR DESCRIPTION
Clone records before emitting them in events to avoid mutation later on. 

Fixes #832 