### PR TITLE
fix: send message to service

### DIFF
--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -337,9 +337,10 @@ export class MessageSender {
         this.logger.warn('Service does not have valid protocolScheme.')
       } else if (transport.supportedSchemes.includes(protocolScheme)) {
         await transport.sendMessage(outboundPackage)
-        break
+        return
       }
     }
+    throw new AriesFrameworkError(`Unable to send message to service: ${service.serviceEndpoint}`)
   }
 
   private async retrieveServicesFromDid(did: string) {


### PR DESCRIPTION
Fixed issue where message sender would incorrectly return early from loop (inside `sendMessage`) even if service was unable to be satisfied by outbound transports.

Signed-off-by: Niall Shaw <niall.shaw@absa.africa>