### PR TITLE
ci: add correct version bump

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,7 +99,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.test.ts', '**/__tests__/**', '**/tests/**', 'jest.*.ts', 'samples/**', 'demo/**'],
+      files: ['*.test.ts', '**/__tests__/**', '**/tests/**', 'jest.*.ts', 'samples/**', 'demo/**', 'scripts/**'],
       env: {
         jest: true,
         node: false,

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -29,9 +29,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Get next version
+        run: export NEXT_VERSION_BUMP=$(yarn next-version-bump)
+
       # On push to main, release unstable version
       - name: Release Unstable
-        run: yarn lerna publish --loglevel=verbose --canary minor --exact --force-publish --yes --no-verify-access --dist-tag alpha
+        run: yarn lerna publish --loglevel=verbose --canary $NEXT_VERSION_BUMP --exact --force-publish --yes --no-verify-access --dist-tag alpha
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -142,14 +142,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      # Lerna will use the latest tag to determine the latest released version. As we create a tag for each commit
-      # we need to remove all pre-release tags so we can determine the last stable release
-      - name: Remove all pre-release tags
-        run: git tag -l | grep -vE 'v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$' | xargs git tag -d
+      - name: Get next version
+        run: export NEXT_VERSION_BUMP=$(yarn next-version-bump)
 
       # no-private is important to not include the internal packages (demo, sample, etc...)
       - name: Update version
-        run: yarn lerna version --conventional-commits --no-git-tag-version --no-push --yes --exact --no-private
+        run: yarn lerna version --conventional-commits --no-git-tag-version --no-push --yes --exact --no-private $NEXT_VERSION_BUMP
 
       - name: Format lerna changes
         run: yarn format

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "eslint --ignore-path .gitignore .",
     "validate": "yarn lint && yarn check-types && yarn check-format",
     "prepare": "husky install",
-    "run-mediator": "ts-node ./samples/mediator.ts"
+    "run-mediator": "ts-node ./samples/mediator.ts",
+    "next-version-bump": "ts-node ./scripts/get-next-bump.ts"
   },
   "devDependencies": {
     "@types/cors": "^2.8.10",
@@ -37,6 +38,8 @@
     "@types/ws": "^7.4.6",
     "@typescript-eslint/eslint-plugin": "^4.26.1",
     "@typescript-eslint/parser": "^4.26.1",
+    "conventional-changelog-conventionalcommits": "^5.0.0",
+    "conventional-recommended-bump": "^6.1.0",
     "cors": "^2.8.5",
     "dotenv": "^10.0.0",
     "eslint": "^7.28.0",

--- a/scripts/get-next-bump.ts
+++ b/scripts/get-next-bump.ts
@@ -1,0 +1,60 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import conventionalRecommendedBump from 'conventional-recommended-bump'
+
+import lerna from '../lerna.json'
+
+const currentVersion = lerna.version
+const currentMajor = Number(currentVersion.split('.')[0])
+
+// eslint-disable-next-line no-restricted-syntax
+const enum VersionBump {
+  Major = 0,
+  Minor = 1,
+  Patch = 2,
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const whatBump = (commits: any[]) => {
+  let versionBump = VersionBump.Patch
+  let breaking = 0
+  let features = 0
+
+  for (const commit of commits) {
+    if (commit.notes.length > 0) {
+      breaking += commit.notes.length
+    } else if (commit.type === 'feat') {
+      features += 1
+    }
+  }
+
+  if (breaking > 0) {
+    // If the current version is less than 1.0.0, then bump the minor version for breaking changes
+    versionBump = currentMajor < 1 ? VersionBump.Minor : VersionBump.Major
+  } else if (features > 0) {
+    // If the current version is less than 1.0.0, then bump the patch version for features
+    versionBump = currentMajor < 1 ? VersionBump.Patch : VersionBump.Patch
+  }
+
+  let reason = `There is ${breaking} BREAKING CHANGE and ${features} features`
+  if (currentMajor < 1) reason += ` in a pre-major release`
+
+  return {
+    level: versionBump,
+    reason,
+  }
+}
+
+conventionalRecommendedBump(
+  {
+    preset: `conventionalcommits`,
+    whatBump,
+    skipUnstable: true,
+  },
+  (error: unknown, recommendation: { releaseType: string | undefined }) => {
+    if (error) throw error
+
+    // eslint-disable-next-line no-console
+    console.log(recommendation.releaseType) // 'major'
+  }
+)

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -15,7 +15,8 @@
     "types",
     "tests",
     "samples",
-    "demo"
+    "demo",
+    "scripts"
   ],
   "exclude": ["node_modules", "build"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,45 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@aries-framework/core@0.1.0", "@aries-framework/core@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@aries-framework/core/-/core-0.1.0.tgz#704e349be6df42bff9c177438b08c03acb8e1611"
+  integrity sha512-NwlPgDKh7f6N0wVB6SvDh7Vr2nZJKGR4+v+8OJCB/Wx7sIAfL8MyLCMEhxkdRF+uIB1QjTzHQ2k9ID0K/NNQQQ==
+  dependencies:
+    "@multiformats/base-x" "^4.0.1"
+    "@types/indy-sdk" "^1.16.6"
+    "@types/node-fetch" "^2.5.10"
+    "@types/ws" "^7.4.4"
+    abort-controller "^3.0.0"
+    bn.js "^5.2.0"
+    borc "^3.0.0"
+    buffer "^6.0.3"
+    class-transformer "0.5.1"
+    class-validator "0.13.1"
+    js-sha256 "^0.9.0"
+    lru_map "^0.4.1"
+    luxon "^1.27.0"
+    make-error "^1.3.6"
+    multibase "^4.0.4"
+    multihashes "^4.0.2"
+    object-inspect "^1.10.3"
+    query-string "^7.0.1"
+    reflect-metadata "^0.1.13"
+    rxjs "^7.1.0"
+    tsyringe "^4.5.0"
+    uuid "^8.3.2"
+
+"@aries-framework/node@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@aries-framework/node/-/node-0.1.0.tgz#07cd29ba1ac0703d9dae64b6eaf9c1ce642e35d8"
+  integrity sha512-ejqmIiTiIOo1xCH826ZHOUtIUB9ysvHZQuXgNc6FNqnmN2p50Z+xBJEtzz8qD4GJ1E4v3woXUG1FE8IOOQKf9A==
+  dependencies:
+    "@aries-framework/core" "0.1.0"
+    express "^4.17.1"
+    indy-sdk "^1.16.0-dev-1636"
+    node-fetch "^2.6.1"
+    ws "^7.5.3"
+
 "@azure/core-asynciterator-polyfill@^1.0.0":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.2.tgz#0dd3849fb8d97f062a39db0e5cadc9ffaf861fec"
@@ -2289,6 +2328,13 @@
   dependencies:
     buffer "^6.0.0"
 
+"@types/indy-sdk@^1.16.6":
+  version "1.16.18"
+  resolved "https://registry.yarnpkg.com/@types/indy-sdk/-/indy-sdk-1.16.18.tgz#3bf3d134449607f91259beee6389971bbdb6f963"
+  integrity sha512-v1z0FAr/4ex9OEniytB8bYPHSxpbmy8xRjb3xpnla2MF3XB+E2ULnZA4moK5yQ1wO+SFW3QlSd/IwHd9JbfU/Q==
+  dependencies:
+    buffer "^6.0.0"
+
 "@types/inquirer@^8.1.3":
   version "8.2.1"
   resolved "https://registry.yarnpkg.com/@types/inquirer/-/inquirer-8.2.1.tgz#28a139be3105a1175e205537e8ac10830e38dbf4"
@@ -2474,7 +2520,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/ws@^7.4.6":
+"@types/ws@^7.4.4", "@types/ws@^7.4.6":
   version "7.4.7"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-7.4.7.tgz#f7c390a36f7a0679aa69de2d501319f4f8d9b702"
   integrity sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==
@@ -3767,6 +3813,15 @@ conventional-changelog-angular@^5.0.12:
   integrity sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==
   dependencies:
     compare-func "^2.0.0"
+    q "^1.5.1"
+
+conventional-changelog-conventionalcommits@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-5.0.0.tgz#41bdce54eb65a848a4a3ffdca93e92fa22b64a86"
+  integrity sha512-lCDbA+ZqVFQGUj7h9QBKoIpLhl8iihkO0nCTyRNzuXtcd7ubODpYB04IFy31JloiJgG0Uovu8ot8oxRzn7Nwtw==
+  dependencies:
+    compare-func "^2.0.0"
+    lodash "^4.17.15"
     q "^1.5.1"
 
 conventional-changelog-core@^4.2.2:
@@ -6514,6 +6569,11 @@ joi@^17.2.1:
     "@sideway/formula" "^3.0.0"
     "@sideway/pinpoint" "^2.0.0"
 
+js-sha256@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
+  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -7558,6 +7618,27 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+multibase@^4.0.1, multibase@^4.0.4:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/multibase/-/multibase-4.0.6.tgz#6e624341483d6123ca1ede956208cb821b440559"
+  integrity sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==
+  dependencies:
+    "@multiformats/base-x" "^4.0.1"
+
+multiformats@^9.4.2:
+  version "9.7.0"
+  resolved "https://registry.yarnpkg.com/multiformats/-/multiformats-9.7.0.tgz#845799e8df70fbb6b15922500e45cb87cf12f7e5"
+  integrity sha512-uv/tcgwk0yN4DStopnBN4GTgvaAlYdy6KnZpuzEPFOYQd71DYFJjs0MN1ERElAflrZaYyGBWXyGxL5GgrxIx0Q==
+
+multihashes@^4.0.2:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/multihashes/-/multihashes-4.0.3.tgz#426610539cd2551edbf533adeac4c06b3b90fb05"
+  integrity sha512-0AhMH7Iu95XjDLxIeuCOOE4t9+vQZsACyKZ9Fxw2pcsRmlX4iCn1mby0hS0bb+nQOVpdQYWPpnyusw4da5RPhA==
+  dependencies:
+    multibase "^4.0.1"
+    uint8arrays "^3.0.0"
+    varint "^5.0.2"
 
 multimatch@^5.0.0:
   version "5.0.0"
@@ -9082,7 +9163,7 @@ rxjs@^6.6.0:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.2.0:
+rxjs@^7.1.0, rxjs@^7.2.0:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
@@ -10132,6 +10213,13 @@ uid-number@0.0.6:
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
   integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
 
+uint8arrays@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-3.0.0.tgz#260869efb8422418b6f04e3fac73a3908175c63b"
+  integrity sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==
+  dependencies:
+    multiformats "^9.4.2"
+
 ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
@@ -10331,6 +10419,11 @@ validator@^13.5.2:
   version "13.7.0"
   resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
   integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
+
+varint@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/varint/-/varint-5.0.2.tgz#5b47f8a947eb668b848e034dcfa87d0ff8a7f7a4"
+  integrity sha512-lKxKYG6H03yCZUpAGOPOsMcGxd1RHCu1iKvEHYDPmTyq2HueGhD73ssNBqqQWfvYs04G9iUFRvmAVLW20Jw6ow==
 
 varint@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
We are using patch version for feature releases and minor versions for breaking releases, this change makes sure that's enforced. 

This should be merged before all other PRs to make sure we aren't going to release 0.3.0-alpha.1 but 0.2.1-alpha.1