### PR TITLE
fix(node): only send 500 if no headers sent yet

### DIFF
--- a/packages/node/src/transport/HttpInboundTransport.ts
+++ b/packages/node/src/transport/HttpInboundTransport.ts
@@ -49,7 +49,10 @@ export class HttpInboundTransport implements InboundTransport {
         }
       } catch (error) {
         config.logger.error(`Error processing inbound message: ${error.message}`, error)
-        res.status(500).send('Error processing message')
+
+        if (!res.headersSent) {
+          res.status(500).send('Error processing message')
+        }
       } finally {
         transportService.removeSession(session)
       }


### PR DESCRIPTION
If an error occurred after a message has been sent in response in the http inbound transport it would error out because we can't return a response twice in http. This just checks if the response is already sent