### PR TITLE
feat(routing): add routing service

### DIFF
--- a/packages/core/src/agent/Agent.ts
+++ b/packages/core/src/agent/Agent.ts
@@ -26,6 +26,7 @@ import { ProofsModule } from '../modules/proofs/ProofsModule'
 import { QuestionAnswerModule } from '../modules/question-answer/QuestionAnswerModule'
 import { MediatorModule } from '../modules/routing/MediatorModule'
 import { RecipientModule } from '../modules/routing/RecipientModule'
+import { RoutingService } from '../modules/routing/services/RoutingService'
 import { StorageUpdateService } from '../storage'
 import { InMemoryMessageRepository } from '../storage/InMemoryMessageRepository'
 import { IndyStorageService } from '../storage/IndyStorageService'
@@ -53,6 +54,7 @@ export class Agent {
   private _isInitialized = false
   public messageSubscription: Subscription
   private walletService: Wallet
+  private routingService: RoutingService
 
   public readonly connections: ConnectionsModule
   public readonly proofs: ProofsModule
@@ -117,6 +119,7 @@ export class Agent {
     this.messageReceiver = this.container.resolve(MessageReceiver)
     this.transportService = this.container.resolve(TransportService)
     this.walletService = this.container.resolve(InjectionSymbols.Wallet)
+    this.routingService = this.container.resolve(RoutingService)
 
     // We set the modules in the constructor because that allows to set them as read-only
     this.connections = this.container.resolve(ConnectionsModule)
@@ -284,7 +287,7 @@ export class Agent {
     if (!connection) {
       this.logger.debug('Mediation connection does not exist, creating connection')
       // We don't want to use the current default mediator when connecting to another mediator
-      const routing = await this.mediationRecipient.getRouting({ useDefaultMediator: false })
+      const routing = await this.routingService.getRouting({ useDefaultMediator: false })
 
       this.logger.debug('Routing created', routing)
       const { connectionRecord: newConnection } = await this.oob.receiveInvitation(outOfBandInvitation, {

--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -13,7 +13,7 @@ import { AriesFrameworkError } from '../../error'
 import { DidResolverService } from '../dids'
 import { DidRepository } from '../dids/repository'
 import { OutOfBandService } from '../oob/OutOfBandService'
-import { MediationRecipientService } from '../routing/services/MediationRecipientService'
+import { RoutingService } from '../routing/services/RoutingService'
 
 import { DidExchangeProtocol } from './DidExchangeProtocol'
 import {
@@ -38,7 +38,7 @@ export class ConnectionsModule {
   private outOfBandService: OutOfBandService
   private messageSender: MessageSender
   private trustPingService: TrustPingService
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   private didRepository: DidRepository
   private didResolverService: DidResolverService
 
@@ -49,7 +49,7 @@ export class ConnectionsModule {
     connectionService: ConnectionService,
     outOfBandService: OutOfBandService,
     trustPingService: TrustPingService,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     didRepository: DidRepository,
     didResolverService: DidResolverService,
     messageSender: MessageSender
@@ -59,7 +59,7 @@ export class ConnectionsModule {
     this.connectionService = connectionService
     this.outOfBandService = outOfBandService
     this.trustPingService = trustPingService
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
     this.didRepository = didRepository
     this.messageSender = messageSender
     this.didResolverService = didResolverService
@@ -79,8 +79,7 @@ export class ConnectionsModule {
   ) {
     const { protocol, label, alias, imageUrl, autoAcceptConnection } = config
 
-    const routing =
-      config.routing || (await this.mediationRecipientService.getRouting({ mediatorId: outOfBandRecord.mediatorId }))
+    const routing = config.routing || (await this.routingService.getRouting({ mediatorId: outOfBandRecord.mediatorId }))
 
     let result
     if (protocol === HandshakeProtocol.DidExchange) {
@@ -270,7 +269,7 @@ export class ConnectionsModule {
         this.agentConfig,
         this.connectionService,
         this.outOfBandService,
-        this.mediationRecipientService,
+        this.routingService,
         this.didRepository
       )
     )
@@ -291,7 +290,7 @@ export class ConnectionsModule {
         this.agentConfig,
         this.didExchangeProtocol,
         this.outOfBandService,
-        this.mediationRecipientService,
+        this.routingService,
         this.didRepository
       )
     )

--- a/packages/core/src/modules/connections/handlers/ConnectionRequestHandler.ts
+++ b/packages/core/src/modules/connections/handlers/ConnectionRequestHandler.ts
@@ -2,7 +2,7 @@ import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { DidRepository } from '../../dids/repository'
 import type { OutOfBandService } from '../../oob/OutOfBandService'
-import type { MediationRecipientService } from '../../routing'
+import type { RoutingService } from '../../routing/services/RoutingService'
 import type { ConnectionService } from '../services/ConnectionService'
 
 import { createOutboundMessage } from '../../../agent/helpers'
@@ -13,7 +13,7 @@ export class ConnectionRequestHandler implements Handler {
   private agentConfig: AgentConfig
   private connectionService: ConnectionService
   private outOfBandService: OutOfBandService
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   private didRepository: DidRepository
   public supportedMessages = [ConnectionRequestMessage]
 
@@ -21,13 +21,13 @@ export class ConnectionRequestHandler implements Handler {
     agentConfig: AgentConfig,
     connectionService: ConnectionService,
     outOfBandService: OutOfBandService,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     didRepository: DidRepository
   ) {
     this.agentConfig = agentConfig
     this.connectionService = connectionService
     this.outOfBandService = outOfBandService
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
     this.didRepository = didRepository
   }
 
@@ -59,7 +59,7 @@ export class ConnectionRequestHandler implements Handler {
 
     if (connectionRecord?.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
       // TODO: Allow rotation of keys used in the invitation for new ones not only when out-of-band is reusable
-      const routing = outOfBandRecord.reusable ? await this.mediationRecipientService.getRouting() : undefined
+      const routing = outOfBandRecord.reusable ? await this.routingService.getRouting() : undefined
 
       const { message } = await this.connectionService.createResponse(connectionRecord, outOfBandRecord, routing)
       return createOutboundMessage(connectionRecord, message, outOfBandRecord)

--- a/packages/core/src/modules/connections/handlers/DidExchangeRequestHandler.ts
+++ b/packages/core/src/modules/connections/handlers/DidExchangeRequestHandler.ts
@@ -2,7 +2,7 @@ import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { DidRepository } from '../../dids/repository'
 import type { OutOfBandService } from '../../oob/OutOfBandService'
-import type { MediationRecipientService } from '../../routing/services/MediationRecipientService'
+import type { RoutingService } from '../../routing/services/RoutingService'
 import type { DidExchangeProtocol } from '../DidExchangeProtocol'
 
 import { createOutboundMessage } from '../../../agent/helpers'
@@ -14,7 +14,7 @@ export class DidExchangeRequestHandler implements Handler {
   private didExchangeProtocol: DidExchangeProtocol
   private outOfBandService: OutOfBandService
   private agentConfig: AgentConfig
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   private didRepository: DidRepository
   public supportedMessages = [DidExchangeRequestMessage]
 
@@ -22,13 +22,13 @@ export class DidExchangeRequestHandler implements Handler {
     agentConfig: AgentConfig,
     didExchangeProtocol: DidExchangeProtocol,
     outOfBandService: OutOfBandService,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     didRepository: DidRepository
   ) {
     this.agentConfig = agentConfig
     this.didExchangeProtocol = didExchangeProtocol
     this.outOfBandService = outOfBandService
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
     this.didRepository = didRepository
   }
 
@@ -72,7 +72,7 @@ export class DidExchangeRequestHandler implements Handler {
     if (connectionRecord?.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
       // TODO We should add an option to not pass routing and therefore do not rotate keys and use the keys from the invitation
       // TODO: Allow rotation of keys used in the invitation for new ones not only when out-of-band is reusable
-      const routing = outOfBandRecord.reusable ? await this.mediationRecipientService.getRouting() : undefined
+      const routing = outOfBandRecord.reusable ? await this.routingService.getRouting() : undefined
 
       const message = await this.didExchangeProtocol.createResponse(connectionRecord, outOfBandRecord, routing)
       return createOutboundMessage(connectionRecord, message, outOfBandRecord)

--- a/packages/core/src/modules/credentials/CredentialsModule.ts
+++ b/packages/core/src/modules/credentials/CredentialsModule.ts
@@ -34,7 +34,7 @@ import { AriesFrameworkError } from '../../error'
 import { DidCommMessageRole } from '../../storage'
 import { DidCommMessageRepository } from '../../storage/didcomm/DidCommMessageRepository'
 import { ConnectionService } from '../connections/services'
-import { MediationRecipientService } from '../routing'
+import { RoutingService } from '../routing/services/RoutingService'
 
 import { CredentialState } from './models/CredentialState'
 import { V1CredentialService } from './protocol/v1/V1CredentialService'
@@ -95,7 +95,7 @@ export class CredentialsModule<
   private credentialRepository: CredentialRepository
   private agentConfig: AgentConfig
   private didCommMessageRepo: DidCommMessageRepository
-  private mediatorRecipientService: MediationRecipientService
+  private routingService: RoutingService
   private logger: Logger
   private serviceMap: ServiceMap<CFs, CSs>
 
@@ -104,7 +104,7 @@ export class CredentialsModule<
     connectionService: ConnectionService,
     agentConfig: AgentConfig,
     credentialRepository: CredentialRepository,
-    mediationRecipientService: MediationRecipientService,
+    mediationRecipientService: RoutingService,
     didCommMessageRepository: DidCommMessageRepository,
     v1Service: V1CredentialService,
     v2Service: V2CredentialService<CFs>,
@@ -116,7 +116,7 @@ export class CredentialsModule<
     this.connectionService = connectionService
     this.credentialRepository = credentialRepository
     this.agentConfig = agentConfig
-    this.mediatorRecipientService = mediationRecipientService
+    this.routingService = mediationRecipientService
     this.didCommMessageRepo = didCommMessageRepository
     this.logger = agentConfig.logger
 
@@ -304,7 +304,7 @@ export class CredentialsModule<
     // Use ~service decorator otherwise
     else if (offerMessage?.service) {
       // Create ~service decorator
-      const routing = await this.mediatorRecipientService.getRouting()
+      const routing = await this.routingService.getRouting()
       const ourService = new ServiceDecorator({
         serviceEndpoint: routing.endpoints[0],
         recipientKeys: [routing.recipientKey.publicKeyBase58],

--- a/packages/core/src/modules/credentials/protocol/v1/V1CredentialService.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/V1CredentialService.ts
@@ -31,7 +31,7 @@ import { isLinkedAttachment } from '../../../../utils/attachment'
 import { uuid } from '../../../../utils/uuid'
 import { AckStatus } from '../../../common'
 import { ConnectionService } from '../../../connections/services'
-import { MediationRecipientService } from '../../../routing'
+import { RoutingService } from '../../../routing/services/RoutingService'
 import { CredentialProblemReportReason } from '../../errors'
 import { IndyCredentialFormatService } from '../../formats/indy/IndyCredentialFormatService'
 import { IndyCredPropose } from '../../formats/indy/models'
@@ -67,13 +67,13 @@ import { V1CredentialPreview } from './messages/V1CredentialPreview'
 export class V1CredentialService extends CredentialService<[IndyCredentialFormat]> {
   private connectionService: ConnectionService
   private formatService: IndyCredentialFormatService
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
 
   public constructor(
     connectionService: ConnectionService,
     didCommMessageRepository: DidCommMessageRepository,
     agentConfig: AgentConfig,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     dispatcher: Dispatcher,
     eventEmitter: EventEmitter,
     credentialRepository: CredentialRepository,
@@ -83,7 +83,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     this.connectionService = connectionService
     this.formatService = formatService
     this.didCommMessageRepository = didCommMessageRepository
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
 
     this.registerHandlers()
   }
@@ -1120,12 +1120,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
   protected registerHandlers() {
     this.dispatcher.registerHandler(new V1ProposeCredentialHandler(this, this.agentConfig))
     this.dispatcher.registerHandler(
-      new V1OfferCredentialHandler(
-        this,
-        this.agentConfig,
-        this.mediationRecipientService,
-        this.didCommMessageRepository
-      )
+      new V1OfferCredentialHandler(this, this.agentConfig, this.routingService, this.didCommMessageRepository)
     )
     this.dispatcher.registerHandler(
       new V1RequestCredentialHandler(this, this.agentConfig, this.didCommMessageRepository)

--- a/packages/core/src/modules/credentials/protocol/v1/__tests__/V1CredentialServiceCred.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/__tests__/V1CredentialServiceCred.test.ts
@@ -19,7 +19,7 @@ import { uuid } from '../../../../../utils/uuid'
 import { AckStatus } from '../../../../common'
 import { DidExchangeState } from '../../../../connections'
 import { ConnectionService } from '../../../../connections/services/ConnectionService'
-import { MediationRecipientService } from '../../../../routing/services/MediationRecipientService'
+import { RoutingService } from '../../../../routing/services/RoutingService'
 import { CredentialEventTypes } from '../../../CredentialEvents'
 import { credDef, credReq } from '../../../__tests__/fixtures'
 import { CredentialProblemReportReason } from '../../../errors/CredentialProblemReportReason'
@@ -47,7 +47,7 @@ import {
 jest.mock('../../../repository/CredentialRepository')
 jest.mock('../../../formats/indy/IndyCredentialFormatService')
 jest.mock('../../../../../storage/didcomm/DidCommMessageRepository')
-jest.mock('../../../../routing/services/MediationRecipientService')
+jest.mock('../../../../routing/services/RoutingService')
 jest.mock('../../../../connections/services/ConnectionService')
 jest.mock('../../../../../agent/Dispatcher')
 
@@ -55,13 +55,13 @@ jest.mock('../../../../../agent/Dispatcher')
 const CredentialRepositoryMock = CredentialRepository as jest.Mock<CredentialRepository>
 const IndyCredentialFormatServiceMock = IndyCredentialFormatService as jest.Mock<IndyCredentialFormatService>
 const DidCommMessageRepositoryMock = DidCommMessageRepository as jest.Mock<DidCommMessageRepository>
-const MediationRecipientServiceMock = MediationRecipientService as jest.Mock<MediationRecipientService>
+const RoutingServiceMock = RoutingService as jest.Mock<RoutingService>
 const ConnectionServiceMock = ConnectionService as jest.Mock<ConnectionService>
 const DispatcherMock = Dispatcher as jest.Mock<Dispatcher>
 
 const credentialRepository = new CredentialRepositoryMock()
 const didCommMessageRepository = new DidCommMessageRepositoryMock()
-const mediationRecipientService = new MediationRecipientServiceMock()
+const routingService = new RoutingServiceMock()
 const indyCredentialFormatService = new IndyCredentialFormatServiceMock()
 const dispatcher = new DispatcherMock()
 const connectionService = new ConnectionServiceMock()
@@ -239,7 +239,7 @@ describe('V1CredentialService', () => {
       connectionService,
       didCommMessageRepository,
       agentConfig,
-      mediationRecipientService,
+      routingService,
       dispatcher,
       eventEmitter,
       credentialRepository,

--- a/packages/core/src/modules/credentials/protocol/v1/__tests__/V1CredentialServiceProposeOffer.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/__tests__/V1CredentialServiceProposeOffer.test.ts
@@ -13,7 +13,7 @@ import { JsonTransformer } from '../../../../../utils'
 import { DidExchangeState } from '../../../../connections'
 import { ConnectionService } from '../../../../connections/services/ConnectionService'
 import { IndyLedgerService } from '../../../../ledger/services'
-import { MediationRecipientService } from '../../../../routing/services/MediationRecipientService'
+import { RoutingService } from '../../../../routing/services/RoutingService'
 import { CredentialEventTypes } from '../../../CredentialEvents'
 import { schema, credDef } from '../../../__tests__/fixtures'
 import { IndyCredentialFormatService } from '../../../formats'
@@ -30,7 +30,7 @@ jest.mock('../../../repository/CredentialRepository')
 jest.mock('../../../../ledger/services/IndyLedgerService')
 jest.mock('../../../formats/indy/IndyCredentialFormatService')
 jest.mock('../../../../../storage/didcomm/DidCommMessageRepository')
-jest.mock('../../../../routing/services/MediationRecipientService')
+jest.mock('../../../../routing/services/RoutingService')
 jest.mock('../../../../connections/services/ConnectionService')
 jest.mock('../../../../../agent/Dispatcher')
 
@@ -39,13 +39,13 @@ const CredentialRepositoryMock = CredentialRepository as jest.Mock<CredentialRep
 const IndyLedgerServiceMock = IndyLedgerService as jest.Mock<IndyLedgerService>
 const IndyCredentialFormatServiceMock = IndyCredentialFormatService as jest.Mock<IndyCredentialFormatService>
 const DidCommMessageRepositoryMock = DidCommMessageRepository as jest.Mock<DidCommMessageRepository>
-const MediationRecipientServiceMock = MediationRecipientService as jest.Mock<MediationRecipientService>
+const RoutingServiceMock = RoutingService as jest.Mock<RoutingService>
 const ConnectionServiceMock = ConnectionService as jest.Mock<ConnectionService>
 const DispatcherMock = Dispatcher as jest.Mock<Dispatcher>
 
 const credentialRepository = new CredentialRepositoryMock()
 const didCommMessageRepository = new DidCommMessageRepositoryMock()
-const mediationRecipientService = new MediationRecipientServiceMock()
+const routingService = new RoutingServiceMock()
 const indyLedgerService = new IndyLedgerServiceMock()
 const indyCredentialFormatService = new IndyCredentialFormatServiceMock()
 const dispatcher = new DispatcherMock()
@@ -108,7 +108,7 @@ describe('V1CredentialServiceProposeOffer', () => {
       connectionService,
       didCommMessageRepository,
       agentConfig,
-      mediationRecipientService,
+      routingService,
       dispatcher,
       eventEmitter,
       credentialRepository,

--- a/packages/core/src/modules/credentials/protocol/v1/handlers/V1OfferCredentialHandler.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/handlers/V1OfferCredentialHandler.ts
@@ -1,7 +1,7 @@
 import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../../../agent/Handler'
 import type { DidCommMessageRepository } from '../../../../../storage'
-import type { MediationRecipientService } from '../../../../routing/services/MediationRecipientService'
+import type { RoutingService } from '../../../../routing/services/RoutingService'
 import type { CredentialExchangeRecord } from '../../../repository/CredentialExchangeRecord'
 import type { V1CredentialService } from '../V1CredentialService'
 
@@ -13,19 +13,19 @@ import { V1OfferCredentialMessage } from '../messages'
 export class V1OfferCredentialHandler implements Handler {
   private credentialService: V1CredentialService
   private agentConfig: AgentConfig
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   private didCommMessageRepository: DidCommMessageRepository
   public supportedMessages = [V1OfferCredentialMessage]
 
   public constructor(
     credentialService: V1CredentialService,
     agentConfig: AgentConfig,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     didCommMessageRepository: DidCommMessageRepository
   ) {
     this.credentialService = credentialService
     this.agentConfig = agentConfig
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
     this.didCommMessageRepository = didCommMessageRepository
   }
 
@@ -54,7 +54,7 @@ export class V1OfferCredentialHandler implements Handler {
 
       return createOutboundMessage(messageContext.connection, message)
     } else if (messageContext.message.service) {
-      const routing = await this.mediationRecipientService.getRouting()
+      const routing = await this.routingService.getRouting()
       const ourService = new ServiceDecorator({
         serviceEndpoint: routing.endpoints[0],
         recipientKeys: [routing.recipientKey.publicKeyBase58],

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialService.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialService.ts
@@ -35,7 +35,7 @@ import { DidCommMessageRepository } from '../../../../storage'
 import { uuid } from '../../../../utils/uuid'
 import { AckStatus } from '../../../common'
 import { ConnectionService } from '../../../connections'
-import { MediationRecipientService } from '../../../routing'
+import { RoutingService } from '../../../routing/services/RoutingService'
 import { CredentialProblemReportReason } from '../../errors'
 import { IndyCredentialFormatService } from '../../formats/indy/IndyCredentialFormatService'
 import { CredentialState, AutoAcceptCredential } from '../../models'
@@ -67,14 +67,14 @@ export class V2CredentialService<CFs extends CredentialFormat[] = CredentialForm
   private connectionService: ConnectionService
   private credentialFormatCoordinator: CredentialFormatCoordinator<CFs>
   protected didCommMessageRepository: DidCommMessageRepository
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   private formatServiceMap: { [key: string]: CredentialFormatService }
 
   public constructor(
     connectionService: ConnectionService,
     didCommMessageRepository: DidCommMessageRepository,
     agentConfig: AgentConfig,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     dispatcher: Dispatcher,
     eventEmitter: EventEmitter,
     credentialRepository: CredentialRepository,
@@ -83,7 +83,7 @@ export class V2CredentialService<CFs extends CredentialFormat[] = CredentialForm
     super(credentialRepository, didCommMessageRepository, eventEmitter, dispatcher, agentConfig)
     this.connectionService = connectionService
     this.didCommMessageRepository = didCommMessageRepository
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
     this.credentialFormatCoordinator = new CredentialFormatCoordinator(didCommMessageRepository)
 
     // Dynamically build format service map. This will be extracted once services are registered dynamically
@@ -1138,12 +1138,7 @@ export class V2CredentialService<CFs extends CredentialFormat[] = CredentialForm
     this.dispatcher.registerHandler(new V2ProposeCredentialHandler(this, this.agentConfig))
 
     this.dispatcher.registerHandler(
-      new V2OfferCredentialHandler(
-        this,
-        this.agentConfig,
-        this.mediationRecipientService,
-        this.didCommMessageRepository
-      )
+      new V2OfferCredentialHandler(this, this.agentConfig, this.routingService, this.didCommMessageRepository)
     )
 
     this.dispatcher.registerHandler(

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialServiceCred.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialServiceCred.test.ts
@@ -17,7 +17,7 @@ import { JsonEncoder } from '../../../../../utils/JsonEncoder'
 import { AckStatus } from '../../../../common/messages/AckMessage'
 import { DidExchangeState } from '../../../../connections'
 import { ConnectionService } from '../../../../connections/services/ConnectionService'
-import { MediationRecipientService } from '../../../../routing/services/MediationRecipientService'
+import { RoutingService } from '../../../../routing/services/RoutingService'
 import { CredentialEventTypes } from '../../../CredentialEvents'
 import { credReq } from '../../../__tests__/fixtures'
 import { CredentialProblemReportReason } from '../../../errors/CredentialProblemReportReason'
@@ -40,7 +40,7 @@ import { V2RequestCredentialMessage } from '../messages/V2RequestCredentialMessa
 jest.mock('../../../repository/CredentialRepository')
 jest.mock('../../../formats/indy/IndyCredentialFormatService')
 jest.mock('../../../../../storage/didcomm/DidCommMessageRepository')
-jest.mock('../../../../routing/services/MediationRecipientService')
+jest.mock('../../../../routing/services/RoutingService')
 jest.mock('../../../../connections/services/ConnectionService')
 jest.mock('../../../../../agent/Dispatcher')
 
@@ -48,13 +48,13 @@ jest.mock('../../../../../agent/Dispatcher')
 const CredentialRepositoryMock = CredentialRepository as jest.Mock<CredentialRepository>
 const IndyCredentialFormatServiceMock = IndyCredentialFormatService as jest.Mock<IndyCredentialFormatService>
 const DidCommMessageRepositoryMock = DidCommMessageRepository as jest.Mock<DidCommMessageRepository>
-const MediationRecipientServiceMock = MediationRecipientService as jest.Mock<MediationRecipientService>
+const RoutingServiceMock = RoutingService as jest.Mock<RoutingService>
 const ConnectionServiceMock = ConnectionService as jest.Mock<ConnectionService>
 const DispatcherMock = Dispatcher as jest.Mock<Dispatcher>
 
 const credentialRepository = new CredentialRepositoryMock()
 const didCommMessageRepository = new DidCommMessageRepositoryMock()
-const mediationRecipientService = new MediationRecipientServiceMock()
+const routingService = new RoutingServiceMock()
 const indyCredentialFormatService = new IndyCredentialFormatServiceMock()
 const dispatcher = new DispatcherMock()
 const connectionService = new ConnectionServiceMock()
@@ -252,7 +252,7 @@ describe('CredentialService', () => {
       connectionService,
       didCommMessageRepository,
       agentConfig,
-      mediationRecipientService,
+      routingService,
       dispatcher,
       eventEmitter,
       credentialRepository,

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialServiceOffer.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialServiceOffer.test.ts
@@ -13,7 +13,7 @@ import { JsonTransformer } from '../../../../../utils'
 import { DidExchangeState } from '../../../../connections'
 import { ConnectionService } from '../../../../connections/services/ConnectionService'
 import { IndyLedgerService } from '../../../../ledger/services'
-import { MediationRecipientService } from '../../../../routing/services/MediationRecipientService'
+import { RoutingService } from '../../../../routing/services/RoutingService'
 import { CredentialEventTypes } from '../../../CredentialEvents'
 import { credDef, schema } from '../../../__tests__/fixtures'
 import { IndyCredentialFormatService } from '../../../formats/indy/IndyCredentialFormatService'
@@ -30,7 +30,7 @@ jest.mock('../../../repository/CredentialRepository')
 jest.mock('../../../../ledger/services/IndyLedgerService')
 jest.mock('../../../formats/indy/IndyCredentialFormatService')
 jest.mock('../../../../../storage/didcomm/DidCommMessageRepository')
-jest.mock('../../../../routing/services/MediationRecipientService')
+jest.mock('../../../../routing/services/RoutingService')
 jest.mock('../../../../connections/services/ConnectionService')
 jest.mock('../../../../../agent/Dispatcher')
 
@@ -39,13 +39,13 @@ const CredentialRepositoryMock = CredentialRepository as jest.Mock<CredentialRep
 const IndyLedgerServiceMock = IndyLedgerService as jest.Mock<IndyLedgerService>
 const IndyCredentialFormatServiceMock = IndyCredentialFormatService as jest.Mock<IndyCredentialFormatService>
 const DidCommMessageRepositoryMock = DidCommMessageRepository as jest.Mock<DidCommMessageRepository>
-const MediationRecipientServiceMock = MediationRecipientService as jest.Mock<MediationRecipientService>
+const RoutingServiceMock = RoutingService as jest.Mock<RoutingService>
 const ConnectionServiceMock = ConnectionService as jest.Mock<ConnectionService>
 const DispatcherMock = Dispatcher as jest.Mock<Dispatcher>
 
 const credentialRepository = new CredentialRepositoryMock()
 const didCommMessageRepository = new DidCommMessageRepositoryMock()
-const mediationRecipientService = new MediationRecipientServiceMock()
+const routingService = new RoutingServiceMock()
 const indyLedgerService = new IndyLedgerServiceMock()
 const indyCredentialFormatService = new IndyCredentialFormatServiceMock()
 const dispatcher = new DispatcherMock()
@@ -97,7 +97,7 @@ describe('V2CredentialServiceOffer', () => {
       connectionService,
       didCommMessageRepository,
       agentConfig,
-      mediationRecipientService,
+      routingService,
       dispatcher,
       eventEmitter,
       credentialRepository,

--- a/packages/core/src/modules/credentials/protocol/v2/handlers/V2OfferCredentialHandler.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/handlers/V2OfferCredentialHandler.ts
@@ -2,7 +2,7 @@ import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../../../agent/Handler'
 import type { InboundMessageContext } from '../../../../../agent/models/InboundMessageContext'
 import type { DidCommMessageRepository } from '../../../../../storage'
-import type { MediationRecipientService } from '../../../../routing/services/MediationRecipientService'
+import type { RoutingService } from '../../../../routing/services/RoutingService'
 import type { CredentialExchangeRecord } from '../../../repository/CredentialExchangeRecord'
 import type { V2CredentialService } from '../V2CredentialService'
 
@@ -14,19 +14,19 @@ import { V2OfferCredentialMessage } from '../messages/V2OfferCredentialMessage'
 export class V2OfferCredentialHandler implements Handler {
   private credentialService: V2CredentialService
   private agentConfig: AgentConfig
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   public supportedMessages = [V2OfferCredentialMessage]
   private didCommMessageRepository: DidCommMessageRepository
 
   public constructor(
     credentialService: V2CredentialService,
     agentConfig: AgentConfig,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     didCommMessageRepository: DidCommMessageRepository
   ) {
     this.credentialService = credentialService
     this.agentConfig = agentConfig
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
     this.didCommMessageRepository = didCommMessageRepository
   }
 
@@ -58,7 +58,7 @@ export class V2OfferCredentialHandler implements Handler {
       })
       return createOutboundMessage(messageContext.connection, message)
     } else if (offerMessage?.service) {
-      const routing = await this.mediationRecipientService.getRouting()
+      const routing = await this.routingService.getRouting()
       const ourService = new ServiceDecorator({
         serviceEndpoint: routing.endpoints[0],
         recipientKeys: [routing.recipientKey.publicKeyBase58],

--- a/packages/core/src/modules/ledger/__tests__/IndyPoolService.test.ts
+++ b/packages/core/src/modules/ledger/__tests__/IndyPoolService.test.ts
@@ -49,8 +49,8 @@ const pools: IndyPoolConfig[] = [
   },
 ]
 
-describe('IndyLedgerService', () => {
-  const config = getAgentConfig('IndyLedgerServiceTest', {
+describe('IndyPoolService', () => {
+  const config = getAgentConfig('IndyPoolServiceTest', {
     indyLedgers: pools,
   })
   let wallet: IndyWallet
@@ -80,7 +80,7 @@ describe('IndyLedgerService', () => {
     })
 
     it('should throw a LedgerNotConfiguredError error if no pools are configured on the agent', async () => {
-      const config = getAgentConfig('IndyLedgerServiceTest', { indyLedgers: [] })
+      const config = getAgentConfig('IndyPoolServiceTest', { indyLedgers: [] })
       poolService = new IndyPoolService(config, cacheRepository)
 
       expect(() => poolService.ledgerWritePool).toThrow(LedgerNotConfiguredError)
@@ -89,7 +89,7 @@ describe('IndyLedgerService', () => {
 
   describe('getPoolForDid', () => {
     it('should throw a LedgerNotConfiguredError error if no pools are configured on the agent', async () => {
-      const config = getAgentConfig('IndyLedgerServiceTest', { indyLedgers: [] })
+      const config = getAgentConfig('IndyPoolServiceTest', { indyLedgers: [] })
       poolService = new IndyPoolService(config, cacheRepository)
 
       expect(poolService.getPoolForDid('some-did')).rejects.toThrow(LedgerNotConfiguredError)

--- a/packages/core/src/modules/oob/OutOfBandModule.ts
+++ b/packages/core/src/modules/oob/OutOfBandModule.ts
@@ -25,7 +25,7 @@ import { parseInvitationUrl } from '../../utils/parseInvitation'
 import { DidKey } from '../dids'
 import { didKeyToVerkey } from '../dids/helpers'
 import { outOfBandServiceToNumAlgo2Did } from '../dids/methods/peer/peerDidNumAlgo2'
-import { MediationRecipientService } from '../routing'
+import { RoutingService } from '../routing/services/RoutingService'
 
 import { OutOfBandService } from './OutOfBandService'
 import { OutOfBandDidCommService } from './domain/OutOfBandDidCommService'
@@ -76,7 +76,7 @@ export interface ReceiveOutOfBandInvitationConfig {
 @scoped(Lifecycle.ContainerScoped)
 export class OutOfBandModule {
   private outOfBandService: OutOfBandService
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   private connectionsModule: ConnectionsModule
   private didCommMessageRepository: DidCommMessageRepository
   private dispatcher: Dispatcher
@@ -89,7 +89,7 @@ export class OutOfBandModule {
     dispatcher: Dispatcher,
     agentConfig: AgentConfig,
     outOfBandService: OutOfBandService,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     connectionsModule: ConnectionsModule,
     didCommMessageRepository: DidCommMessageRepository,
     messageSender: MessageSender,
@@ -99,7 +99,7 @@ export class OutOfBandModule {
     this.agentConfig = agentConfig
     this.logger = agentConfig.logger
     this.outOfBandService = outOfBandService
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
     this.connectionsModule = connectionsModule
     this.didCommMessageRepository = didCommMessageRepository
     this.messageSender = messageSender
@@ -160,7 +160,7 @@ export class OutOfBandModule {
       }
     }
 
-    const routing = config.routing ?? (await this.mediationRecipientService.getRouting({}))
+    const routing = config.routing ?? (await this.routingService.getRouting({}))
 
     const services = routing.endpoints.map((endpoint, index) => {
       return new OutOfBandDidCommService({
@@ -231,7 +231,7 @@ export class OutOfBandModule {
     domain: string
   }): Promise<{ message: Message; invitationUrl: string }> {
     // Create keys (and optionally register them at the mediator)
-    const routing = await this.mediationRecipientService.getRouting()
+    const routing = await this.routingService.getRouting()
 
     // Set the service on the message
     config.message.service = new ServiceDecorator({

--- a/packages/core/src/modules/proofs/ProofsModule.ts
+++ b/packages/core/src/modules/proofs/ProofsModule.ts
@@ -13,7 +13,7 @@ import { createOutboundMessage } from '../../agent/helpers'
 import { ServiceDecorator } from '../../decorators/service/ServiceDecorator'
 import { AriesFrameworkError } from '../../error'
 import { ConnectionService } from '../connections/services/ConnectionService'
-import { MediationRecipientService } from '../routing/services/MediationRecipientService'
+import { RoutingService } from '../routing/services/RoutingService'
 
 import { ProofResponseCoordinator } from './ProofResponseCoordinator'
 import { PresentationProblemReportReason } from './errors'
@@ -33,7 +33,7 @@ export class ProofsModule {
   private proofService: ProofService
   private connectionService: ConnectionService
   private messageSender: MessageSender
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   private agentConfig: AgentConfig
   private proofResponseCoordinator: ProofResponseCoordinator
 
@@ -41,7 +41,7 @@ export class ProofsModule {
     dispatcher: Dispatcher,
     proofService: ProofService,
     connectionService: ConnectionService,
-    mediationRecipientService: MediationRecipientService,
+    routingService: RoutingService,
     agentConfig: AgentConfig,
     messageSender: MessageSender,
     proofResponseCoordinator: ProofResponseCoordinator
@@ -49,7 +49,7 @@ export class ProofsModule {
     this.proofService = proofService
     this.connectionService = connectionService
     this.messageSender = messageSender
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
     this.agentConfig = agentConfig
     this.proofResponseCoordinator = proofResponseCoordinator
     this.registerHandlers(dispatcher)
@@ -196,7 +196,7 @@ export class ProofsModule {
     const { message, proofRecord } = await this.proofService.createRequest(proofRequest, undefined, config)
 
     // Create and set ~service decorator
-    const routing = await this.mediationRecipientService.getRouting()
+    const routing = await this.routingService.getRouting()
     message.service = new ServiceDecorator({
       serviceEndpoint: routing.endpoints[0],
       recipientKeys: [routing.recipientKey.publicKeyBase58],
@@ -242,7 +242,7 @@ export class ProofsModule {
     // Use ~service decorator otherwise
     else if (proofRecord.requestMessage?.service) {
       // Create ~service decorator
-      const routing = await this.mediationRecipientService.getRouting()
+      const routing = await this.routingService.getRouting()
       const ourService = new ServiceDecorator({
         serviceEndpoint: routing.endpoints[0],
         recipientKeys: [routing.recipientKey.publicKeyBase58],
@@ -452,7 +452,7 @@ export class ProofsModule {
         this.proofService,
         this.agentConfig,
         this.proofResponseCoordinator,
-        this.mediationRecipientService
+        this.routingService
       )
     )
     dispatcher.registerHandler(

--- a/packages/core/src/modules/proofs/handlers/RequestPresentationHandler.ts
+++ b/packages/core/src/modules/proofs/handlers/RequestPresentationHandler.ts
@@ -1,6 +1,6 @@
 import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
-import type { MediationRecipientService } from '../../routing'
+import type { RoutingService } from '../../routing/services/RoutingService'
 import type { ProofResponseCoordinator } from '../ProofResponseCoordinator'
 import type { ProofRecord } from '../repository'
 import type { ProofService } from '../services'
@@ -13,19 +13,19 @@ export class RequestPresentationHandler implements Handler {
   private proofService: ProofService
   private agentConfig: AgentConfig
   private proofResponseCoordinator: ProofResponseCoordinator
-  private mediationRecipientService: MediationRecipientService
+  private routingService: RoutingService
   public supportedMessages = [RequestPresentationMessage]
 
   public constructor(
     proofService: ProofService,
     agentConfig: AgentConfig,
     proofResponseCoordinator: ProofResponseCoordinator,
-    mediationRecipientService: MediationRecipientService
+    routingService: RoutingService
   ) {
     this.proofService = proofService
     this.agentConfig = agentConfig
     this.proofResponseCoordinator = proofResponseCoordinator
-    this.mediationRecipientService = mediationRecipientService
+    this.routingService = routingService
   }
 
   public async handle(messageContext: HandlerInboundMessage<RequestPresentationHandler>) {
@@ -64,7 +64,7 @@ export class RequestPresentationHandler implements Handler {
       return createOutboundMessage(messageContext.connection, message)
     } else if (proofRecord.requestMessage?.service) {
       // Create ~service decorator
-      const routing = await this.mediationRecipientService.getRouting()
+      const routing = await this.routingService.getRouting()
       const ourService = new ServiceDecorator({
         serviceEndpoint: routing.endpoints[0],
         recipientKeys: [routing.recipientKey.publicKeyBase58],

--- a/packages/core/src/modules/routing/RecipientModule.ts
+++ b/packages/core/src/modules/routing/RecipientModule.ts
@@ -4,7 +4,7 @@ import type { OutboundMessage } from '../../types'
 import type { ConnectionRecord } from '../connections'
 import type { MediationStateChangedEvent } from './RoutingEvents'
 import type { MediationRecord } from './index'
-import type { GetRoutingOptions } from './services/MediationRecipientService'
+import type { GetRoutingOptions } from './services/RoutingService'
 
 import { firstValueFrom, interval, ReplaySubject, timer } from 'rxjs'
 import { filter, first, takeUntil, throttleTime, timeout, tap, delayWhen } from 'rxjs/operators'
@@ -13,7 +13,6 @@ import { Lifecycle, scoped } from 'tsyringe'
 import { AgentConfig } from '../../agent/AgentConfig'
 import { Dispatcher } from '../../agent/Dispatcher'
 import { EventEmitter } from '../../agent/EventEmitter'
-import { MessageReceiver } from '../../agent/MessageReceiver'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
 import { AriesFrameworkError } from '../../error'
@@ -33,6 +32,7 @@ import { BatchPickupMessage } from './messages/BatchPickupMessage'
 import { MediationState } from './models/MediationState'
 import { MediationRepository } from './repository'
 import { MediationRecipientService } from './services/MediationRecipientService'
+import { RoutingService } from './services/RoutingService'
 
 @scoped(Lifecycle.ContainerScoped)
 export class RecipientModule {
@@ -41,11 +41,11 @@ export class RecipientModule {
   private connectionService: ConnectionService
   private dids: DidsModule
   private messageSender: MessageSender
-  private messageReceiver: MessageReceiver
   private eventEmitter: EventEmitter
   private logger: Logger
   private discoverFeaturesModule: DiscoverFeaturesModule
   private mediationRepository: MediationRepository
+  private routingService: RoutingService
 
   public constructor(
     dispatcher: Dispatcher,
@@ -54,21 +54,21 @@ export class RecipientModule {
     connectionService: ConnectionService,
     dids: DidsModule,
     messageSender: MessageSender,
-    messageReceiver: MessageReceiver,
     eventEmitter: EventEmitter,
     discoverFeaturesModule: DiscoverFeaturesModule,
-    mediationRepository: MediationRepository
+    mediationRepository: MediationRepository,
+    routingService: RoutingService
   ) {
     this.agentConfig = agentConfig
     this.connectionService = connectionService
     this.dids = dids
     this.mediationRecipientService = mediationRecipientService
     this.messageSender = messageSender
-    this.messageReceiver = messageReceiver
     this.eventEmitter = eventEmitter
     this.logger = agentConfig.logger
     this.discoverFeaturesModule = discoverFeaturesModule
     this.mediationRepository = mediationRepository
+    this.routingService = routingService
     this.registerHandlers(dispatcher)
   }
 
@@ -366,7 +366,7 @@ export class RecipientModule {
   }
 
   public async getRouting(options: GetRoutingOptions) {
-    return this.mediationRecipientService.getRouting(options)
+    return this.routingService.getRouting(options)
   }
 
   // Register handlers for the several messages for the mediator.

--- a/packages/core/src/modules/routing/RoutingEvents.ts
+++ b/packages/core/src/modules/routing/RoutingEvents.ts
@@ -1,4 +1,5 @@
 import type { BaseEvent } from '../../agent/Events'
+import type { Routing } from '../connections'
 import type { KeylistUpdate } from './messages/KeylistUpdateMessage'
 import type { MediationState } from './models/MediationState'
 import type { MediationRecord } from './repository/MediationRecord'
@@ -6,6 +7,14 @@ import type { MediationRecord } from './repository/MediationRecord'
 export enum RoutingEventTypes {
   MediationStateChanged = 'MediationStateChanged',
   RecipientKeylistUpdated = 'RecipientKeylistUpdated',
+  RoutingCreatedEvent = 'RoutingCreatedEvent',
+}
+
+export interface RoutingCreatedEvent extends BaseEvent {
+  type: typeof RoutingEventTypes.RoutingCreatedEvent
+  payload: {
+    routing: Routing
+  }
 }
 
 export interface MediationStateChangedEvent extends BaseEvent {

--- a/packages/core/src/modules/routing/services/MediationRecipientService.ts
+++ b/packages/core/src/modules/routing/services/MediationRecipientService.ts
@@ -12,21 +12,20 @@ import type {
   MessageDeliveryMessage,
 } from '../messages'
 import type { StatusMessage } from '../messages/StatusMessage'
+import type { GetRoutingOptions } from './RoutingService'
 
 import { firstValueFrom, ReplaySubject } from 'rxjs'
 import { filter, first, timeout } from 'rxjs/operators'
-import { inject, Lifecycle, scoped } from 'tsyringe'
+import { Lifecycle, scoped } from 'tsyringe'
 
 import { AgentConfig } from '../../../agent/AgentConfig'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { AgentEventTypes } from '../../../agent/Events'
 import { MessageSender } from '../../../agent/MessageSender'
 import { createOutboundMessage } from '../../../agent/helpers'
-import { InjectionSymbols } from '../../../constants'
 import { KeyType } from '../../../crypto'
 import { AriesFrameworkError } from '../../../error'
 import { JsonTransformer } from '../../../utils'
-import { Wallet } from '../../../wallet/Wallet'
 import { ConnectionService } from '../../connections/services/ConnectionService'
 import { Key } from '../../dids'
 import { ProblemReportError } from '../../problem-reports'
@@ -46,7 +45,6 @@ import { MediationRepository } from '../repository/MediationRepository'
 
 @scoped(Lifecycle.ContainerScoped)
 export class MediationRecipientService {
-  private wallet: Wallet
   private mediationRepository: MediationRepository
   private eventEmitter: EventEmitter
   private connectionService: ConnectionService
@@ -54,7 +52,6 @@ export class MediationRecipientService {
   private config: AgentConfig
 
   public constructor(
-    @inject(InjectionSymbols.Wallet) wallet: Wallet,
     connectionService: ConnectionService,
     messageSender: MessageSender,
     config: AgentConfig,
@@ -62,7 +59,6 @@ export class MediationRecipientService {
     eventEmitter: EventEmitter
   ) {
     this.config = config
-    this.wallet = wallet
     this.mediationRepository = mediatorRepository
     this.eventEmitter = eventEmitter
     this.connectionService = connectionService
@@ -197,7 +193,10 @@ export class MediationRecipientService {
     return keylistUpdateMessage
   }
 
-  public async getRouting({ mediatorId, useDefaultMediator = true }: GetRoutingOptions = {}): Promise<Routing> {
+  public async addMediationRouting(
+    routing: Routing,
+    { mediatorId, useDefaultMediator = true }: GetRoutingOptions = {}
+  ): Promise<Routing> {
     let mediationRecord: MediationRecord | null = null
 
     if (mediatorId) {
@@ -208,21 +207,17 @@ export class MediationRecipientService {
       mediationRecord = await this.findDefaultMediator()
     }
 
-    let endpoints = this.config.endpoints
-    let routingKeys: Key[] = []
+    // Return early if no mediation record
+    if (!mediationRecord) return routing
 
-    // Create and store new key
-    const { verkey } = await this.wallet.createDid()
+    // new did has been created and mediator needs to be updated with the public key.
+    mediationRecord = await this.keylistUpdateAndAwait(mediationRecord, routing.recipientKey.publicKeyBase58)
 
-    const recipientKey = Key.fromPublicKeyBase58(verkey, KeyType.Ed25519)
-    if (mediationRecord) {
-      routingKeys = mediationRecord.routingKeys.map((key) => Key.fromPublicKeyBase58(key, KeyType.Ed25519))
-      endpoints = mediationRecord.endpoint ? [mediationRecord.endpoint] : endpoints
-      // new did has been created and mediator needs to be updated with the public key.
-      mediationRecord = await this.keylistUpdateAndAwait(mediationRecord, verkey)
+    return {
+      ...routing,
+      endpoints: mediationRecord.endpoint ? [mediationRecord.endpoint] : routing.endpoints,
+      routingKeys: mediationRecord.routingKeys.map((key) => Key.fromPublicKeyBase58(key, KeyType.Ed25519)),
     }
-
-    return { endpoints, routingKeys, recipientKey, mediatorId: mediationRecord?.id }
   }
 
   public async processMediationDeny(messageContext: InboundMessageContext<MediationDenyMessage>) {
@@ -407,17 +402,4 @@ export class MediationRecipientService {
 export interface MediationProtocolMsgReturnType<MessageType extends AgentMessage> {
   message: MessageType
   mediationRecord: MediationRecord
-}
-
-export interface GetRoutingOptions {
-  /**
-   * Identifier of the mediator to use when setting up routing
-   */
-  mediatorId?: string
-
-  /**
-   * Whether to use the default mediator if available and `mediatorId` has not been provided
-   * @default true
-   */
-  useDefaultMediator?: boolean
 }

--- a/packages/core/src/modules/routing/services/RoutingService.ts
+++ b/packages/core/src/modules/routing/services/RoutingService.ts
@@ -1,0 +1,76 @@
+import type { Routing } from '../../connections'
+import type { RoutingCreatedEvent } from '../RoutingEvents'
+
+import { inject, Lifecycle, scoped } from 'tsyringe'
+
+import { AgentConfig } from '../../../agent/AgentConfig'
+import { EventEmitter } from '../../../agent/EventEmitter'
+import { InjectionSymbols } from '../../../constants'
+import { KeyType } from '../../../crypto'
+import { Wallet } from '../../../wallet'
+import { Key } from '../../dids'
+import { RoutingEventTypes } from '../RoutingEvents'
+
+import { MediationRecipientService } from './MediationRecipientService'
+
+@scoped(Lifecycle.ContainerScoped)
+export class RoutingService {
+  private mediationRecipientService: MediationRecipientService
+  private agentConfig: AgentConfig
+  private wallet: Wallet
+  private eventEmitter: EventEmitter
+
+  public constructor(
+    mediationRecipientService: MediationRecipientService,
+    agentConfig: AgentConfig,
+    @inject(InjectionSymbols.Wallet) wallet: Wallet,
+    eventEmitter: EventEmitter
+  ) {
+    this.mediationRecipientService = mediationRecipientService
+    this.agentConfig = agentConfig
+    this.wallet = wallet
+    this.eventEmitter = eventEmitter
+  }
+
+  public async getRouting({ mediatorId, useDefaultMediator = true }: GetRoutingOptions = {}): Promise<Routing> {
+    // Create and store new key
+    const { verkey: publicKeyBase58 } = await this.wallet.createDid()
+
+    const recipientKey = Key.fromPublicKeyBase58(publicKeyBase58, KeyType.Ed25519)
+
+    let routing: Routing = {
+      endpoints: this.agentConfig.endpoints,
+      routingKeys: [],
+      recipientKey,
+    }
+
+    // Extend routing with mediator keys (if applicable)
+    routing = await this.mediationRecipientService.addMediationRouting(routing, {
+      mediatorId,
+      useDefaultMediator,
+    })
+
+    // Emit event so other parts of the framework can react on keys created
+    this.eventEmitter.emit<RoutingCreatedEvent>({
+      type: RoutingEventTypes.RoutingCreatedEvent,
+      payload: {
+        routing,
+      },
+    })
+
+    return routing
+  }
+}
+
+export interface GetRoutingOptions {
+  /**
+   * Identifier of the mediator to use when setting up routing
+   */
+  mediatorId?: string
+
+  /**
+   * Whether to use the default mediator if available and `mediatorId` has not been provided
+   * @default true
+   */
+  useDefaultMediator?: boolean
+}

--- a/packages/core/src/modules/routing/services/__tests__/RoutingService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/RoutingService.test.ts
@@ -1,0 +1,69 @@
+import { getAgentConfig, mockFunction } from '../../../../../tests/helpers'
+import { EventEmitter } from '../../../../agent/EventEmitter'
+import { IndyWallet } from '../../../../wallet/IndyWallet'
+import { Key } from '../../../dids'
+import { RoutingEventTypes } from '../../RoutingEvents'
+import { MediationRecipientService } from '../MediationRecipientService'
+import { RoutingService } from '../RoutingService'
+
+jest.mock('../../../../wallet/IndyWallet')
+const IndyWalletMock = IndyWallet as jest.Mock<IndyWallet>
+
+jest.mock('../MediationRecipientService')
+const MediationRecipientServiceMock = MediationRecipientService as jest.Mock<MediationRecipientService>
+
+const agentConfig = getAgentConfig('RoutingService', {
+  endpoints: ['http://endpoint.com'],
+})
+const eventEmitter = new EventEmitter(agentConfig)
+const wallet = new IndyWalletMock()
+const mediationRecipientService = new MediationRecipientServiceMock()
+const routingService = new RoutingService(mediationRecipientService, agentConfig, wallet, eventEmitter)
+
+const recipientKey = Key.fromFingerprint('z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL')
+
+const routing = {
+  endpoints: ['http://endpoint.com'],
+  recipientKey,
+  routingKeys: [],
+}
+mockFunction(mediationRecipientService.addMediationRouting).mockResolvedValue(routing)
+mockFunction(wallet.createDid).mockResolvedValue({
+  did: 'some-did',
+  verkey: recipientKey.publicKeyBase58,
+})
+
+describe('RoutingService', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getRouting', () => {
+    test('calls mediation recipient service', async () => {
+      const routing = await routingService.getRouting({
+        mediatorId: 'mediator-id',
+        useDefaultMediator: true,
+      })
+
+      expect(mediationRecipientService.addMediationRouting).toHaveBeenCalledWith(routing, {
+        mediatorId: 'mediator-id',
+        useDefaultMediator: true,
+      })
+    })
+
+    test('emits RoutingCreatedEvent', async () => {
+      const routingListener = jest.fn()
+      eventEmitter.on(RoutingEventTypes.RoutingCreatedEvent, routingListener)
+
+      const routing = await routingService.getRouting()
+
+      expect(routing).toEqual(routing)
+      expect(routingListener).toHaveBeenCalledWith({
+        type: RoutingEventTypes.RoutingCreatedEvent,
+        payload: {
+          routing,
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
Adds a routing service that handles the creating of keys for routing and integrates with the mediation recipient service to add routing for the mediator.

The extraction is just to make sure we don't have to depend on a mediator dependency all across the framework. 

What this also adds is an event for when routing keys are created. This allows the tenant module to listen for created routing keys and can then create a mapping of it in the base wallet. I first started with a middleware approach (As described in the design document: https://hackmd.io/vGLVlxLvQR6jsEEjzNcL8g), but this added _ A LOT_ of complexity and didn't abstract away the mediator functionality as that is a part of the core API. So I went for the less generic but simpler API, that is just fine I think.

Again no changes to the public api, so we can merge this without issues


