### PR TITLE
fix: support pre-aip2 please ack decorator

### DIFF
--- a/packages/core/src/decorators/ack/AckDecorator.test.ts
+++ b/packages/core/src/decorators/ack/AckDecorator.test.ts
@@ -1,5 +1,6 @@
 import { BaseMessage } from '../../agent/BaseMessage'
 import { JsonTransformer } from '../../utils/JsonTransformer'
+import { MessageValidator } from '../../utils/MessageValidator'
 import { Compose } from '../../utils/mixins'
 
 import { AckDecorated } from './AckDecoratorExtension'
@@ -26,7 +27,106 @@ describe('Decorators | AckDecoratorExtension', () => {
   test('transforms Json to AckDecorator class', () => {
     const transformed = JsonTransformer.fromJSON({ '~please_ack': {} }, TestMessage)
 
-    expect(transformed).toEqual({ pleaseAck: {} })
+    expect(transformed).toEqual({
+      pleaseAck: {
+        on: ['RECEIPT'],
+      },
+    })
     expect(transformed).toBeInstanceOf(TestMessage)
+  })
+
+  test('successfully transforms ack decorator with on field present', () => {
+    const transformed = JsonTransformer.fromJSON(
+      {
+        '~please_ack': {
+          on: ['RECEIPT'],
+        },
+        '@id': '7517433f-1150-46f2-8495-723da61b872a',
+        '@type': 'https://didcomm.org/test-protocol/1.0/test-message',
+      },
+      TestMessage
+    )
+
+    expect(transformed).toEqual({
+      id: '7517433f-1150-46f2-8495-723da61b872a',
+      type: 'https://didcomm.org/test-protocol/1.0/test-message',
+      pleaseAck: {
+        on: ['RECEIPT'],
+      },
+    })
+    expect(transformed).toBeInstanceOf(TestMessage)
+  })
+
+  // this covers the pre-aip 2 please ack decorator
+  test('sets `on` value to `receipt` if `on` is not present in ack decorator', () => {
+    const transformed = JsonTransformer.fromJSON(
+      {
+        '~please_ack': {},
+        '@id': '7517433f-1150-46f2-8495-723da61b872a',
+        '@type': 'https://didcomm.org/test-protocol/1.0/test-message',
+      },
+      TestMessage
+    )
+
+    expect(transformed).toEqual({
+      id: '7517433f-1150-46f2-8495-723da61b872a',
+      type: 'https://didcomm.org/test-protocol/1.0/test-message',
+      pleaseAck: {
+        on: ['RECEIPT'],
+      },
+    })
+    expect(transformed).toBeInstanceOf(TestMessage)
+  })
+
+  test('successfully validates please ack decorator', async () => {
+    const transformedWithDefault = JsonTransformer.fromJSON(
+      {
+        '~please_ack': {},
+        '@id': '7517433f-1150-46f2-8495-723da61b872a',
+        '@type': 'https://didcomm.org/test-protocol/1.0/test-message',
+      },
+      TestMessage
+    )
+
+    await expect(MessageValidator.validate(transformedWithDefault)).resolves.toBeUndefined()
+
+    const transformedWithoutDefault = JsonTransformer.fromJSON(
+      {
+        '~please_ack': {
+          on: ['OUTCOME'],
+        },
+        '@id': '7517433f-1150-46f2-8495-723da61b872a',
+        '@type': 'https://didcomm.org/test-protocol/1.0/test-message',
+      },
+      TestMessage
+    )
+
+    await expect(MessageValidator.validate(transformedWithoutDefault)).resolves.toBeUndefined()
+
+    const transformedWithIncorrectValue = JsonTransformer.fromJSON(
+      {
+        '~please_ack': {
+          on: ['NOT_A_VALID_VALUE'],
+        },
+        '@id': '7517433f-1150-46f2-8495-723da61b872a',
+        '@type': 'https://didcomm.org/test-protocol/1.0/test-message',
+      },
+      TestMessage
+    )
+
+    await expect(MessageValidator.validate(transformedWithIncorrectValue)).rejects.toMatchObject([
+      {
+        children: [
+          {
+            children: [],
+            constraints: { isEnum: 'each value in on must be a valid enum value' },
+            property: 'on',
+            target: { on: ['NOT_A_VALID_VALUE'] },
+            value: ['NOT_A_VALID_VALUE'],
+          },
+        ],
+        property: 'pleaseAck',
+      },
+    ])
   })
 })

--- a/packages/core/src/decorators/ack/AckDecorator.ts
+++ b/packages/core/src/decorators/ack/AckDecorator.ts
@@ -15,7 +15,9 @@ export class AckDecorator {
     }
   }
 
+  // pre-aip 2 the on value was not defined yet. We interpret this as
+  // the value being set to on receipt
   @IsEnum(AckValues, { each: true })
   @IsArray()
-  public on!: AckValues[]
+  public on: AckValues[] = [AckValues.Receipt]
 }

--- a/packages/core/src/decorators/ack/AckDecoratorExtension.ts
+++ b/packages/core/src/decorators/ack/AckDecoratorExtension.ts
@@ -14,8 +14,8 @@ export function AckDecorated<T extends BaseMessageConstructor>(Base: T) {
     @IsOptional()
     public pleaseAck?: AckDecorator
 
-    public setPleaseAck(on?: [AckValues.Receipt]) {
-      this.pleaseAck = new AckDecorator({ on: on ?? [AckValues.Receipt] })
+    public setPleaseAck(on: [AckValues.Receipt] = [AckValues.Receipt]) {
+      this.pleaseAck = new AckDecorator({ on })
     }
 
     public getPleaseAck(): AckDecorator | undefined {


### PR DESCRIPTION
The update to the please ack decorator broke for pre-aip 2 ack decorators. This adds some sane defaults to make sure AFJ doesn't break with old please ack decorators