### PR TITLE
fix(connection): set image url in create request

### DIFF
--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -120,6 +120,7 @@ export class ConnectionService {
       autoAcceptConnection: config?.autoAcceptConnection,
       outOfBandId: outOfBandRecord.id,
       invitationDid,
+      imageUrl: outOfBandInvitation.imageUrl,
     })
 
     const { label, imageUrl, autoAcceptConnection } = config


### PR DESCRIPTION
Signed-off-by: Amit-Padmani <amit.padmani@ontario.ca>

Image URL is missing in connection record [#895](https://github.com/hyperledger/aries-framework-javascript/issues/895)