### PR TITLE
fix(credentials): use interface in module api

### DIFF
--- a/packages/core/src/modules/credentials/formats/CredentialFormat.ts
+++ b/packages/core/src/modules/credentials/formats/CredentialFormat.ts
@@ -34,6 +34,5 @@ export interface CredentialFormat {
     acceptOffer: unknown
     createRequest: unknown
     acceptRequest: unknown
-    createCredential: unknown
   }
 }

--- a/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormat.ts
+++ b/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormat.ts
@@ -31,13 +31,13 @@ export interface IndyAcceptOfferFormat {
  */
 export interface IndyOfferCredentialFormat {
   credentialDefinitionId: string
-  attributes: CredentialPreviewAttribute[]
+  attributes: CredentialPreviewAttributeOptions[]
   linkedAttachments?: LinkedAttachment[]
 }
 
 export interface IndyIssueCredentialFormat {
   credentialDefinitionId?: string
-  attributes?: CredentialPreviewAttribute[]
+  attributes?: CredentialPreviewAttributeOptions[]
 }
 
 export interface IndyCredentialFormat extends CredentialFormat {
@@ -50,6 +50,5 @@ export interface IndyCredentialFormat extends CredentialFormat {
     acceptOffer: IndyAcceptOfferFormat
     createRequest: never // cannot start from createRequest
     acceptRequest: Record<string, never> // empty object
-    createCredential: IndyIssueCredentialFormat
   }
 }


### PR DESCRIPTION
My previous PR to generalize the crdentials module undid some of the changes to only allow interfaces.