### PR TITLE
ci: fix lerna version detection based on tags

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -142,8 +142,14 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+      # Lerna will use the latest tag to determine the latest released version. As we create a tag for each commit
+      # we need to remove all pre-release tags so we can determine the last stable release
+      - name: Remove all pre-release tags
+        run: git tag -l | grep -vE 'v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' | xargs git tag -d
+
+      # no-private is important to not include the internal packages (demo, sample, etc...)
       - name: Update version
-        run: yarn lerna version --conventional-commits --no-git-tag-version --no-push --yes --exact
+        run: yarn lerna version --conventional-commits --no-git-tag-version --no-push --yes --exact --no-private
 
       - name: Format lerna changes
         run: yarn format


### PR DESCRIPTION
Fixes lerna version detection for next release. Lerna will use the latest tag to determine the latest released version. As we create a tag for each commit we need to remove all pre-release tags so we can determine the last stable release. It also excludes the private packages that have been added since 0.1.0 (extension-module and demo) from the release / changelog creation.