### PR TITLE
fix: Fix for Credential records created before adding protocol v2

### DIFF
--- a/packages/core/src/modules/credentials/CredentialsModule.ts
+++ b/packages/core/src/modules/credentials/CredentialsModule.ts
@@ -113,7 +113,7 @@ export class CredentialsModule implements CredentialsModule {
     this.logger.debug(`Initializing Credentials Module for agent ${this.agentConfig.label}`)
   }
 
-  public getService(protocolVersion: CredentialProtocolVersion): CredentialService {
+  public getService(protocolVersion: CredentialProtocolVersion = CredentialProtocolVersion.V1): CredentialService {
     return this.serviceMap[protocolVersion]
   }
 


### PR DESCRIPTION
Credential records created before adding protocol v2 don't have protocol version set, so `credentialRecord.protocolVersion` returns `undefined`, and `getService` also returned undefined. Old credentials couldn't be deleted due to this issue.