### PR TITLE
refactor!: add agent context

### DIFF
--- a/packages/core/src/agent/Agent.ts
+++ b/packages/core/src/agent/Agent.ts
@@ -2,13 +2,13 @@ import type { Logger } from '../logger'
 import type { InboundTransport } from '../transport/InboundTransport'
 import type { OutboundTransport } from '../transport/OutboundTransport'
 import type { InitConfig } from '../types'
-import type { Wallet } from '../wallet/Wallet'
 import type { AgentDependencies } from './AgentDependencies'
 import type { AgentMessageReceivedEvent } from './Events'
 import type { TransportSession } from './TransportService'
 import type { Subscription } from 'rxjs'
 import type { DependencyContainer } from 'tsyringe'
 
+import { Subject } from 'rxjs'
 import { concatMap, takeUntil } from 'rxjs/operators'
 import { container as baseContainer } from 'tsyringe'
 
@@ -42,6 +42,7 @@ import { WalletModule } from '../wallet/WalletModule'
 import { WalletError } from '../wallet/error'
 
 import { AgentConfig } from './AgentConfig'
+import { AgentContext } from './AgentContext'
 import { Dispatcher } from './Dispatcher'
 import { EnvelopeService } from './EnvelopeService'
 import { EventEmitter } from './EventEmitter'
@@ -60,8 +61,9 @@ export class Agent {
   protected messageSender: MessageSender
   private _isInitialized = false
   public messageSubscription: Subscription
-  private walletService: Wallet
   private routingService: RoutingService
+  private agentContext: AgentContext
+  private stop$ = new Subject<boolean>()
 
   public readonly connections: ConnectionsModule
   public readonly proofs: ProofsModule
@@ -112,8 +114,8 @@ export class Agent {
     this.messageSender = this.dependencyManager.resolve(MessageSender)
     this.messageReceiver = this.dependencyManager.resolve(MessageReceiver)
     this.transportService = this.dependencyManager.resolve(TransportService)
-    this.walletService = this.dependencyManager.resolve(InjectionSymbols.Wallet)
     this.routingService = this.dependencyManager.resolve(RoutingService)
+    this.agentContext = this.dependencyManager.resolve(AgentContext)
 
     // We set the modules in the constructor because that allows to set them as read-only
     this.connections = this.dependencyManager.resolve(ConnectionsModule)
@@ -134,8 +136,12 @@ export class Agent {
     this.messageSubscription = this.eventEmitter
       .observable<AgentMessageReceivedEvent>(AgentEventTypes.AgentMessageReceived)
       .pipe(
-        takeUntil(this.agentConfig.stop$),
-        concatMap((e) => this.messageReceiver.receiveMessage(e.payload.message, { connection: e.payload.connection }))
+        takeUntil(this.stop$),
+        concatMap((e) =>
+          this.messageReceiver.receiveMessage(this.agentContext, e.payload.message, {
+            connection: e.payload.connection,
+          })
+        )
       )
       .subscribe()
   }
@@ -185,7 +191,7 @@ export class Agent {
 
     // Make sure the storage is up to date
     const storageUpdateService = this.dependencyManager.resolve(StorageUpdateService)
-    const isStorageUpToDate = await storageUpdateService.isUpToDate()
+    const isStorageUpToDate = await storageUpdateService.isUpToDate(this.agentContext)
     this.logger.info(`Agent storage is ${isStorageUpToDate ? '' : 'not '}up to date.`)
 
     if (!isStorageUpToDate && this.agentConfig.autoUpdateStorageOnStartup) {
@@ -194,7 +200,7 @@ export class Agent {
       await updateAssistant.initialize()
       await updateAssistant.update()
     } else if (!isStorageUpToDate) {
-      const currentVersion = await storageUpdateService.getCurrentStorageVersion()
+      const currentVersion = await storageUpdateService.getCurrentStorageVersion(this.agentContext)
       // Close wallet to prevent un-initialized agent with initialized wallet
       await this.wallet.close()
       throw new AriesFrameworkError(
@@ -208,9 +214,11 @@ export class Agent {
 
     if (publicDidSeed) {
       // If an agent has publicDid it will be used as routing key.
-      await this.walletService.initPublicDid({ seed: publicDidSeed })
+      await this.agentContext.wallet.initPublicDid({ seed: publicDidSeed })
     }
 
+    // set the pools on the ledger.
+    this.ledger.setPools(this.agentContext.config.indyLedgers)
     // As long as value isn't false we will async connect to all genesis pools on startup
     if (connectToIndyLedgersOnStartup) {
       this.ledger.connectToPools().catch((error) => {
@@ -243,7 +251,7 @@ export class Agent {
   public async shutdown() {
     // All observables use takeUntil with the stop$ observable
     // this means all observables will stop running if a value is emitted on this observable
-    this.agentConfig.stop$.next(true)
+    this.stop$.next(true)
 
     // Stop transports
     const allTransports = [...this.inboundTransports, ...this.outboundTransports]
@@ -258,11 +266,11 @@ export class Agent {
   }
 
   public get publicDid() {
-    return this.walletService.publicDid
+    return this.agentContext.wallet.publicDid
   }
 
   public async receiveMessage(inboundMessage: unknown, session?: TransportSession) {
-    return await this.messageReceiver.receiveMessage(inboundMessage, { session })
+    return await this.messageReceiver.receiveMessage(this.agentContext, inboundMessage, { session })
   }
 
   public get injectionContainer() {
@@ -273,6 +281,10 @@ export class Agent {
     return this.agentConfig
   }
 
+  public get context() {
+    return this.agentContext
+  }
+
   private async getMediationConnection(mediatorInvitationUrl: string) {
     const outOfBandInvitation = this.oob.parseInvitation(mediatorInvitationUrl)
     const outOfBandRecord = await this.oob.findByInvitationId(outOfBandInvitation.id)
@@ -281,7 +293,7 @@ export class Agent {
     if (!connection) {
       this.logger.debug('Mediation connection does not exist, creating connection')
       // We don't want to use the current default mediator when connecting to another mediator
-      const routing = await this.routingService.getRouting({ useDefaultMediator: false })
+      const routing = await this.routingService.getRouting(this.agentContext, { useDefaultMediator: false })
 
       this.logger.debug('Routing created', routing)
       const { connectionRecord: newConnection } = await this.oob.receiveInvitation(outOfBandInvitation, {
@@ -303,7 +315,7 @@ export class Agent {
   }
 
   private registerDependencies(dependencyManager: DependencyManager) {
-    dependencyManager.registerInstance(AgentConfig, this.agentConfig)
+    const dependencies = this.agentConfig.agentDependencies
 
     // Register internal dependencies
     dependencyManager.registerSingleton(EventEmitter)
@@ -318,11 +330,14 @@ export class Agent {
     dependencyManager.registerSingleton(StorageVersionRepository)
     dependencyManager.registerSingleton(StorageUpdateService)
 
+    dependencyManager.registerInstance(AgentConfig, this.agentConfig)
+    dependencyManager.registerInstance(InjectionSymbols.AgentDependencies, dependencies)
+    dependencyManager.registerInstance(InjectionSymbols.FileSystem, new dependencies.FileSystem())
+    dependencyManager.registerInstance(InjectionSymbols.Stop$, this.stop$)
+
     // Register possibly already defined services
     if (!dependencyManager.isRegistered(InjectionSymbols.Wallet)) {
-      this.dependencyManager.registerSingleton(IndyWallet)
-      const wallet = this.dependencyManager.resolve(IndyWallet)
-      dependencyManager.registerInstance(InjectionSymbols.Wallet, wallet)
+      dependencyManager.registerContextScoped(InjectionSymbols.Wallet, IndyWallet)
     }
     if (!dependencyManager.isRegistered(InjectionSymbols.Logger)) {
       dependencyManager.registerInstance(InjectionSymbols.Logger, this.logger)
@@ -352,5 +367,7 @@ export class Agent {
       IndyModule,
       W3cVcModule
     )
+
+    dependencyManager.registerInstance(AgentContext, new AgentContext({ dependencyManager }))
   }
 }

--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -1,9 +1,6 @@
 import type { Logger } from '../logger'
-import type { FileSystem } from '../storage/FileSystem'
 import type { InitConfig } from '../types'
 import type { AgentDependencies } from './AgentDependencies'
-
-import { Subject } from 'rxjs'
 
 import { DID_COMM_TRANSPORT_QUEUE } from '../constants'
 import { AriesFrameworkError } from '../error'
@@ -17,17 +14,12 @@ export class AgentConfig {
   public label: string
   public logger: Logger
   public readonly agentDependencies: AgentDependencies
-  public readonly fileSystem: FileSystem
-
-  // $stop is used for agent shutdown signal
-  public readonly stop$ = new Subject<boolean>()
 
   public constructor(initConfig: InitConfig, agentDependencies: AgentDependencies) {
     this.initConfig = initConfig
     this.label = initConfig.label
     this.logger = initConfig.logger ?? new ConsoleLogger(LogLevel.off)
     this.agentDependencies = agentDependencies
-    this.fileSystem = new agentDependencies.FileSystem()
 
     const { mediatorConnectionsInvite, clearDefaultMediator, defaultMediatorId } = this.initConfig
 

--- a/packages/core/src/agent/AgentContext.ts
+++ b/packages/core/src/agent/AgentContext.ts
@@ -1,0 +1,32 @@
+import type { DependencyManager } from '../plugins'
+import type { Wallet } from '../wallet'
+
+import { InjectionSymbols } from '../constants'
+
+import { AgentConfig } from './AgentConfig'
+
+export class AgentContext {
+  /**
+   * Dependency manager holds all dependencies for the current context. Possibly a child of a parent dependency manager,
+   * in which case all singleton dependencies from the parent context are also available to this context.
+   */
+  public readonly dependencyManager: DependencyManager
+
+  public constructor({ dependencyManager }: { dependencyManager: DependencyManager }) {
+    this.dependencyManager = dependencyManager
+  }
+
+  /**
+   * Convenience method to access the agent config for the current context.
+   */
+  public get config() {
+    return this.dependencyManager.resolve(AgentConfig)
+  }
+
+  /**
+   * Convenience method to access the wallet for the current context.
+   */
+  public get wallet() {
+    return this.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
+  }
+}

--- a/packages/core/src/agent/EnvelopeService.ts
+++ b/packages/core/src/agent/EnvelopeService.ts
@@ -1,14 +1,12 @@
-import type { Logger } from '../logger'
 import type { EncryptedMessage, PlaintextMessage } from '../types'
+import type { AgentContext } from './AgentContext'
 import type { AgentMessage } from './AgentMessage'
 
 import { InjectionSymbols } from '../constants'
 import { Key, KeyType } from '../crypto'
+import { Logger } from '../logger'
 import { ForwardMessage } from '../modules/routing/messages'
 import { inject, injectable } from '../plugins'
-import { Wallet } from '../wallet/Wallet'
-
-import { AgentConfig } from './AgentConfig'
 
 export interface EnvelopeKeys {
   recipientKeys: Key[]
@@ -18,28 +16,28 @@ export interface EnvelopeKeys {
 
 @injectable()
 export class EnvelopeService {
-  private wallet: Wallet
   private logger: Logger
-  private config: AgentConfig
 
-  public constructor(@inject(InjectionSymbols.Wallet) wallet: Wallet, agentConfig: AgentConfig) {
-    this.wallet = wallet
-    this.logger = agentConfig.logger
-    this.config = agentConfig
+  public constructor(@inject(InjectionSymbols.Logger) logger: Logger) {
+    this.logger = logger
   }
 
-  public async packMessage(payload: AgentMessage, keys: EnvelopeKeys): Promise<EncryptedMessage> {
+  public async packMessage(
+    agentContext: AgentContext,
+    payload: AgentMessage,
+    keys: EnvelopeKeys
+  ): Promise<EncryptedMessage> {
     const { recipientKeys, routingKeys, senderKey } = keys
     let recipientKeysBase58 = recipientKeys.map((key) => key.publicKeyBase58)
     const routingKeysBase58 = routingKeys.map((key) => key.publicKeyBase58)
     const senderKeyBase58 = senderKey && senderKey.publicKeyBase58
 
     // pass whether we want to use legacy did sov prefix
-    const message = payload.toJSON({ useLegacyDidSovPrefix: this.config.useLegacyDidSovPrefix })
+    const message = payload.toJSON({ useLegacyDidSovPrefix: agentContext.config.useLegacyDidSovPrefix })
 
     this.logger.debug(`Pack outbound message ${message['@type']}`)
 
-    let encryptedMessage = await this.wallet.pack(message, recipientKeysBase58, senderKeyBase58 ?? undefined)
+    let encryptedMessage = await agentContext.wallet.pack(message, recipientKeysBase58, senderKeyBase58 ?? undefined)
 
     // If the message has routing keys (mediator) pack for each mediator
     for (const routingKeyBase58 of routingKeysBase58) {
@@ -51,17 +49,20 @@ export class EnvelopeService {
       recipientKeysBase58 = [routingKeyBase58]
       this.logger.debug('Forward message created', forwardMessage)
 
-      const forwardJson = forwardMessage.toJSON({ useLegacyDidSovPrefix: this.config.useLegacyDidSovPrefix })
+      const forwardJson = forwardMessage.toJSON({ useLegacyDidSovPrefix: agentContext.config.useLegacyDidSovPrefix })
 
       // Forward messages are anon packed
-      encryptedMessage = await this.wallet.pack(forwardJson, [routingKeyBase58], undefined)
+      encryptedMessage = await agentContext.wallet.pack(forwardJson, [routingKeyBase58], undefined)
     }
 
     return encryptedMessage
   }
 
-  public async unpackMessage(encryptedMessage: EncryptedMessage): Promise<DecryptedMessageContext> {
-    const decryptedMessage = await this.wallet.unpack(encryptedMessage)
+  public async unpackMessage(
+    agentContext: AgentContext,
+    encryptedMessage: EncryptedMessage
+  ): Promise<DecryptedMessageContext> {
+    const decryptedMessage = await agentContext.wallet.unpack(encryptedMessage)
     const { recipientKey, senderKey, plaintextMessage } = decryptedMessage
     return {
       recipientKey: recipientKey ? Key.fromPublicKeyBase58(recipientKey, KeyType.Ed25519) : undefined,

--- a/packages/core/src/agent/MessageReceiver.ts
+++ b/packages/core/src/agent/MessageReceiver.ts
@@ -1,20 +1,21 @@
-import type { Logger } from '../logger'
 import type { ConnectionRecord } from '../modules/connections'
 import type { InboundTransport } from '../transport'
-import type { PlaintextMessage, EncryptedMessage } from '../types'
+import type { EncryptedMessage, PlaintextMessage } from '../types'
+import type { AgentContext } from './AgentContext'
 import type { AgentMessage } from './AgentMessage'
 import type { DecryptedMessageContext } from './EnvelopeService'
 import type { TransportSession } from './TransportService'
 
+import { InjectionSymbols } from '../constants'
 import { AriesFrameworkError } from '../error'
-import { ConnectionsModule } from '../modules/connections'
+import { Logger } from '../logger'
+import { ConnectionService } from '../modules/connections'
 import { ProblemReportError, ProblemReportMessage, ProblemReportReason } from '../modules/problem-reports'
-import { injectable } from '../plugins'
+import { injectable, inject } from '../plugins'
 import { isValidJweStructure } from '../utils/JWE'
 import { JsonTransformer } from '../utils/JsonTransformer'
 import { canHandleMessageType, parseMessageType, replaceLegacyDidSovPrefixOnMessage } from '../utils/messageType'
 
-import { AgentConfig } from './AgentConfig'
 import { Dispatcher } from './Dispatcher'
 import { EnvelopeService } from './EnvelopeService'
 import { MessageSender } from './MessageSender'
@@ -24,30 +25,28 @@ import { InboundMessageContext } from './models/InboundMessageContext'
 
 @injectable()
 export class MessageReceiver {
-  private config: AgentConfig
   private envelopeService: EnvelopeService
   private transportService: TransportService
   private messageSender: MessageSender
   private dispatcher: Dispatcher
   private logger: Logger
-  private connectionsModule: ConnectionsModule
+  private connectionService: ConnectionService
   public readonly inboundTransports: InboundTransport[] = []
 
   public constructor(
-    config: AgentConfig,
     envelopeService: EnvelopeService,
     transportService: TransportService,
     messageSender: MessageSender,
-    connectionsModule: ConnectionsModule,
-    dispatcher: Dispatcher
+    connectionService: ConnectionService,
+    dispatcher: Dispatcher,
+    @inject(InjectionSymbols.Logger) logger: Logger
   ) {
-    this.config = config
     this.envelopeService = envelopeService
     this.transportService = transportService
     this.messageSender = messageSender
-    this.connectionsModule = connectionsModule
+    this.connectionService = connectionService
     this.dispatcher = dispatcher
-    this.logger = this.config.logger
+    this.logger = logger
   }
 
   public registerInboundTransport(inboundTransport: InboundTransport) {
@@ -61,27 +60,36 @@ export class MessageReceiver {
    * @param inboundMessage the message to receive and handle
    */
   public async receiveMessage(
+    agentContext: AgentContext,
     inboundMessage: unknown,
     { session, connection }: { session?: TransportSession; connection?: ConnectionRecord }
   ) {
-    this.logger.debug(`Agent ${this.config.label} received message`)
+    this.logger.debug(`Agent ${agentContext.config.label} received message`)
     if (this.isEncryptedMessage(inboundMessage)) {
-      await this.receiveEncryptedMessage(inboundMessage as EncryptedMessage, session)
+      await this.receiveEncryptedMessage(agentContext, inboundMessage as EncryptedMessage, session)
     } else if (this.isPlaintextMessage(inboundMessage)) {
-      await this.receivePlaintextMessage(inboundMessage, connection)
+      await this.receivePlaintextMessage(agentContext, inboundMessage, connection)
     } else {
       throw new AriesFrameworkError('Unable to parse incoming message: unrecognized format')
     }
   }
 
-  private async receivePlaintextMessage(plaintextMessage: PlaintextMessage, connection?: ConnectionRecord) {
-    const message = await this.transformAndValidate(plaintextMessage)
-    const messageContext = new InboundMessageContext(message, { connection })
+  private async receivePlaintextMessage(
+    agentContext: AgentContext,
+    plaintextMessage: PlaintextMessage,
+    connection?: ConnectionRecord
+  ) {
+    const message = await this.transformAndValidate(agentContext, plaintextMessage)
+    const messageContext = new InboundMessageContext(message, { connection, agentContext })
     await this.dispatcher.dispatch(messageContext)
   }
 
-  private async receiveEncryptedMessage(encryptedMessage: EncryptedMessage, session?: TransportSession) {
-    const decryptedMessage = await this.decryptMessage(encryptedMessage)
+  private async receiveEncryptedMessage(
+    agentContext: AgentContext,
+    encryptedMessage: EncryptedMessage,
+    session?: TransportSession
+  ) {
+    const decryptedMessage = await this.decryptMessage(agentContext, encryptedMessage)
     const { plaintextMessage, senderKey, recipientKey } = decryptedMessage
 
     this.logger.info(
@@ -89,9 +97,9 @@ export class MessageReceiver {
       plaintextMessage
     )
 
-    const connection = await this.findConnectionByMessageKeys(decryptedMessage)
+    const connection = await this.findConnectionByMessageKeys(agentContext, decryptedMessage)
 
-    const message = await this.transformAndValidate(plaintextMessage, connection)
+    const message = await this.transformAndValidate(agentContext, plaintextMessage, connection)
 
     const messageContext = new InboundMessageContext(message, {
       // Only make the connection available in message context if the connection is ready
@@ -100,6 +108,7 @@ export class MessageReceiver {
       connection: connection?.isReady ? connection : undefined,
       senderKey,
       recipientKey,
+      agentContext,
     })
 
     // We want to save a session if there is a chance of returning outbound message via inbound transport.
@@ -133,9 +142,12 @@ export class MessageReceiver {
    *
    * @param message the received inbound message to decrypt
    */
-  private async decryptMessage(message: EncryptedMessage): Promise<DecryptedMessageContext> {
+  private async decryptMessage(
+    agentContext: AgentContext,
+    message: EncryptedMessage
+  ): Promise<DecryptedMessageContext> {
     try {
-      return await this.envelopeService.unpackMessage(message)
+      return await this.envelopeService.unpackMessage(agentContext, message)
     } catch (error) {
       this.logger.error('Error while decrypting message', {
         error,
@@ -160,6 +172,7 @@ export class MessageReceiver {
   }
 
   private async transformAndValidate(
+    agentContext: AgentContext,
     plaintextMessage: PlaintextMessage,
     connection?: ConnectionRecord | null
   ): Promise<AgentMessage> {
@@ -167,21 +180,21 @@ export class MessageReceiver {
     try {
       message = await this.transformMessage(plaintextMessage)
     } catch (error) {
-      if (connection) await this.sendProblemReportMessage(error.message, connection, plaintextMessage)
+      if (connection) await this.sendProblemReportMessage(agentContext, error.message, connection, plaintextMessage)
       throw error
     }
     return message
   }
 
-  private async findConnectionByMessageKeys({
-    recipientKey,
-    senderKey,
-  }: DecryptedMessageContext): Promise<ConnectionRecord | null> {
+  private async findConnectionByMessageKeys(
+    agentContext: AgentContext,
+    { recipientKey, senderKey }: DecryptedMessageContext
+  ): Promise<ConnectionRecord | null> {
     // We only fetch connections that are sent in AuthCrypt mode
     if (!recipientKey || !senderKey) return null
 
     // Try to find the did records that holds the sender and recipient keys
-    return this.connectionsModule.findByKeys({
+    return this.connectionService.findByKeys(agentContext, {
       senderKey,
       recipientKey,
     })
@@ -228,6 +241,7 @@ export class MessageReceiver {
    * @param plaintextMessage received inbound message
    */
   private async sendProblemReportMessage(
+    agentContext: AgentContext,
     message: string,
     connection: ConnectionRecord,
     plaintextMessage: PlaintextMessage
@@ -247,7 +261,7 @@ export class MessageReceiver {
     })
     const outboundMessage = createOutboundMessage(connection, problemReportMessage)
     if (outboundMessage) {
-      await this.messageSender.sendMessage(outboundMessage)
+      await this.messageSender.sendMessage(agentContext, outboundMessage)
     }
   }
 }

--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -4,6 +4,7 @@ import type { DidDocument } from '../modules/dids'
 import type { OutOfBandRecord } from '../modules/oob/repository'
 import type { OutboundTransport } from '../transport/OutboundTransport'
 import type { OutboundMessage, OutboundPackage, EncryptedMessage } from '../types'
+import type { AgentContext } from './AgentContext'
 import type { AgentMessage } from './AgentMessage'
 import type { EnvelopeKeys } from './EnvelopeService'
 import type { TransportSession } from './TransportService'
@@ -65,16 +66,19 @@ export class MessageSender {
     this.outboundTransports.push(outboundTransport)
   }
 
-  public async packMessage({
-    keys,
-    message,
-    endpoint,
-  }: {
-    keys: EnvelopeKeys
-    message: AgentMessage
-    endpoint: string
-  }): Promise<OutboundPackage> {
-    const encryptedMessage = await this.envelopeService.packMessage(message, keys)
+  public async packMessage(
+    agentContext: AgentContext,
+    {
+      keys,
+      message,
+      endpoint,
+    }: {
+      keys: EnvelopeKeys
+      message: AgentMessage
+      endpoint: string
+    }
+  ): Promise<OutboundPackage> {
+    const encryptedMessage = await this.envelopeService.packMessage(agentContext, message, keys)
 
     return {
       payload: encryptedMessage,
@@ -83,24 +87,27 @@ export class MessageSender {
     }
   }
 
-  private async sendMessageToSession(session: TransportSession, message: AgentMessage) {
+  private async sendMessageToSession(agentContext: AgentContext, session: TransportSession, message: AgentMessage) {
     this.logger.debug(`Existing ${session.type} transport session has been found.`)
     if (!session.keys) {
       throw new AriesFrameworkError(`There are no keys for the given ${session.type} transport session.`)
     }
-    const encryptedMessage = await this.envelopeService.packMessage(message, session.keys)
+    const encryptedMessage = await this.envelopeService.packMessage(agentContext, message, session.keys)
     await session.send(encryptedMessage)
   }
 
-  public async sendPackage({
-    connection,
-    encryptedMessage,
-    options,
-  }: {
-    connection: ConnectionRecord
-    encryptedMessage: EncryptedMessage
-    options?: { transportPriority?: TransportPriorityOptions }
-  }) {
+  public async sendPackage(
+    agentContext: AgentContext,
+    {
+      connection,
+      encryptedMessage,
+      options,
+    }: {
+      connection: ConnectionRecord
+      encryptedMessage: EncryptedMessage
+      options?: { transportPriority?: TransportPriorityOptions }
+    }
+  ) {
     const errors: Error[] = []
 
     // Try to send to already open session
@@ -116,7 +123,11 @@ export class MessageSender {
     }
 
     // Retrieve DIDComm services
-    const { services, queueService } = await this.retrieveServicesByConnection(connection, options?.transportPriority)
+    const { services, queueService } = await this.retrieveServicesByConnection(
+      agentContext,
+      connection,
+      options?.transportPriority
+    )
 
     if (this.outboundTransports.length === 0 && !queueService) {
       throw new AriesFrameworkError('Agent has no outbound transport!')
@@ -167,6 +178,7 @@ export class MessageSender {
   }
 
   public async sendMessage(
+    agentContext: AgentContext,
     outboundMessage: OutboundMessage,
     options?: {
       transportPriority?: TransportPriorityOptions
@@ -193,7 +205,7 @@ export class MessageSender {
     if (session?.inboundMessage?.hasReturnRouting(payload.threadId)) {
       this.logger.debug(`Found session with return routing for message '${payload.id}' (connection '${connection.id}'`)
       try {
-        await this.sendMessageToSession(session, payload)
+        await this.sendMessageToSession(agentContext, session, payload)
         return
       } catch (error) {
         errors.push(error)
@@ -203,6 +215,7 @@ export class MessageSender {
 
     // Retrieve DIDComm services
     const { services, queueService } = await this.retrieveServicesByConnection(
+      agentContext,
       connection,
       options?.transportPriority,
       outOfBand
@@ -215,7 +228,7 @@ export class MessageSender {
       )
     }
 
-    const ourDidDocument = await this.didResolverService.resolveDidDocument(connection.did)
+    const ourDidDocument = await this.didResolverService.resolveDidDocument(agentContext, connection.did)
     const ourAuthenticationKeys = getAuthenticationKeys(ourDidDocument)
 
     // TODO We're selecting just the first authentication key. Is it ok?
@@ -234,7 +247,7 @@ export class MessageSender {
     for await (const service of services) {
       try {
         // Enable return routing if the our did document does not have any inbound endpoint for given sender key
-        await this.sendMessageToService({
+        await this.sendMessageToService(agentContext, {
           message: payload,
           service,
           senderKey: firstOurAuthenticationKey,
@@ -265,7 +278,7 @@ export class MessageSender {
         senderKey: firstOurAuthenticationKey,
       }
 
-      const encryptedMessage = await this.envelopeService.packMessage(payload, keys)
+      const encryptedMessage = await this.envelopeService.packMessage(agentContext, payload, keys)
       this.messageRepository.add(connection.id, encryptedMessage)
       return
     }
@@ -279,19 +292,22 @@ export class MessageSender {
     throw new AriesFrameworkError(`Message is undeliverable to connection ${connection.id} (${connection.theirLabel})`)
   }
 
-  public async sendMessageToService({
-    message,
-    service,
-    senderKey,
-    returnRoute,
-    connectionId,
-  }: {
-    message: AgentMessage
-    service: ResolvedDidCommService
-    senderKey: Key
-    returnRoute?: boolean
-    connectionId?: string
-  }) {
+  public async sendMessageToService(
+    agentContext: AgentContext,
+    {
+      message,
+      service,
+      senderKey,
+      returnRoute,
+      connectionId,
+    }: {
+      message: AgentMessage
+      service: ResolvedDidCommService
+      senderKey: Key
+      returnRoute?: boolean
+      connectionId?: string
+    }
+  ) {
     if (this.outboundTransports.length === 0) {
       throw new AriesFrameworkError('Agent has no outbound transport!')
     }
@@ -326,7 +342,7 @@ export class MessageSender {
       throw error
     }
 
-    const outboundPackage = await this.packMessage({ message, keys, endpoint: service.serviceEndpoint })
+    const outboundPackage = await this.packMessage(agentContext, { message, keys, endpoint: service.serviceEndpoint })
     outboundPackage.endpoint = service.serviceEndpoint
     outboundPackage.connectionId = connectionId
     for (const transport of this.outboundTransports) {
@@ -341,9 +357,9 @@ export class MessageSender {
     throw new AriesFrameworkError(`Unable to send message to service: ${service.serviceEndpoint}`)
   }
 
-  private async retrieveServicesFromDid(did: string) {
+  private async retrieveServicesFromDid(agentContext: AgentContext, did: string) {
     this.logger.debug(`Resolving services for did ${did}.`)
-    const didDocument = await this.didResolverService.resolveDidDocument(did)
+    const didDocument = await this.didResolverService.resolveDidDocument(agentContext, did)
 
     const didCommServices: ResolvedDidCommService[] = []
 
@@ -362,7 +378,7 @@ export class MessageSender {
         // Resolve dids to DIDDocs to retrieve routingKeys
         const routingKeys = []
         for (const routingKey of didCommService.routingKeys ?? []) {
-          const routingDidDocument = await this.didResolverService.resolveDidDocument(routingKey)
+          const routingDidDocument = await this.didResolverService.resolveDidDocument(agentContext, routingKey)
           routingKeys.push(keyReferenceToKey(routingDidDocument, routingKey))
         }
 
@@ -385,6 +401,7 @@ export class MessageSender {
   }
 
   private async retrieveServicesByConnection(
+    agentContext: AgentContext,
     connection: ConnectionRecord,
     transportPriority?: TransportPriorityOptions,
     outOfBand?: OutOfBandRecord
@@ -398,14 +415,14 @@ export class MessageSender {
 
     if (connection.theirDid) {
       this.logger.debug(`Resolving services for connection theirDid ${connection.theirDid}.`)
-      didCommServices = await this.retrieveServicesFromDid(connection.theirDid)
+      didCommServices = await this.retrieveServicesFromDid(agentContext, connection.theirDid)
     } else if (outOfBand) {
       this.logger.debug(`Resolving services from out-of-band record ${outOfBand?.id}.`)
       if (connection.isRequester) {
         for (const service of outOfBand.outOfBandInvitation.services) {
           // Resolve dids to DIDDocs to retrieve services
           if (typeof service === 'string') {
-            didCommServices = await this.retrieveServicesFromDid(service)
+            didCommServices = await this.retrieveServicesFromDid(agentContext, service)
           } else {
             // Out of band inline service contains keys encoded as did:key references
             didCommServices.push({

--- a/packages/core/src/agent/__tests__/Agent.test.ts
+++ b/packages/core/src/agent/__tests__/Agent.test.ts
@@ -1,5 +1,3 @@
-import type { Wallet } from '../../wallet/Wallet'
-
 import { getBaseConfig } from '../../../tests/helpers'
 import { InjectionSymbols } from '../../constants'
 import { BasicMessageRepository, BasicMessageService } from '../../modules/basic-messages'
@@ -23,7 +21,6 @@ import {
 } from '../../modules/routing'
 import { InMemoryMessageRepository } from '../../storage/InMemoryMessageRepository'
 import { IndyStorageService } from '../../storage/IndyStorageService'
-import { IndyWallet } from '../../wallet/IndyWallet'
 import { WalletError } from '../../wallet/error'
 import { Agent } from '../Agent'
 import { Dispatcher } from '../Dispatcher'
@@ -38,7 +35,7 @@ describe('Agent', () => {
     let agent: Agent
 
     afterEach(async () => {
-      const wallet = agent.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
+      const wallet = agent.context.wallet
 
       if (wallet.isInitialized) {
         await wallet.delete()
@@ -59,7 +56,7 @@ describe('Agent', () => {
       expect.assertions(4)
 
       agent = new Agent(config, dependencies)
-      const wallet = agent.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
+      const wallet = agent.context.wallet
 
       expect(agent.isInitialized).toBe(false)
       expect(wallet.isInitialized).toBe(false)
@@ -139,7 +136,6 @@ describe('Agent', () => {
       expect(container.resolve(IndyLedgerService)).toBeInstanceOf(IndyLedgerService)
 
       // Symbols, interface based
-      expect(container.resolve(InjectionSymbols.Wallet)).toBeInstanceOf(IndyWallet)
       expect(container.resolve(InjectionSymbols.Logger)).toBe(config.logger)
       expect(container.resolve(InjectionSymbols.MessageRepository)).toBeInstanceOf(InMemoryMessageRepository)
       expect(container.resolve(InjectionSymbols.StorageService)).toBeInstanceOf(IndyStorageService)
@@ -182,7 +178,6 @@ describe('Agent', () => {
       expect(container.resolve(IndyLedgerService)).toBe(container.resolve(IndyLedgerService))
 
       // Symbols, interface based
-      expect(container.resolve(InjectionSymbols.Wallet)).toBe(container.resolve(InjectionSymbols.Wallet))
       expect(container.resolve(InjectionSymbols.Logger)).toBe(container.resolve(InjectionSymbols.Logger))
       expect(container.resolve(InjectionSymbols.MessageRepository)).toBe(
         container.resolve(InjectionSymbols.MessageRepository)

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,0 +1,1 @@
+export * from './AgentContext'

--- a/packages/core/src/agent/models/InboundMessageContext.ts
+++ b/packages/core/src/agent/models/InboundMessageContext.ts
@@ -1,5 +1,6 @@
 import type { Key } from '../../crypto'
 import type { ConnectionRecord } from '../../modules/connections'
+import type { AgentContext } from '../AgentContext'
 import type { AgentMessage } from '../AgentMessage'
 
 import { AriesFrameworkError } from '../../error'
@@ -9,6 +10,7 @@ export interface MessageContextParams {
   sessionId?: string
   senderKey?: Key
   recipientKey?: Key
+  agentContext: AgentContext
 }
 
 export class InboundMessageContext<T extends AgentMessage = AgentMessage> {
@@ -17,13 +19,15 @@ export class InboundMessageContext<T extends AgentMessage = AgentMessage> {
   public sessionId?: string
   public senderKey?: Key
   public recipientKey?: Key
+  public readonly agentContext: AgentContext
 
-  public constructor(message: T, context: MessageContextParams = {}) {
+  public constructor(message: T, context: MessageContextParams) {
     this.message = message
     this.recipientKey = context.recipientKey
     this.senderKey = context.senderKey
     this.connection = context.connection
     this.sessionId = context.sessionId
+    this.agentContext = context.agentContext
   }
 
   /**

--- a/packages/core/src/cache/__tests__/PersistedLruCache.test.ts
+++ b/packages/core/src/cache/__tests__/PersistedLruCache.test.ts
@@ -1,10 +1,12 @@
-import { mockFunction } from '../../../tests/helpers'
+import { getAgentContext, mockFunction } from '../../../tests/helpers'
 import { CacheRecord } from '../CacheRecord'
 import { CacheRepository } from '../CacheRepository'
 import { PersistedLruCache } from '../PersistedLruCache'
 
 jest.mock('../CacheRepository')
 const CacheRepositoryMock = CacheRepository as jest.Mock<CacheRepository>
+
+const agentContext = getAgentContext()
 
 describe('PersistedLruCache', () => {
   let cacheRepository: CacheRepository
@@ -30,42 +32,42 @@ describe('PersistedLruCache', () => {
       })
     )
 
-    expect(await cache.get('doesnotexist')).toBeUndefined()
-    expect(await cache.get('test')).toBe('somevalue')
-    expect(findMock).toHaveBeenCalledWith('cacheId')
+    expect(await cache.get(agentContext, 'doesnotexist')).toBeUndefined()
+    expect(await cache.get(agentContext, 'test')).toBe('somevalue')
+    expect(findMock).toHaveBeenCalledWith(agentContext, 'cacheId')
   })
 
   it('should set the value in the persisted record', async () => {
     const updateMock = mockFunction(cacheRepository.update).mockResolvedValue()
 
-    await cache.set('test', 'somevalue')
-    const [[cacheRecord]] = updateMock.mock.calls
+    await cache.set(agentContext, 'test', 'somevalue')
+    const [[, cacheRecord]] = updateMock.mock.calls
 
     expect(cacheRecord.entries.length).toBe(1)
     expect(cacheRecord.entries[0].key).toBe('test')
     expect(cacheRecord.entries[0].value).toBe('somevalue')
 
-    expect(await cache.get('test')).toBe('somevalue')
+    expect(await cache.get(agentContext, 'test')).toBe('somevalue')
   })
 
   it('should remove least recently used entries if entries are added that exceed the limit', async () => {
     // Set first value in cache, resolves fine
-    await cache.set('one', 'valueone')
-    expect(await cache.get('one')).toBe('valueone')
+    await cache.set(agentContext, 'one', 'valueone')
+    expect(await cache.get(agentContext, 'one')).toBe('valueone')
 
     // Set two more entries in the cache. Third item
     // exceeds limit, so first item gets removed
-    await cache.set('two', 'valuetwo')
-    await cache.set('three', 'valuethree')
-    expect(await cache.get('one')).toBeUndefined()
-    expect(await cache.get('two')).toBe('valuetwo')
-    expect(await cache.get('three')).toBe('valuethree')
+    await cache.set(agentContext, 'two', 'valuetwo')
+    await cache.set(agentContext, 'three', 'valuethree')
+    expect(await cache.get(agentContext, 'one')).toBeUndefined()
+    expect(await cache.get(agentContext, 'two')).toBe('valuetwo')
+    expect(await cache.get(agentContext, 'three')).toBe('valuethree')
 
     // Get two from the cache, meaning three will be removed first now
     // because it is not recently used
-    await cache.get('two')
-    await cache.set('four', 'valuefour')
-    expect(await cache.get('three')).toBeUndefined()
-    expect(await cache.get('two')).toBe('valuetwo')
+    await cache.get(agentContext, 'two')
+    await cache.set(agentContext, 'four', 'valuefour')
+    expect(await cache.get(agentContext, 'three')).toBeUndefined()
+    expect(await cache.get(agentContext, 'two')).toBe('valuetwo')
   })
 })

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -1,8 +1,11 @@
 export const InjectionSymbols = {
-  Wallet: Symbol('Wallet'),
   MessageRepository: Symbol('MessageRepository'),
   StorageService: Symbol('StorageService'),
   Logger: Symbol('Logger'),
+  AgentDependencies: Symbol('AgentDependencies'),
+  Stop$: Symbol('Stop$'),
+  FileSystem: Symbol('FileSystem'),
+  Wallet: Symbol('Wallet'),
 }
 
 export const DID_COMM_TRANSPORT_QUEUE = 'didcomm:transport/queue'

--- a/packages/core/src/crypto/__tests__/JwsService.test.ts
+++ b/packages/core/src/crypto/__tests__/JwsService.test.ts
@@ -1,6 +1,7 @@
+import type { AgentContext } from '../../agent'
 import type { Wallet } from '@aries-framework/core'
 
-import { getAgentConfig } from '../../../tests/helpers'
+import { getAgentConfig, getAgentContext } from '../../../tests/helpers'
 import { DidKey } from '../../modules/dids'
 import { Buffer, JsonEncoder } from '../../utils'
 import { IndyWallet } from '../../wallet/IndyWallet'
@@ -13,15 +14,19 @@ import * as didJwsz6Mkv from './__fixtures__/didJwsz6Mkv'
 
 describe('JwsService', () => {
   let wallet: Wallet
+  let agentContext: AgentContext
   let jwsService: JwsService
 
   beforeAll(async () => {
     const config = getAgentConfig('JwsService')
-    wallet = new IndyWallet(config)
+    wallet = new IndyWallet(config.agentDependencies, config.logger)
+    agentContext = getAgentContext({
+      wallet,
+    })
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await wallet.createAndOpen(config.walletConfig!)
 
-    jwsService = new JwsService(wallet)
+    jwsService = new JwsService()
   })
 
   afterAll(async () => {
@@ -36,7 +41,7 @@ describe('JwsService', () => {
       const key = Key.fromPublicKeyBase58(verkey, KeyType.Ed25519)
       const kid = new DidKey(key).did
 
-      const jws = await jwsService.createJws({
+      const jws = await jwsService.createJws(agentContext, {
         payload,
         verkey,
         header: { kid },
@@ -50,7 +55,7 @@ describe('JwsService', () => {
     it('returns true if the jws signature matches the payload', async () => {
       const payload = JsonEncoder.toBuffer(didJwsz6Mkf.DATA_JSON)
 
-      const { isValid, signerVerkeys } = await jwsService.verifyJws({
+      const { isValid, signerVerkeys } = await jwsService.verifyJws(agentContext, {
         payload,
         jws: didJwsz6Mkf.JWS_JSON,
       })
@@ -62,7 +67,7 @@ describe('JwsService', () => {
     it('returns all verkeys that signed the jws', async () => {
       const payload = JsonEncoder.toBuffer(didJwsz6Mkf.DATA_JSON)
 
-      const { isValid, signerVerkeys } = await jwsService.verifyJws({
+      const { isValid, signerVerkeys } = await jwsService.verifyJws(agentContext, {
         payload,
         jws: { signatures: [didJwsz6Mkf.JWS_JSON, didJwsz6Mkv.JWS_JSON] },
       })
@@ -74,7 +79,7 @@ describe('JwsService', () => {
     it('returns false if the jws signature does not match the payload', async () => {
       const payload = JsonEncoder.toBuffer({ ...didJwsz6Mkf.DATA_JSON, did: 'another_did' })
 
-      const { isValid, signerVerkeys } = await jwsService.verifyJws({
+      const { isValid, signerVerkeys } = await jwsService.verifyJws(agentContext, {
         payload,
         jws: didJwsz6Mkf.JWS_JSON,
       })
@@ -85,7 +90,7 @@ describe('JwsService', () => {
 
     it('throws an error if the jws signatures array does not contain a JWS', async () => {
       await expect(
-        jwsService.verifyJws({
+        jwsService.verifyJws(agentContext, {
           payload: new Buffer([]),
           jws: { signatures: [] },
         })

--- a/packages/core/src/decorators/signature/SignatureDecoratorUtils.test.ts
+++ b/packages/core/src/decorators/signature/SignatureDecoratorUtils.test.ts
@@ -41,7 +41,7 @@ describe('Decorators | Signature | SignatureDecoratorUtils', () => {
 
   beforeAll(async () => {
     const config = getAgentConfig('SignatureDecoratorUtilsTest')
-    wallet = new IndyWallet(config)
+    wallet = new IndyWallet(config.agentDependencies, config.logger)
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await wallet.createAndOpen(config.walletConfig!)
   })

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 // reflect-metadata used for class-transformer + class-validator
 import 'reflect-metadata'
 
+export { AgentContext } from './agent/AgentContext'
 export { Agent } from './agent/Agent'
 export { EventEmitter } from './agent/EventEmitter'
 export { Handler, HandlerInboundMessage } from './agent/Handler'

--- a/packages/core/src/modules/basic-messages/BasicMessagesModule.ts
+++ b/packages/core/src/modules/basic-messages/BasicMessagesModule.ts
@@ -1,6 +1,7 @@
 import type { DependencyManager } from '../../plugins'
 import type { BasicMessageTags } from './repository/BasicMessageRecord'
 
+import { AgentContext } from '../../agent'
 import { Dispatcher } from '../../agent/Dispatcher'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
@@ -17,29 +18,32 @@ export class BasicMessagesModule {
   private basicMessageService: BasicMessageService
   private messageSender: MessageSender
   private connectionService: ConnectionService
+  private agentContext: AgentContext
 
   public constructor(
     dispatcher: Dispatcher,
     basicMessageService: BasicMessageService,
     messageSender: MessageSender,
-    connectionService: ConnectionService
+    connectionService: ConnectionService,
+    agentContext: AgentContext
   ) {
     this.basicMessageService = basicMessageService
     this.messageSender = messageSender
     this.connectionService = connectionService
+    this.agentContext = agentContext
     this.registerHandlers(dispatcher)
   }
 
   public async sendMessage(connectionId: string, message: string) {
-    const connection = await this.connectionService.getById(connectionId)
+    const connection = await this.connectionService.getById(this.agentContext, connectionId)
 
-    const basicMessage = await this.basicMessageService.createMessage(message, connection)
+    const basicMessage = await this.basicMessageService.createMessage(this.agentContext, message, connection)
     const outboundMessage = createOutboundMessage(connection, basicMessage)
-    await this.messageSender.sendMessage(outboundMessage)
+    await this.messageSender.sendMessage(this.agentContext, outboundMessage)
   }
 
   public async findAllByQuery(query: Partial<BasicMessageTags>) {
-    return this.basicMessageService.findAllByQuery(query)
+    return this.basicMessageService.findAllByQuery(this.agentContext, query)
   }
 
   private registerHandlers(dispatcher: Dispatcher) {

--- a/packages/core/src/modules/basic-messages/__tests__/BasicMessageService.test.ts
+++ b/packages/core/src/modules/basic-messages/__tests__/BasicMessageService.test.ts
@@ -1,66 +1,69 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
-import type { StorageService } from '../../../storage/StorageService'
-import type { BasicMessageStateChangedEvent } from '../BasicMessageEvents'
-
-import { getAgentConfig, getMockConnection } from '../../../../tests/helpers'
+import { getAgentContext, getMockConnection } from '../../../../tests/helpers'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
-import { IndyStorageService } from '../../../storage/IndyStorageService'
-import { Repository } from '../../../storage/Repository'
-import { IndyWallet } from '../../../wallet/IndyWallet'
-import { BasicMessageEventTypes } from '../BasicMessageEvents'
 import { BasicMessageRole } from '../BasicMessageRole'
 import { BasicMessage } from '../messages'
 import { BasicMessageRecord } from '../repository/BasicMessageRecord'
+import { BasicMessageRepository } from '../repository/BasicMessageRepository'
 import { BasicMessageService } from '../services'
 
+jest.mock('../repository/BasicMessageRepository')
+const BasicMessageRepositoryMock = BasicMessageRepository as jest.Mock<BasicMessageRepository>
+const basicMessageRepository = new BasicMessageRepositoryMock()
+
+jest.mock('../../../agent/EventEmitter')
+const EventEmitterMock = EventEmitter as jest.Mock<EventEmitter>
+const eventEmitter = new EventEmitterMock()
+
+const agentContext = getAgentContext()
+
 describe('BasicMessageService', () => {
+  let basicMessageService: BasicMessageService
   const mockConnectionRecord = getMockConnection({
     id: 'd3849ac3-c981-455b-a1aa-a10bea6cead8',
     did: 'did:sov:C2SsBf5QUQpqSAQfhu3sd2',
   })
 
-  let wallet: IndyWallet
-  let storageService: StorageService<BasicMessageRecord>
-  let agentConfig: AgentConfig
-
-  beforeAll(async () => {
-    agentConfig = getAgentConfig('BasicMessageServiceTest')
-    wallet = new IndyWallet(agentConfig)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await wallet.createAndOpen(agentConfig.walletConfig!)
-    storageService = new IndyStorageService(wallet, agentConfig)
+  beforeEach(() => {
+    basicMessageService = new BasicMessageService(basicMessageRepository, eventEmitter)
   })
 
-  afterAll(async () => {
-    await wallet.delete()
+  describe('createMessage', () => {
+    it(`creates message and record, and emits message and basic message record`, async () => {
+      const message = await basicMessageService.createMessage(agentContext, 'hello', mockConnectionRecord)
+
+      expect(message.content).toBe('hello')
+
+      expect(basicMessageRepository.save).toHaveBeenCalledWith(agentContext, expect.any(BasicMessageRecord))
+      expect(eventEmitter.emit).toHaveBeenCalledWith(agentContext, {
+        type: 'BasicMessageStateChanged',
+        payload: {
+          basicMessageRecord: expect.objectContaining({
+            connectionId: mockConnectionRecord.id,
+            id: expect.any(String),
+            sentTime: expect.any(String),
+            content: 'hello',
+            role: BasicMessageRole.Sender,
+          }),
+          message,
+        },
+      })
+    })
   })
 
   describe('save', () => {
-    let basicMessageRepository: Repository<BasicMessageRecord>
-    let basicMessageService: BasicMessageService
-    let eventEmitter: EventEmitter
-
-    beforeEach(() => {
-      eventEmitter = new EventEmitter(agentConfig)
-      basicMessageRepository = new Repository<BasicMessageRecord>(BasicMessageRecord, storageService, eventEmitter)
-      basicMessageService = new BasicMessageService(basicMessageRepository, eventEmitter)
-    })
-
-    it(`emits newMessage with message and basic message record`, async () => {
-      const eventListenerMock = jest.fn()
-      eventEmitter.on<BasicMessageStateChangedEvent>(BasicMessageEventTypes.BasicMessageStateChanged, eventListenerMock)
-
+    it(`stores record and emits message and basic message record`, async () => {
       const basicMessage = new BasicMessage({
         id: '123',
         content: 'message',
       })
 
-      const messageContext = new InboundMessageContext(basicMessage)
+      const messageContext = new InboundMessageContext(basicMessage, { agentContext })
 
       await basicMessageService.save(messageContext, mockConnectionRecord)
 
-      expect(eventListenerMock).toHaveBeenCalledWith({
+      expect(basicMessageRepository.save).toHaveBeenCalledWith(agentContext, expect.any(BasicMessageRecord))
+      expect(eventEmitter.emit).toHaveBeenCalledWith(agentContext, {
         type: 'BasicMessageStateChanged',
         payload: {
           basicMessageRecord: expect.objectContaining({

--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -4,7 +4,7 @@ import type { OutOfBandRecord } from '../oob/repository'
 import type { ConnectionRecord } from './repository/ConnectionRecord'
 import type { Routing } from './services'
 
-import { AgentConfig } from '../../agent/AgentConfig'
+import { AgentContext } from '../../agent'
 import { Dispatcher } from '../../agent/Dispatcher'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
@@ -34,7 +34,6 @@ import { TrustPingService } from './services/TrustPingService'
 @module()
 @injectable()
 export class ConnectionsModule {
-  private agentConfig: AgentConfig
   private didExchangeProtocol: DidExchangeProtocol
   private connectionService: ConnectionService
   private outOfBandService: OutOfBandService
@@ -43,10 +42,10 @@ export class ConnectionsModule {
   private routingService: RoutingService
   private didRepository: DidRepository
   private didResolverService: DidResolverService
+  private agentContext: AgentContext
 
   public constructor(
     dispatcher: Dispatcher,
-    agentConfig: AgentConfig,
     didExchangeProtocol: DidExchangeProtocol,
     connectionService: ConnectionService,
     outOfBandService: OutOfBandService,
@@ -54,9 +53,9 @@ export class ConnectionsModule {
     routingService: RoutingService,
     didRepository: DidRepository,
     didResolverService: DidResolverService,
-    messageSender: MessageSender
+    messageSender: MessageSender,
+    agentContext: AgentContext
   ) {
-    this.agentConfig = agentConfig
     this.didExchangeProtocol = didExchangeProtocol
     this.connectionService = connectionService
     this.outOfBandService = outOfBandService
@@ -65,6 +64,8 @@ export class ConnectionsModule {
     this.didRepository = didRepository
     this.messageSender = messageSender
     this.didResolverService = didResolverService
+    this.agentContext = agentContext
+
     this.registerHandlers(dispatcher)
   }
 
@@ -81,18 +82,20 @@ export class ConnectionsModule {
   ) {
     const { protocol, label, alias, imageUrl, autoAcceptConnection } = config
 
-    const routing = config.routing || (await this.routingService.getRouting({ mediatorId: outOfBandRecord.mediatorId }))
+    const routing =
+      config.routing ||
+      (await this.routingService.getRouting(this.agentContext, { mediatorId: outOfBandRecord.mediatorId }))
 
     let result
     if (protocol === HandshakeProtocol.DidExchange) {
-      result = await this.didExchangeProtocol.createRequest(outOfBandRecord, {
+      result = await this.didExchangeProtocol.createRequest(this.agentContext, outOfBandRecord, {
         label,
         alias,
         routing,
         autoAcceptConnection,
       })
     } else if (protocol === HandshakeProtocol.Connections) {
-      result = await this.connectionService.createRequest(outOfBandRecord, {
+      result = await this.connectionService.createRequest(this.agentContext, outOfBandRecord, {
         label,
         alias,
         imageUrl,
@@ -105,7 +108,7 @@ export class ConnectionsModule {
 
     const { message, connectionRecord } = result
     const outboundMessage = createOutboundMessage(connectionRecord, message, outOfBandRecord)
-    await this.messageSender.sendMessage(outboundMessage)
+    await this.messageSender.sendMessage(this.agentContext, outboundMessage)
     return connectionRecord
   }
 
@@ -117,7 +120,7 @@ export class ConnectionsModule {
    * @returns connection record
    */
   public async acceptRequest(connectionId: string): Promise<ConnectionRecord> {
-    const connectionRecord = await this.connectionService.findById(connectionId)
+    const connectionRecord = await this.connectionService.findById(this.agentContext, connectionId)
     if (!connectionRecord) {
       throw new AriesFrameworkError(`Connection record ${connectionId} not found.`)
     }
@@ -125,21 +128,29 @@ export class ConnectionsModule {
       throw new AriesFrameworkError(`Connection record ${connectionId} does not have out-of-band record.`)
     }
 
-    const outOfBandRecord = await this.outOfBandService.findById(connectionRecord.outOfBandId)
+    const outOfBandRecord = await this.outOfBandService.findById(this.agentContext, connectionRecord.outOfBandId)
     if (!outOfBandRecord) {
       throw new AriesFrameworkError(`Out-of-band record ${connectionRecord.outOfBandId} not found.`)
     }
 
     let outboundMessage
     if (connectionRecord.protocol === HandshakeProtocol.DidExchange) {
-      const message = await this.didExchangeProtocol.createResponse(connectionRecord, outOfBandRecord)
+      const message = await this.didExchangeProtocol.createResponse(
+        this.agentContext,
+        connectionRecord,
+        outOfBandRecord
+      )
       outboundMessage = createOutboundMessage(connectionRecord, message)
     } else {
-      const { message } = await this.connectionService.createResponse(connectionRecord, outOfBandRecord)
+      const { message } = await this.connectionService.createResponse(
+        this.agentContext,
+        connectionRecord,
+        outOfBandRecord
+      )
       outboundMessage = createOutboundMessage(connectionRecord, message)
     }
 
-    await this.messageSender.sendMessage(outboundMessage)
+    await this.messageSender.sendMessage(this.agentContext, outboundMessage)
     return connectionRecord
   }
 
@@ -151,34 +162,38 @@ export class ConnectionsModule {
    * @returns connection record
    */
   public async acceptResponse(connectionId: string): Promise<ConnectionRecord> {
-    const connectionRecord = await this.connectionService.getById(connectionId)
+    const connectionRecord = await this.connectionService.getById(this.agentContext, connectionId)
 
     let outboundMessage
     if (connectionRecord.protocol === HandshakeProtocol.DidExchange) {
       if (!connectionRecord.outOfBandId) {
         throw new AriesFrameworkError(`Connection ${connectionRecord.id} does not have outOfBandId!`)
       }
-      const outOfBandRecord = await this.outOfBandService.findById(connectionRecord.outOfBandId)
+      const outOfBandRecord = await this.outOfBandService.findById(this.agentContext, connectionRecord.outOfBandId)
       if (!outOfBandRecord) {
         throw new AriesFrameworkError(
           `OutOfBand record for connection ${connectionRecord.id} with outOfBandId ${connectionRecord.outOfBandId} not found!`
         )
       }
-      const message = await this.didExchangeProtocol.createComplete(connectionRecord, outOfBandRecord)
+      const message = await this.didExchangeProtocol.createComplete(
+        this.agentContext,
+        connectionRecord,
+        outOfBandRecord
+      )
       outboundMessage = createOutboundMessage(connectionRecord, message)
     } else {
-      const { message } = await this.connectionService.createTrustPing(connectionRecord, {
+      const { message } = await this.connectionService.createTrustPing(this.agentContext, connectionRecord, {
         responseRequested: false,
       })
       outboundMessage = createOutboundMessage(connectionRecord, message)
     }
 
-    await this.messageSender.sendMessage(outboundMessage)
+    await this.messageSender.sendMessage(this.agentContext, outboundMessage)
     return connectionRecord
   }
 
   public async returnWhenIsConnected(connectionId: string, options?: { timeoutMs: number }): Promise<ConnectionRecord> {
-    return this.connectionService.returnWhenIsConnected(connectionId, options?.timeoutMs)
+    return this.connectionService.returnWhenIsConnected(this.agentContext, connectionId, options?.timeoutMs)
   }
 
   /**
@@ -187,7 +202,7 @@ export class ConnectionsModule {
    * @returns List containing all connection records
    */
   public getAll() {
-    return this.connectionService.getAll()
+    return this.connectionService.getAll(this.agentContext)
   }
 
   /**
@@ -199,7 +214,7 @@ export class ConnectionsModule {
    *
    */
   public getById(connectionId: string): Promise<ConnectionRecord> {
-    return this.connectionService.getById(connectionId)
+    return this.connectionService.getById(this.agentContext, connectionId)
   }
 
   /**
@@ -209,7 +224,7 @@ export class ConnectionsModule {
    * @returns The connection record or null if not found
    */
   public findById(connectionId: string): Promise<ConnectionRecord | null> {
-    return this.connectionService.findById(connectionId)
+    return this.connectionService.findById(this.agentContext, connectionId)
   }
 
   /**
@@ -218,31 +233,11 @@ export class ConnectionsModule {
    * @param connectionId the connection record id
    */
   public async deleteById(connectionId: string) {
-    return this.connectionService.deleteById(connectionId)
-  }
-
-  public async findByKeys({ senderKey, recipientKey }: { senderKey: Key; recipientKey: Key }) {
-    const theirDidRecord = await this.didRepository.findByRecipientKey(senderKey)
-    if (theirDidRecord) {
-      const ourDidRecord = await this.didRepository.findByRecipientKey(recipientKey)
-      if (ourDidRecord) {
-        const connectionRecord = await this.connectionService.findSingleByQuery({
-          did: ourDidRecord.id,
-          theirDid: theirDidRecord.id,
-        })
-        if (connectionRecord && connectionRecord.isReady) return connectionRecord
-      }
-    }
-
-    this.agentConfig.logger.debug(
-      `No connection record found for encrypted message with recipient key ${recipientKey.fingerprint} and sender key ${senderKey.fingerprint}`
-    )
-
-    return null
+    return this.connectionService.deleteById(this.agentContext, connectionId)
   }
 
   public async findAllByOutOfBandId(outOfBandId: string) {
-    return this.connectionService.findAllByOutOfBandId(outOfBandId)
+    return this.connectionService.findAllByOutOfBandId(this.agentContext, outOfBandId)
   }
 
   /**
@@ -254,21 +249,20 @@ export class ConnectionsModule {
    * @returns The connection record
    */
   public getByThreadId(threadId: string): Promise<ConnectionRecord> {
-    return this.connectionService.getByThreadId(threadId)
+    return this.connectionService.getByThreadId(this.agentContext, threadId)
   }
 
   public async findByDid(did: string): Promise<ConnectionRecord | null> {
-    return this.connectionService.findByTheirDid(did)
+    return this.connectionService.findByTheirDid(this.agentContext, did)
   }
 
   public async findByInvitationDid(invitationDid: string): Promise<ConnectionRecord[]> {
-    return this.connectionService.findByInvitationDid(invitationDid)
+    return this.connectionService.findByInvitationDid(this.agentContext, invitationDid)
   }
 
   private registerHandlers(dispatcher: Dispatcher) {
     dispatcher.registerHandler(
       new ConnectionRequestHandler(
-        this.agentConfig,
         this.connectionService,
         this.outOfBandService,
         this.routingService,
@@ -276,12 +270,7 @@ export class ConnectionsModule {
       )
     )
     dispatcher.registerHandler(
-      new ConnectionResponseHandler(
-        this.agentConfig,
-        this.connectionService,
-        this.outOfBandService,
-        this.didResolverService
-      )
+      new ConnectionResponseHandler(this.connectionService, this.outOfBandService, this.didResolverService)
     )
     dispatcher.registerHandler(new AckMessageHandler(this.connectionService))
     dispatcher.registerHandler(new TrustPingMessageHandler(this.trustPingService, this.connectionService))
@@ -289,7 +278,6 @@ export class ConnectionsModule {
 
     dispatcher.registerHandler(
       new DidExchangeRequestHandler(
-        this.agentConfig,
         this.didExchangeProtocol,
         this.outOfBandService,
         this.routingService,
@@ -299,7 +287,6 @@ export class ConnectionsModule {
 
     dispatcher.registerHandler(
       new DidExchangeResponseHandler(
-        this.agentConfig,
         this.didExchangeProtocol,
         this.outOfBandService,
         this.connectionService,

--- a/packages/core/src/modules/connections/DidExchangeProtocol.ts
+++ b/packages/core/src/modules/connections/DidExchangeProtocol.ts
@@ -1,18 +1,19 @@
+import type { AgentContext } from '../../agent'
 import type { ResolvedDidCommService } from '../../agent/MessageSender'
 import type { InboundMessageContext } from '../../agent/models/InboundMessageContext'
-import type { Logger } from '../../logger'
 import type { ParsedMessageType } from '../../utils/messageType'
 import type { OutOfBandDidCommService } from '../oob/domain/OutOfBandDidCommService'
 import type { OutOfBandRecord } from '../oob/repository'
 import type { ConnectionRecord } from './repository'
 import type { Routing } from './services/ConnectionService'
 
-import { AgentConfig } from '../../agent/AgentConfig'
+import { InjectionSymbols } from '../../constants'
 import { Key, KeyType } from '../../crypto'
 import { JwsService } from '../../crypto/JwsService'
 import { Attachment, AttachmentData } from '../../decorators/attachment/Attachment'
 import { AriesFrameworkError } from '../../error'
-import { injectable } from '../../plugins'
+import { Logger } from '../../logger'
+import { inject, injectable } from '../../plugins'
 import { JsonEncoder } from '../../utils/JsonEncoder'
 import { JsonTransformer } from '../../utils/JsonTransformer'
 import { DidDocument } from '../dids'
@@ -23,7 +24,7 @@ import { didKeyToInstanceOfKey } from '../dids/helpers'
 import { DidKey } from '../dids/methods/key/DidKey'
 import { getNumAlgoFromPeerDid, PeerDidNumAlgo } from '../dids/methods/peer/didPeer'
 import { didDocumentJsonToNumAlgo1Did } from '../dids/methods/peer/peerDidNumAlgo1'
-import { DidRepository, DidRecord } from '../dids/repository'
+import { DidRecord, DidRepository } from '../dids/repository'
 import { OutOfBandRole } from '../oob/domain/OutOfBandRole'
 import { OutOfBandState } from '../oob/domain/OutOfBandState'
 
@@ -32,7 +33,7 @@ import { DidExchangeProblemReportError, DidExchangeProblemReportReason } from '.
 import { DidExchangeCompleteMessage } from './messages/DidExchangeCompleteMessage'
 import { DidExchangeRequestMessage } from './messages/DidExchangeRequestMessage'
 import { DidExchangeResponseMessage } from './messages/DidExchangeResponseMessage'
-import { HandshakeProtocol, DidExchangeRole, DidExchangeState } from './models'
+import { DidExchangeRole, DidExchangeState, HandshakeProtocol } from './models'
 import { ConnectionService } from './services'
 
 interface DidExchangeRequestParams {
@@ -46,26 +47,25 @@ interface DidExchangeRequestParams {
 
 @injectable()
 export class DidExchangeProtocol {
-  private config: AgentConfig
   private connectionService: ConnectionService
   private jwsService: JwsService
   private didRepository: DidRepository
   private logger: Logger
 
   public constructor(
-    config: AgentConfig,
     connectionService: ConnectionService,
     didRepository: DidRepository,
-    jwsService: JwsService
+    jwsService: JwsService,
+    @inject(InjectionSymbols.Logger) logger: Logger
   ) {
-    this.config = config
     this.connectionService = connectionService
     this.didRepository = didRepository
     this.jwsService = jwsService
-    this.logger = config.logger
+    this.logger = logger
   }
 
   public async createRequest(
+    agentContext: AgentContext,
     outOfBandRecord: OutOfBandRecord,
     params: DidExchangeRequestParams
   ): Promise<{ message: DidExchangeRequestMessage; connectionRecord: ConnectionRecord }> {
@@ -81,7 +81,7 @@ export class DidExchangeProtocol {
     // We take just the first one for now.
     const [invitationDid] = outOfBandInvitation.invitationDids
 
-    const connectionRecord = await this.connectionService.createConnection({
+    const connectionRecord = await this.connectionService.createConnection(agentContext, {
       protocol: HandshakeProtocol.DidExchange,
       role: DidExchangeRole.Requester,
       alias,
@@ -96,15 +96,17 @@ export class DidExchangeProtocol {
     DidExchangeStateMachine.assertCreateMessageState(DidExchangeRequestMessage.type, connectionRecord)
 
     // Create message
-    const label = params.label ?? this.config.label
-    const didDocument = await this.createPeerDidDoc(this.routingToServices(routing))
+    const label = params.label ?? agentContext.config.label
+    const didDocument = await this.createPeerDidDoc(agentContext, this.routingToServices(routing))
     const parentThreadId = outOfBandInvitation.id
 
     const message = new DidExchangeRequestMessage({ label, parentThreadId, did: didDocument.id, goal, goalCode })
 
     // Create sign attachment containing didDoc
     if (getNumAlgoFromPeerDid(didDocument.id) === PeerDidNumAlgo.GenesisDoc) {
-      const didDocAttach = await this.createSignedAttachment(didDocument, [routing.recipientKey.publicKeyBase58])
+      const didDocAttach = await this.createSignedAttachment(agentContext, didDocument, [
+        routing.recipientKey.publicKeyBase58,
+      ])
       message.didDoc = didDocAttach
     }
 
@@ -115,7 +117,7 @@ export class DidExchangeProtocol {
       connectionRecord.autoAcceptConnection = autoAcceptConnection
     }
 
-    await this.updateState(DidExchangeRequestMessage.type, connectionRecord)
+    await this.updateState(agentContext, DidExchangeRequestMessage.type, connectionRecord)
     this.logger.debug(`Create message ${DidExchangeRequestMessage.type.messageTypeUri} end`, {
       connectionRecord,
       message,
@@ -163,7 +165,7 @@ export class DidExchangeProtocol {
       )
     }
 
-    const didDocument = await this.extractDidDocument(message)
+    const didDocument = await this.extractDidDocument(messageContext.agentContext, message)
     const didRecord = new DidRecord({
       id: message.did,
       role: DidDocumentRole.Received,
@@ -184,9 +186,9 @@ export class DidExchangeProtocol {
       didDocument: 'omitted...',
     })
 
-    await this.didRepository.save(didRecord)
+    await this.didRepository.save(messageContext.agentContext, didRecord)
 
-    const connectionRecord = await this.connectionService.createConnection({
+    const connectionRecord = await this.connectionService.createConnection(messageContext.agentContext, {
       protocol: HandshakeProtocol.DidExchange,
       role: DidExchangeRole.Responder,
       state: DidExchangeState.RequestReceived,
@@ -198,12 +200,13 @@ export class DidExchangeProtocol {
       outOfBandId: outOfBandRecord.id,
     })
 
-    await this.updateState(DidExchangeRequestMessage.type, connectionRecord)
+    await this.updateState(messageContext.agentContext, DidExchangeRequestMessage.type, connectionRecord)
     this.logger.debug(`Process message ${DidExchangeRequestMessage.type.messageTypeUri} end`, connectionRecord)
     return connectionRecord
   }
 
   public async createResponse(
+    agentContext: AgentContext,
     connectionRecord: ConnectionRecord,
     outOfBandRecord: OutOfBandRecord,
     routing?: Routing
@@ -233,11 +236,12 @@ export class DidExchangeProtocol {
       }))
     }
 
-    const didDocument = await this.createPeerDidDoc(services)
+    const didDocument = await this.createPeerDidDoc(agentContext, services)
     const message = new DidExchangeResponseMessage({ did: didDocument.id, threadId })
 
     if (getNumAlgoFromPeerDid(didDocument.id) === PeerDidNumAlgo.GenesisDoc) {
       const didDocAttach = await this.createSignedAttachment(
+        agentContext,
         didDocument,
         Array.from(
           new Set(
@@ -253,7 +257,7 @@ export class DidExchangeProtocol {
 
     connectionRecord.did = didDocument.id
 
-    await this.updateState(DidExchangeResponseMessage.type, connectionRecord)
+    await this.updateState(agentContext, DidExchangeResponseMessage.type, connectionRecord)
     this.logger.debug(`Create message ${DidExchangeResponseMessage.type.messageTypeUri} end`, {
       connectionRecord,
       message,
@@ -299,6 +303,7 @@ export class DidExchangeProtocol {
     }
 
     const didDocument = await this.extractDidDocument(
+      messageContext.agentContext,
       message,
       outOfBandRecord.outOfBandInvitation.getRecipientKeys().map((key) => key.publicKeyBase58)
     )
@@ -320,16 +325,17 @@ export class DidExchangeProtocol {
       didDocument: 'omitted...',
     })
 
-    await this.didRepository.save(didRecord)
+    await this.didRepository.save(messageContext.agentContext, didRecord)
 
     connectionRecord.theirDid = message.did
 
-    await this.updateState(DidExchangeResponseMessage.type, connectionRecord)
+    await this.updateState(messageContext.agentContext, DidExchangeResponseMessage.type, connectionRecord)
     this.logger.debug(`Process message ${DidExchangeResponseMessage.type.messageTypeUri} end`, connectionRecord)
     return connectionRecord
   }
 
   public async createComplete(
+    agentContext: AgentContext,
     connectionRecord: ConnectionRecord,
     outOfBandRecord: OutOfBandRecord
   ): Promise<DidExchangeCompleteMessage> {
@@ -351,7 +357,7 @@ export class DidExchangeProtocol {
 
     const message = new DidExchangeCompleteMessage({ threadId, parentThreadId })
 
-    await this.updateState(DidExchangeCompleteMessage.type, connectionRecord)
+    await this.updateState(agentContext, DidExchangeCompleteMessage.type, connectionRecord)
     this.logger.debug(`Create message ${DidExchangeCompleteMessage.type.messageTypeUri} end`, {
       connectionRecord,
       message,
@@ -384,18 +390,22 @@ export class DidExchangeProtocol {
       })
     }
 
-    await this.updateState(DidExchangeCompleteMessage.type, connectionRecord)
+    await this.updateState(messageContext.agentContext, DidExchangeCompleteMessage.type, connectionRecord)
     this.logger.debug(`Process message ${DidExchangeCompleteMessage.type.messageTypeUri} end`, { connectionRecord })
     return connectionRecord
   }
 
-  private async updateState(messageType: ParsedMessageType, connectionRecord: ConnectionRecord) {
+  private async updateState(
+    agentContext: AgentContext,
+    messageType: ParsedMessageType,
+    connectionRecord: ConnectionRecord
+  ) {
     this.logger.debug(`Updating state`, { connectionRecord })
     const nextState = DidExchangeStateMachine.nextState(messageType, connectionRecord)
-    return this.connectionService.updateState(connectionRecord, nextState)
+    return this.connectionService.updateState(agentContext, connectionRecord, nextState)
   }
 
-  private async createPeerDidDoc(services: ResolvedDidCommService[]) {
+  private async createPeerDidDoc(agentContext: AgentContext, services: ResolvedDidCommService[]) {
     const didDocument = createDidDocumentFromServices(services)
 
     const peerDid = didDocumentJsonToNumAlgo1Did(didDocument.toJSON())
@@ -419,12 +429,12 @@ export class DidExchangeProtocol {
       didDocument: 'omitted...',
     })
 
-    await this.didRepository.save(didRecord)
+    await this.didRepository.save(agentContext, didRecord)
     this.logger.debug('Did record created.', didRecord)
     return didDocument
   }
 
-  private async createSignedAttachment(didDoc: DidDocument, verkeys: string[]) {
+  private async createSignedAttachment(agentContext: AgentContext, didDoc: DidDocument, verkeys: string[]) {
     const didDocAttach = new Attachment({
       mimeType: 'application/json',
       data: new AttachmentData({
@@ -438,7 +448,7 @@ export class DidExchangeProtocol {
         const kid = new DidKey(key).did
         const payload = JsonEncoder.toBuffer(didDoc)
 
-        const jws = await this.jwsService.createJws({
+        const jws = await this.jwsService.createJws(agentContext, {
           payload,
           verkey,
           header: {
@@ -460,6 +470,7 @@ export class DidExchangeProtocol {
    * @returns verified DID document content from message attachment
    */
   private async extractDidDocument(
+    agentContext: AgentContext,
     message: DidExchangeRequestMessage | DidExchangeResponseMessage,
     invitationKeysBase58: string[] = []
   ): Promise<DidDocument> {
@@ -485,7 +496,7 @@ export class DidExchangeProtocol {
     this.logger.trace('DidDocument JSON', json)
 
     const payload = JsonEncoder.toBuffer(json)
-    const { isValid, signerVerkeys } = await this.jwsService.verifyJws({ jws, payload })
+    const { isValid, signerVerkeys } = await this.jwsService.verifyJws(agentContext, { jws, payload })
 
     const didDocument = JsonTransformer.fromJSON(json, DidDocument)
     const didDocumentKeysBase58 = didDocument.authentication

--- a/packages/core/src/modules/connections/handlers/ConnectionRequestHandler.ts
+++ b/packages/core/src/modules/connections/handlers/ConnectionRequestHandler.ts
@@ -1,4 +1,3 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { DidRepository } from '../../dids/repository'
 import type { OutOfBandService } from '../../oob/OutOfBandService'
@@ -10,7 +9,6 @@ import { AriesFrameworkError } from '../../../error/AriesFrameworkError'
 import { ConnectionRequestMessage } from '../messages'
 
 export class ConnectionRequestHandler implements Handler {
-  private agentConfig: AgentConfig
   private connectionService: ConnectionService
   private outOfBandService: OutOfBandService
   private routingService: RoutingService
@@ -18,13 +16,11 @@ export class ConnectionRequestHandler implements Handler {
   public supportedMessages = [ConnectionRequestMessage]
 
   public constructor(
-    agentConfig: AgentConfig,
     connectionService: ConnectionService,
     outOfBandService: OutOfBandService,
     routingService: RoutingService,
     didRepository: DidRepository
   ) {
-    this.agentConfig = agentConfig
     this.connectionService = connectionService
     this.outOfBandService = outOfBandService
     this.routingService = routingService
@@ -38,7 +34,7 @@ export class ConnectionRequestHandler implements Handler {
       throw new AriesFrameworkError('Unable to process connection request without senderVerkey or recipientKey')
     }
 
-    const outOfBandRecord = await this.outOfBandService.findByRecipientKey(recipientKey)
+    const outOfBandRecord = await this.outOfBandService.findByRecipientKey(messageContext.agentContext, recipientKey)
 
     if (!outOfBandRecord) {
       throw new AriesFrameworkError(`Out-of-band record for recipient key ${recipientKey.fingerprint} was not found.`)
@@ -50,18 +46,25 @@ export class ConnectionRequestHandler implements Handler {
       )
     }
 
-    const didRecord = await this.didRepository.findByRecipientKey(senderKey)
+    const didRecord = await this.didRepository.findByRecipientKey(messageContext.agentContext, senderKey)
     if (didRecord) {
       throw new AriesFrameworkError(`Did record for sender key ${senderKey.fingerprint} already exists.`)
     }
 
     const connectionRecord = await this.connectionService.processRequest(messageContext, outOfBandRecord)
 
-    if (connectionRecord?.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
+    if (connectionRecord?.autoAcceptConnection ?? messageContext.agentContext.config.autoAcceptConnections) {
       // TODO: Allow rotation of keys used in the invitation for new ones not only when out-of-band is reusable
-      const routing = outOfBandRecord.reusable ? await this.routingService.getRouting() : undefined
+      const routing = outOfBandRecord.reusable
+        ? await this.routingService.getRouting(messageContext.agentContext)
+        : undefined
 
-      const { message } = await this.connectionService.createResponse(connectionRecord, outOfBandRecord, routing)
+      const { message } = await this.connectionService.createResponse(
+        messageContext.agentContext,
+        connectionRecord,
+        outOfBandRecord,
+        routing
+      )
       return createOutboundMessage(connectionRecord, message, outOfBandRecord)
     }
   }

--- a/packages/core/src/modules/connections/handlers/DidExchangeCompleteHandler.ts
+++ b/packages/core/src/modules/connections/handlers/DidExchangeCompleteHandler.ts
@@ -35,14 +35,17 @@ export class DidExchangeCompleteHandler implements Handler {
     if (!message.thread?.parentThreadId) {
       throw new AriesFrameworkError(`Message does not contain pthid attribute`)
     }
-    const outOfBandRecord = await this.outOfBandService.findByInvitationId(message.thread?.parentThreadId)
+    const outOfBandRecord = await this.outOfBandService.findByInvitationId(
+      messageContext.agentContext,
+      message.thread?.parentThreadId
+    )
 
     if (!outOfBandRecord) {
       throw new AriesFrameworkError(`OutOfBand record for message ID ${message.thread?.parentThreadId} not found!`)
     }
 
     if (!outOfBandRecord.reusable) {
-      await this.outOfBandService.updateState(outOfBandRecord, OutOfBandState.Done)
+      await this.outOfBandService.updateState(messageContext.agentContext, outOfBandRecord, OutOfBandState.Done)
     }
     await this.didExchangeProtocol.processComplete(messageContext, outOfBandRecord)
   }

--- a/packages/core/src/modules/connections/handlers/DidExchangeRequestHandler.ts
+++ b/packages/core/src/modules/connections/handlers/DidExchangeRequestHandler.ts
@@ -1,4 +1,3 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { DidRepository } from '../../dids/repository'
 import type { OutOfBandService } from '../../oob/OutOfBandService'
@@ -13,19 +12,16 @@ import { DidExchangeRequestMessage } from '../messages'
 export class DidExchangeRequestHandler implements Handler {
   private didExchangeProtocol: DidExchangeProtocol
   private outOfBandService: OutOfBandService
-  private agentConfig: AgentConfig
   private routingService: RoutingService
   private didRepository: DidRepository
   public supportedMessages = [DidExchangeRequestMessage]
 
   public constructor(
-    agentConfig: AgentConfig,
     didExchangeProtocol: DidExchangeProtocol,
     outOfBandService: OutOfBandService,
     routingService: RoutingService,
     didRepository: DidRepository
   ) {
-    this.agentConfig = agentConfig
     this.didExchangeProtocol = didExchangeProtocol
     this.outOfBandService = outOfBandService
     this.routingService = routingService
@@ -42,7 +38,10 @@ export class DidExchangeRequestHandler implements Handler {
     if (!message.thread?.parentThreadId) {
       throw new AriesFrameworkError(`Message does not contain 'pthid' attribute`)
     }
-    const outOfBandRecord = await this.outOfBandService.findByInvitationId(message.thread.parentThreadId)
+    const outOfBandRecord = await this.outOfBandService.findByInvitationId(
+      messageContext.agentContext,
+      message.thread.parentThreadId
+    )
 
     if (!outOfBandRecord) {
       throw new AriesFrameworkError(`OutOfBand record for message ID ${message.thread?.parentThreadId} not found!`)
@@ -54,7 +53,7 @@ export class DidExchangeRequestHandler implements Handler {
       )
     }
 
-    const didRecord = await this.didRepository.findByRecipientKey(senderKey)
+    const didRecord = await this.didRepository.findByRecipientKey(messageContext.agentContext, senderKey)
     if (didRecord) {
       throw new AriesFrameworkError(`Did record for sender key ${senderKey.fingerprint} already exists.`)
     }
@@ -69,12 +68,19 @@ export class DidExchangeRequestHandler implements Handler {
 
     const connectionRecord = await this.didExchangeProtocol.processRequest(messageContext, outOfBandRecord)
 
-    if (connectionRecord?.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
+    if (connectionRecord?.autoAcceptConnection ?? messageContext.agentContext.config.autoAcceptConnections) {
       // TODO We should add an option to not pass routing and therefore do not rotate keys and use the keys from the invitation
       // TODO: Allow rotation of keys used in the invitation for new ones not only when out-of-band is reusable
-      const routing = outOfBandRecord.reusable ? await this.routingService.getRouting() : undefined
+      const routing = outOfBandRecord.reusable
+        ? await this.routingService.getRouting(messageContext.agentContext)
+        : undefined
 
-      const message = await this.didExchangeProtocol.createResponse(connectionRecord, outOfBandRecord, routing)
+      const message = await this.didExchangeProtocol.createResponse(
+        messageContext.agentContext,
+        connectionRecord,
+        outOfBandRecord,
+        routing
+      )
       return createOutboundMessage(connectionRecord, message, outOfBandRecord)
     }
   }

--- a/packages/core/src/modules/connections/handlers/DidExchangeResponseHandler.ts
+++ b/packages/core/src/modules/connections/handlers/DidExchangeResponseHandler.ts
@@ -1,4 +1,3 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { DidResolverService } from '../../dids'
 import type { OutOfBandService } from '../../oob/OutOfBandService'
@@ -12,7 +11,6 @@ import { DidExchangeResponseMessage } from '../messages'
 import { HandshakeProtocol } from '../models'
 
 export class DidExchangeResponseHandler implements Handler {
-  private agentConfig: AgentConfig
   private didExchangeProtocol: DidExchangeProtocol
   private outOfBandService: OutOfBandService
   private connectionService: ConnectionService
@@ -20,13 +18,11 @@ export class DidExchangeResponseHandler implements Handler {
   public supportedMessages = [DidExchangeResponseMessage]
 
   public constructor(
-    agentConfig: AgentConfig,
     didExchangeProtocol: DidExchangeProtocol,
     outOfBandService: OutOfBandService,
     connectionService: ConnectionService,
     didResolverService: DidResolverService
   ) {
-    this.agentConfig = agentConfig
     this.didExchangeProtocol = didExchangeProtocol
     this.outOfBandService = outOfBandService
     this.connectionService = connectionService
@@ -40,7 +36,7 @@ export class DidExchangeResponseHandler implements Handler {
       throw new AriesFrameworkError('Unable to process connection response without sender key or recipient key')
     }
 
-    const connectionRecord = await this.connectionService.getByThreadId(message.threadId)
+    const connectionRecord = await this.connectionService.getByThreadId(messageContext.agentContext, message.threadId)
     if (!connectionRecord) {
       throw new AriesFrameworkError(`Connection for thread ID ${message.threadId} not found!`)
     }
@@ -49,7 +45,10 @@ export class DidExchangeResponseHandler implements Handler {
       throw new AriesFrameworkError(`Connection record ${connectionRecord.id} has no 'did'`)
     }
 
-    const ourDidDocument = await this.didResolverService.resolveDidDocument(connectionRecord.did)
+    const ourDidDocument = await this.didResolverService.resolveDidDocument(
+      messageContext.agentContext,
+      connectionRecord.did
+    )
     if (!ourDidDocument) {
       throw new AriesFrameworkError(`Did document for did ${connectionRecord.did} was not resolved`)
     }
@@ -73,7 +72,10 @@ export class DidExchangeResponseHandler implements Handler {
       throw new AriesFrameworkError(`Connection ${connectionRecord.id} does not have outOfBandId!`)
     }
 
-    const outOfBandRecord = await this.outOfBandService.findById(connectionRecord.outOfBandId)
+    const outOfBandRecord = await this.outOfBandService.findById(
+      messageContext.agentContext,
+      connectionRecord.outOfBandId
+    )
 
     if (!outOfBandRecord) {
       throw new AriesFrameworkError(
@@ -94,11 +96,15 @@ export class DidExchangeResponseHandler implements Handler {
 
     // TODO: should we only send complete message in case of autoAcceptConnection or always?
     // In AATH we have a separate step to send the complete. So for now we'll only do it
-    // if auto accept is enable
-    if (connection.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
-      const message = await this.didExchangeProtocol.createComplete(connection, outOfBandRecord)
+    // if auto accept is enabled
+    if (connection.autoAcceptConnection ?? messageContext.agentContext.config.autoAcceptConnections) {
+      const message = await this.didExchangeProtocol.createComplete(
+        messageContext.agentContext,
+        connection,
+        outOfBandRecord
+      )
       if (!outOfBandRecord.reusable) {
-        await this.outOfBandService.updateState(outOfBandRecord, OutOfBandState.Done)
+        await this.outOfBandService.updateState(messageContext.agentContext, outOfBandRecord, OutOfBandState.Done)
       }
       return createOutboundMessage(connection, message)
     }

--- a/packages/core/src/modules/connections/handlers/TrustPingMessageHandler.ts
+++ b/packages/core/src/modules/connections/handlers/TrustPingMessageHandler.ts
@@ -25,7 +25,7 @@ export class TrustPingMessageHandler implements Handler {
     // TODO: This is better addressed in a middleware of some kind because
     // any message can transition the state to complete, not just an ack or trust ping
     if (connection.state === DidExchangeState.ResponseSent) {
-      await this.connectionService.updateState(connection, DidExchangeState.Completed)
+      await this.connectionService.updateState(messageContext.agentContext, connection, DidExchangeState.Completed)
     }
 
     return this.trustPingService.processPing(messageContext, connection)

--- a/packages/core/src/modules/connections/repository/ConnectionRepository.ts
+++ b/packages/core/src/modules/connections/repository/ConnectionRepository.ts
@@ -1,6 +1,8 @@
+import type { AgentContext } from '../../../agent'
+
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InjectionSymbols } from '../../../constants'
-import { inject, injectable } from '../../../plugins'
+import { injectable, inject } from '../../../plugins'
 import { Repository } from '../../../storage/Repository'
 import { StorageService } from '../../../storage/StorageService'
 
@@ -15,14 +17,14 @@ export class ConnectionRepository extends Repository<ConnectionRecord> {
     super(ConnectionRecord, storageService, eventEmitter)
   }
 
-  public async findByDids({ ourDid, theirDid }: { ourDid: string; theirDid: string }) {
-    return this.findSingleByQuery({
+  public async findByDids(agentContext: AgentContext, { ourDid, theirDid }: { ourDid: string; theirDid: string }) {
+    return this.findSingleByQuery(agentContext, {
       did: ourDid,
       theirDid,
     })
   }
 
-  public getByThreadId(threadId: string): Promise<ConnectionRecord> {
-    return this.getSingleByQuery({ threadId })
+  public getByThreadId(agentContext: AgentContext, threadId: string): Promise<ConnectionRecord> {
+    return this.getSingleByQuery(agentContext, { threadId })
   }
 }

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -1,6 +1,6 @@
+import type { AgentContext } from '../../../agent'
 import type { AgentMessage } from '../../../agent/AgentMessage'
 import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
-import type { Logger } from '../../../logger'
 import type { AckMessage } from '../../common'
 import type { OutOfBandDidCommService } from '../../oob/domain/OutOfBandDidCommService'
 import type { OutOfBandRecord } from '../../oob/repository'
@@ -11,21 +11,20 @@ import type { ConnectionRecordProps } from '../repository/ConnectionRecord'
 import { firstValueFrom, ReplaySubject } from 'rxjs'
 import { first, map, timeout } from 'rxjs/operators'
 
-import { AgentConfig } from '../../../agent/AgentConfig'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InjectionSymbols } from '../../../constants'
 import { Key } from '../../../crypto'
 import { signData, unpackAndVerifySignatureDecorator } from '../../../decorators/signature/SignatureDecoratorUtils'
 import { AriesFrameworkError } from '../../../error'
+import { Logger } from '../../../logger'
 import { inject, injectable } from '../../../plugins'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
 import { indyDidFromPublicKeyBase58 } from '../../../utils/did'
-import { Wallet } from '../../../wallet/Wallet'
 import { DidKey, IndyAgentService } from '../../dids'
 import { DidDocumentRole } from '../../dids/domain/DidDocumentRole'
 import { didKeyToVerkey } from '../../dids/helpers'
 import { didDocumentJsonToNumAlgo1Did } from '../../dids/methods/peer/peerDidNumAlgo1'
-import { DidRepository, DidRecord } from '../../dids/repository'
+import { DidRecord, DidRepository } from '../../dids/repository'
 import { DidRecordMetadataKeys } from '../../dids/repository/didRecordMetadataTypes'
 import { OutOfBandRole } from '../../oob/domain/OutOfBandRole'
 import { OutOfBandState } from '../../oob/domain/OutOfBandState'
@@ -33,14 +32,14 @@ import { ConnectionEventTypes } from '../ConnectionEvents'
 import { ConnectionProblemReportError, ConnectionProblemReportReason } from '../errors'
 import { ConnectionRequestMessage, ConnectionResponseMessage, TrustPingMessage } from '../messages'
 import {
-  DidExchangeRole,
-  DidExchangeState,
+  authenticationTypes,
   Connection,
   DidDoc,
+  DidExchangeRole,
+  DidExchangeState,
   Ed25119Sig2018,
   HandshakeProtocol,
   ReferencedAuthentication,
-  authenticationTypes,
 } from '../models'
 import { ConnectionRecord } from '../repository/ConnectionRecord'
 import { ConnectionRepository } from '../repository/ConnectionRepository'
@@ -57,26 +56,21 @@ export interface ConnectionRequestParams {
 
 @injectable()
 export class ConnectionService {
-  private wallet: Wallet
-  private config: AgentConfig
   private connectionRepository: ConnectionRepository
   private didRepository: DidRepository
   private eventEmitter: EventEmitter
   private logger: Logger
 
   public constructor(
-    @inject(InjectionSymbols.Wallet) wallet: Wallet,
-    config: AgentConfig,
+    @inject(InjectionSymbols.Logger) logger: Logger,
     connectionRepository: ConnectionRepository,
     didRepository: DidRepository,
     eventEmitter: EventEmitter
   ) {
-    this.wallet = wallet
-    this.config = config
     this.connectionRepository = connectionRepository
     this.didRepository = didRepository
     this.eventEmitter = eventEmitter
-    this.logger = config.logger
+    this.logger = logger
   }
 
   /**
@@ -87,6 +81,7 @@ export class ConnectionService {
    * @returns outbound message containing connection request
    */
   public async createRequest(
+    agentContext: AgentContext,
     outOfBandRecord: OutOfBandRecord,
     config: ConnectionRequestParams
   ): Promise<ConnectionProtocolMsgReturnType<ConnectionRequestMessage>> {
@@ -105,12 +100,12 @@ export class ConnectionService {
     // We take just the first one for now.
     const [invitationDid] = outOfBandInvitation.invitationDids
 
-    const { did: peerDid } = await this.createDid({
+    const { did: peerDid } = await this.createDid(agentContext, {
       role: DidDocumentRole.Created,
       didDoc,
     })
 
-    const connectionRecord = await this.createConnection({
+    const connectionRecord = await this.createConnection(agentContext, {
       protocol: HandshakeProtocol.Connections,
       role: DidExchangeRole.Requester,
       state: DidExchangeState.InvitationReceived,
@@ -127,10 +122,10 @@ export class ConnectionService {
     const { label, imageUrl, autoAcceptConnection } = config
 
     const connectionRequest = new ConnectionRequestMessage({
-      label: label ?? this.config.label,
+      label: label ?? agentContext.config.label,
       did: didDoc.id,
       didDoc,
-      imageUrl: imageUrl ?? this.config.connectionImageUrl,
+      imageUrl: imageUrl ?? agentContext.config.connectionImageUrl,
     })
 
     if (autoAcceptConnection !== undefined || autoAcceptConnection !== null) {
@@ -138,7 +133,7 @@ export class ConnectionService {
     }
 
     connectionRecord.threadId = connectionRequest.id
-    await this.updateState(connectionRecord, DidExchangeState.RequestSent)
+    await this.updateState(agentContext, connectionRecord, DidExchangeState.RequestSent)
 
     return {
       connectionRecord,
@@ -150,7 +145,9 @@ export class ConnectionService {
     messageContext: InboundMessageContext<ConnectionRequestMessage>,
     outOfBandRecord: OutOfBandRecord
   ): Promise<ConnectionRecord> {
-    this.logger.debug(`Process message ${ConnectionRequestMessage.type} start`, messageContext)
+    this.logger.debug(`Process message ${ConnectionRequestMessage.type} start`, {
+      message: messageContext.message,
+    })
     outOfBandRecord.assertRole(OutOfBandRole.Sender)
     outOfBandRecord.assertState(OutOfBandState.AwaitResponse)
 
@@ -163,12 +160,12 @@ export class ConnectionService {
       })
     }
 
-    const { did: peerDid } = await this.createDid({
+    const { did: peerDid } = await this.createDid(messageContext.agentContext, {
       role: DidDocumentRole.Received,
       didDoc: message.connection.didDoc,
     })
 
-    const connectionRecord = await this.createConnection({
+    const connectionRecord = await this.createConnection(messageContext.agentContext, {
       protocol: HandshakeProtocol.Connections,
       role: DidExchangeRole.Responder,
       state: DidExchangeState.RequestReceived,
@@ -181,8 +178,8 @@ export class ConnectionService {
       autoAcceptConnection: outOfBandRecord.autoAcceptConnection,
     })
 
-    await this.connectionRepository.update(connectionRecord)
-    this.emitStateChangedEvent(connectionRecord, null)
+    await this.connectionRepository.update(messageContext.agentContext, connectionRecord)
+    this.emitStateChangedEvent(messageContext.agentContext, connectionRecord, null)
 
     this.logger.debug(`Process message ${ConnectionRequestMessage.type} end`, connectionRecord)
     return connectionRecord
@@ -195,6 +192,7 @@ export class ConnectionService {
    * @returns outbound message containing connection response
    */
   public async createResponse(
+    agentContext: AgentContext,
     connectionRecord: ConnectionRecord,
     outOfBandRecord: OutOfBandRecord,
     routing?: Routing
@@ -211,7 +209,7 @@ export class ConnectionService {
           )
         )
 
-    const { did: peerDid } = await this.createDid({
+    const { did: peerDid } = await this.createDid(agentContext, {
       role: DidDocumentRole.Created,
       didDoc,
     })
@@ -231,11 +229,11 @@ export class ConnectionService {
 
     const connectionResponse = new ConnectionResponseMessage({
       threadId: connectionRecord.threadId,
-      connectionSig: await signData(connectionJson, this.wallet, signingKey),
+      connectionSig: await signData(connectionJson, agentContext.wallet, signingKey),
     })
 
     connectionRecord.did = peerDid
-    await this.updateState(connectionRecord, DidExchangeState.ResponseSent)
+    await this.updateState(agentContext, connectionRecord, DidExchangeState.ResponseSent)
 
     this.logger.debug(`Create message ${ConnectionResponseMessage.type.messageTypeUri} end`, {
       connectionRecord,
@@ -260,7 +258,9 @@ export class ConnectionService {
     messageContext: InboundMessageContext<ConnectionResponseMessage>,
     outOfBandRecord: OutOfBandRecord
   ): Promise<ConnectionRecord> {
-    this.logger.debug(`Process message ${ConnectionResponseMessage.type} start`, messageContext)
+    this.logger.debug(`Process message ${ConnectionResponseMessage.type} start`, {
+      message: messageContext.message,
+    })
     const { connection: connectionRecord, message, recipientKey, senderKey } = messageContext
 
     if (!recipientKey || !senderKey) {
@@ -276,7 +276,10 @@ export class ConnectionService {
 
     let connectionJson = null
     try {
-      connectionJson = await unpackAndVerifySignatureDecorator(message.connectionSig, this.wallet)
+      connectionJson = await unpackAndVerifySignatureDecorator(
+        message.connectionSig,
+        messageContext.agentContext.wallet
+      )
     } catch (error) {
       if (error instanceof AriesFrameworkError) {
         throw new ConnectionProblemReportError(error.message, {
@@ -305,7 +308,7 @@ export class ConnectionService {
       throw new AriesFrameworkError('DID Document is missing.')
     }
 
-    const { did: peerDid } = await this.createDid({
+    const { did: peerDid } = await this.createDid(messageContext.agentContext, {
       role: DidDocumentRole.Received,
       didDoc: connection.didDoc,
     })
@@ -313,7 +316,7 @@ export class ConnectionService {
     connectionRecord.theirDid = peerDid
     connectionRecord.threadId = message.threadId
 
-    await this.updateState(connectionRecord, DidExchangeState.ResponseReceived)
+    await this.updateState(messageContext.agentContext, connectionRecord, DidExchangeState.ResponseReceived)
     return connectionRecord
   }
 
@@ -328,6 +331,7 @@ export class ConnectionService {
    * @returns outbound message containing trust ping message
    */
   public async createTrustPing(
+    agentContext: AgentContext,
     connectionRecord: ConnectionRecord,
     config: { responseRequested?: boolean; comment?: string } = {}
   ): Promise<ConnectionProtocolMsgReturnType<TrustPingMessage>> {
@@ -340,7 +344,7 @@ export class ConnectionService {
 
     // Only update connection record and emit an event if the state is not already 'Complete'
     if (connectionRecord.state !== DidExchangeState.Completed) {
-      await this.updateState(connectionRecord, DidExchangeState.Completed)
+      await this.updateState(agentContext, connectionRecord, DidExchangeState.Completed)
     }
 
     return {
@@ -368,7 +372,7 @@ export class ConnectionService {
     // TODO: This is better addressed in a middleware of some kind because
     // any message can transition the state to complete, not just an ack or trust ping
     if (connection.state === DidExchangeState.ResponseSent && connection.role === DidExchangeRole.Responder) {
-      await this.updateState(connection, DidExchangeState.Completed)
+      await this.updateState(messageContext.agentContext, connection, DidExchangeState.Completed)
     }
 
     return connection
@@ -393,9 +397,9 @@ export class ConnectionService {
     }
 
     let connectionRecord
-    const ourDidRecords = await this.didRepository.findAllByRecipientKey(recipientKey)
+    const ourDidRecords = await this.didRepository.findAllByRecipientKey(messageContext.agentContext, recipientKey)
     for (const ourDidRecord of ourDidRecords) {
-      connectionRecord = await this.findByOurDid(ourDidRecord.id)
+      connectionRecord = await this.findByOurDid(messageContext.agentContext, ourDidRecord.id)
     }
 
     if (!connectionRecord) {
@@ -404,7 +408,9 @@ export class ConnectionService {
       )
     }
 
-    const theirDidRecord = connectionRecord.theirDid && (await this.didRepository.findById(connectionRecord.theirDid))
+    const theirDidRecord =
+      connectionRecord.theirDid &&
+      (await this.didRepository.findById(messageContext.agentContext, connectionRecord.theirDid))
     if (!theirDidRecord) {
       throw new AriesFrameworkError(`Did record with id ${connectionRecord.theirDid} not found.`)
     }
@@ -416,7 +422,7 @@ export class ConnectionService {
     }
 
     connectionRecord.errorMessage = `${connectionProblemReportMessage.description.code} : ${connectionProblemReportMessage.description.en}`
-    await this.update(connectionRecord)
+    await this.update(messageContext.agentContext, connectionRecord)
     return connectionRecord
   }
 
@@ -494,19 +500,23 @@ export class ConnectionService {
     }
   }
 
-  public async updateState(connectionRecord: ConnectionRecord, newState: DidExchangeState) {
+  public async updateState(agentContext: AgentContext, connectionRecord: ConnectionRecord, newState: DidExchangeState) {
     const previousState = connectionRecord.state
     connectionRecord.state = newState
-    await this.connectionRepository.update(connectionRecord)
+    await this.connectionRepository.update(agentContext, connectionRecord)
 
-    this.emitStateChangedEvent(connectionRecord, previousState)
+    this.emitStateChangedEvent(agentContext, connectionRecord, previousState)
   }
 
-  private emitStateChangedEvent(connectionRecord: ConnectionRecord, previousState: DidExchangeState | null) {
+  private emitStateChangedEvent(
+    agentContext: AgentContext,
+    connectionRecord: ConnectionRecord,
+    previousState: DidExchangeState | null
+  ) {
     // Connection record in event should be static
     const clonedConnection = JsonTransformer.clone(connectionRecord)
 
-    this.eventEmitter.emit<ConnectionStateChangedEvent>({
+    this.eventEmitter.emit<ConnectionStateChangedEvent>(agentContext, {
       type: ConnectionEventTypes.ConnectionStateChanged,
       payload: {
         connectionRecord: clonedConnection,
@@ -515,8 +525,8 @@ export class ConnectionService {
     })
   }
 
-  public update(connectionRecord: ConnectionRecord) {
-    return this.connectionRepository.update(connectionRecord)
+  public update(agentContext: AgentContext, connectionRecord: ConnectionRecord) {
+    return this.connectionRepository.update(agentContext, connectionRecord)
   }
 
   /**
@@ -524,8 +534,8 @@ export class ConnectionService {
    *
    * @returns List containing all connection records
    */
-  public getAll() {
-    return this.connectionRepository.getAll()
+  public getAll(agentContext: AgentContext) {
+    return this.connectionRepository.getAll(agentContext)
   }
 
   /**
@@ -536,8 +546,8 @@ export class ConnectionService {
    * @return The connection record
    *
    */
-  public getById(connectionId: string): Promise<ConnectionRecord> {
-    return this.connectionRepository.getById(connectionId)
+  public getById(agentContext: AgentContext, connectionId: string): Promise<ConnectionRecord> {
+    return this.connectionRepository.getById(agentContext, connectionId)
   }
 
   /**
@@ -546,8 +556,8 @@ export class ConnectionService {
    * @param connectionId the connection record id
    * @returns The connection record or null if not found
    */
-  public findById(connectionId: string): Promise<ConnectionRecord | null> {
-    return this.connectionRepository.findById(connectionId)
+  public findById(agentContext: AgentContext, connectionId: string): Promise<ConnectionRecord | null> {
+    return this.connectionRepository.findById(agentContext, connectionId)
   }
 
   /**
@@ -555,13 +565,13 @@ export class ConnectionService {
    *
    * @param connectionId the connection record id
    */
-  public async deleteById(connectionId: string) {
-    const connectionRecord = await this.getById(connectionId)
-    return this.connectionRepository.delete(connectionRecord)
+  public async deleteById(agentContext: AgentContext, connectionId: string) {
+    const connectionRecord = await this.getById(agentContext, connectionId)
+    return this.connectionRepository.delete(agentContext, connectionRecord)
   }
 
-  public async findSingleByQuery(query: { did: string; theirDid: string }) {
-    return this.connectionRepository.findSingleByQuery(query)
+  public async findByDids(agentContext: AgentContext, query: { ourDid: string; theirDid: string }) {
+    return this.connectionRepository.findByDids(agentContext, query)
   }
 
   /**
@@ -572,33 +582,56 @@ export class ConnectionService {
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The connection record
    */
-  public getByThreadId(threadId: string): Promise<ConnectionRecord> {
-    return this.connectionRepository.getByThreadId(threadId)
+  public async getByThreadId(agentContext: AgentContext, threadId: string): Promise<ConnectionRecord> {
+    return this.connectionRepository.getByThreadId(agentContext, threadId)
   }
 
-  public async findByTheirDid(did: string): Promise<ConnectionRecord | null> {
-    return this.connectionRepository.findSingleByQuery({ theirDid: did })
+  public async findByTheirDid(agentContext: AgentContext, theirDid: string): Promise<ConnectionRecord | null> {
+    return this.connectionRepository.findSingleByQuery(agentContext, { theirDid })
   }
 
-  public async findByOurDid(did: string): Promise<ConnectionRecord | null> {
-    return this.connectionRepository.findSingleByQuery({ did })
+  public async findByOurDid(agentContext: AgentContext, ourDid: string): Promise<ConnectionRecord | null> {
+    return this.connectionRepository.findSingleByQuery(agentContext, { did: ourDid })
   }
 
-  public async findAllByOutOfBandId(outOfBandId: string) {
-    return this.connectionRepository.findByQuery({ outOfBandId })
+  public async findAllByOutOfBandId(agentContext: AgentContext, outOfBandId: string) {
+    return this.connectionRepository.findByQuery(agentContext, { outOfBandId })
   }
 
-  public async findByInvitationDid(invitationDid: string) {
-    return this.connectionRepository.findByQuery({ invitationDid })
+  public async findByInvitationDid(agentContext: AgentContext, invitationDid: string) {
+    return this.connectionRepository.findByQuery(agentContext, { invitationDid })
   }
 
-  public async createConnection(options: ConnectionRecordProps): Promise<ConnectionRecord> {
+  public async findByKeys(
+    agentContext: AgentContext,
+    { senderKey, recipientKey }: { senderKey: Key; recipientKey: Key }
+  ) {
+    const theirDidRecord = await this.didRepository.findByRecipientKey(agentContext, senderKey)
+    if (theirDidRecord) {
+      const ourDidRecord = await this.didRepository.findByRecipientKey(agentContext, recipientKey)
+      if (ourDidRecord) {
+        const connectionRecord = await this.findByDids(agentContext, {
+          ourDid: ourDidRecord.id,
+          theirDid: theirDidRecord.id,
+        })
+        if (connectionRecord && connectionRecord.isReady) return connectionRecord
+      }
+    }
+
+    this.logger.debug(
+      `No connection record found for encrypted message with recipient key ${recipientKey.fingerprint} and sender key ${senderKey.fingerprint}`
+    )
+
+    return null
+  }
+
+  public async createConnection(agentContext: AgentContext, options: ConnectionRecordProps): Promise<ConnectionRecord> {
     const connectionRecord = new ConnectionRecord(options)
-    await this.connectionRepository.save(connectionRecord)
+    await this.connectionRepository.save(agentContext, connectionRecord)
     return connectionRecord
   }
 
-  private async createDid({ role, didDoc }: { role: DidDocumentRole; didDoc: DidDoc }) {
+  private async createDid(agentContext: AgentContext, { role, didDoc }: { role: DidDocumentRole; didDoc: DidDoc }) {
     // Convert the legacy did doc to a new did document
     const didDocument = convertToNewDidDocument(didDoc)
 
@@ -629,7 +662,7 @@ export class ConnectionService {
       didDocument: 'omitted...',
     })
 
-    await this.didRepository.save(didRecord)
+    await this.didRepository.save(agentContext, didRecord)
     this.logger.debug('Did record created.', didRecord)
     return { did: peerDid, didDocument }
   }
@@ -700,7 +733,11 @@ export class ConnectionService {
     })
   }
 
-  public async returnWhenIsConnected(connectionId: string, timeoutMs = 20000): Promise<ConnectionRecord> {
+  public async returnWhenIsConnected(
+    agentContext: AgentContext,
+    connectionId: string,
+    timeoutMs = 20000
+  ): Promise<ConnectionRecord> {
     const isConnected = (connection: ConnectionRecord) => {
       return connection.id === connectionId && connection.state === DidExchangeState.Completed
     }
@@ -718,7 +755,7 @@ export class ConnectionService {
       )
       .subscribe(subject)
 
-    const connection = await this.getById(connectionId)
+    const connection = await this.getById(agentContext, connectionId)
     if (isConnected(connection)) {
       subject.next(connection)
     }

--- a/packages/core/src/modules/credentials/formats/CredentialFormatService.ts
+++ b/packages/core/src/modules/credentials/formats/CredentialFormatService.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../agent'
 import type { EventEmitter } from '../../../agent/EventEmitter'
 import type { CredentialRepository } from '../repository'
 import type { CredentialFormat } from './CredentialFormat'
@@ -34,30 +35,48 @@ export abstract class CredentialFormatService<CF extends CredentialFormat = Cred
   abstract readonly credentialRecordType: CF['credentialRecordType']
 
   // proposal methods
-  abstract createProposal(options: FormatCreateProposalOptions<CF>): Promise<FormatCreateProposalReturn>
-  abstract processProposal(options: FormatProcessOptions): Promise<void>
-  abstract acceptProposal(options: FormatAcceptProposalOptions<CF>): Promise<FormatCreateOfferReturn>
+  abstract createProposal(
+    agentContext: AgentContext,
+    options: FormatCreateProposalOptions<CF>
+  ): Promise<FormatCreateProposalReturn>
+  abstract processProposal(agentContext: AgentContext, options: FormatProcessOptions): Promise<void>
+  abstract acceptProposal(
+    agentContext: AgentContext,
+    options: FormatAcceptProposalOptions<CF>
+  ): Promise<FormatCreateOfferReturn>
 
   // offer methods
-  abstract createOffer(options: FormatCreateOfferOptions<CF>): Promise<FormatCreateOfferReturn>
-  abstract processOffer(options: FormatProcessOptions): Promise<void>
-  abstract acceptOffer(options: FormatAcceptOfferOptions<CF>): Promise<FormatCreateReturn>
+  abstract createOffer(
+    agentContext: AgentContext,
+    options: FormatCreateOfferOptions<CF>
+  ): Promise<FormatCreateOfferReturn>
+  abstract processOffer(agentContext: AgentContext, options: FormatProcessOptions): Promise<void>
+  abstract acceptOffer(agentContext: AgentContext, options: FormatAcceptOfferOptions<CF>): Promise<FormatCreateReturn>
 
   // request methods
-  abstract createRequest(options: FormatCreateRequestOptions<CF>): Promise<FormatCreateReturn>
-  abstract processRequest(options: FormatProcessOptions): Promise<void>
-  abstract acceptRequest(options: FormatAcceptRequestOptions<CF>): Promise<FormatCreateReturn>
+  abstract createRequest(
+    agentContext: AgentContext,
+    options: FormatCreateRequestOptions<CF>
+  ): Promise<FormatCreateReturn>
+  abstract processRequest(agentContext: AgentContext, options: FormatProcessOptions): Promise<void>
+  abstract acceptRequest(
+    agentContext: AgentContext,
+    options: FormatAcceptRequestOptions<CF>
+  ): Promise<FormatCreateReturn>
 
   // credential methods
-  abstract processCredential(options: FormatProcessOptions): Promise<void>
+  abstract processCredential(agentContext: AgentContext, options: FormatProcessOptions): Promise<void>
 
   // auto accept methods
-  abstract shouldAutoRespondToProposal(options: FormatAutoRespondProposalOptions): boolean
-  abstract shouldAutoRespondToOffer(options: FormatAutoRespondOfferOptions): boolean
-  abstract shouldAutoRespondToRequest(options: FormatAutoRespondRequestOptions): boolean
-  abstract shouldAutoRespondToCredential(options: FormatAutoRespondCredentialOptions): boolean
+  abstract shouldAutoRespondToProposal(agentContext: AgentContext, options: FormatAutoRespondProposalOptions): boolean
+  abstract shouldAutoRespondToOffer(agentContext: AgentContext, options: FormatAutoRespondOfferOptions): boolean
+  abstract shouldAutoRespondToRequest(agentContext: AgentContext, options: FormatAutoRespondRequestOptions): boolean
+  abstract shouldAutoRespondToCredential(
+    agentContext: AgentContext,
+    options: FormatAutoRespondCredentialOptions
+  ): boolean
 
-  abstract deleteCredentialById(credentialId: string): Promise<void>
+  abstract deleteCredentialById(agentContext: AgentContext, credentialId: string): Promise<void>
 
   abstract supportsFormat(format: string): boolean
 

--- a/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
+++ b/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
@@ -1,36 +1,35 @@
+import type { AgentContext } from '../../../../agent'
 import type { Attachment } from '../../../../decorators/attachment/Attachment'
-import type { Logger } from '../../../../logger'
 import type { LinkedAttachment } from '../../../../utils/LinkedAttachment'
 import type { CredentialPreviewAttributeOptions } from '../../models/CredentialPreviewAttribute'
 import type { CredentialExchangeRecord } from '../../repository/CredentialExchangeRecord'
 import type {
-  FormatAutoRespondCredentialOptions,
   FormatAcceptOfferOptions,
   FormatAcceptProposalOptions,
   FormatAcceptRequestOptions,
+  FormatAutoRespondCredentialOptions,
+  FormatAutoRespondOfferOptions,
+  FormatAutoRespondProposalOptions,
+  FormatAutoRespondRequestOptions,
   FormatCreateOfferOptions,
   FormatCreateOfferReturn,
   FormatCreateProposalOptions,
   FormatCreateProposalReturn,
   FormatCreateReturn,
   FormatProcessOptions,
-  FormatAutoRespondOfferOptions,
-  FormatAutoRespondProposalOptions,
-  FormatAutoRespondRequestOptions,
 } from '../CredentialFormatServiceOptions'
 import type { IndyCredentialFormat } from './IndyCredentialFormat'
 import type * as Indy from 'indy-sdk'
 
-import { AgentConfig } from '../../../../agent/AgentConfig'
 import { EventEmitter } from '../../../../agent/EventEmitter'
 import { InjectionSymbols } from '../../../../constants'
 import { AriesFrameworkError } from '../../../../error'
+import { Logger } from '../../../../logger'
 import { inject, injectable } from '../../../../plugins'
 import { JsonTransformer } from '../../../../utils/JsonTransformer'
 import { MessageValidator } from '../../../../utils/MessageValidator'
 import { getIndyDidFromVerificationMethod } from '../../../../utils/did'
 import { uuid } from '../../../../utils/uuid'
-import { Wallet } from '../../../../wallet/Wallet'
 import { ConnectionService } from '../../../connections'
 import { DidResolverService, findVerificationMethodByKeyType } from '../../../dids'
 import { IndyHolderService, IndyIssuerService } from '../../../indy'
@@ -57,7 +56,6 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
   private indyHolderService: IndyHolderService
   private connectionService: ConnectionService
   private didResolver: DidResolverService
-  private wallet: Wallet
   private logger: Logger
 
   public constructor(
@@ -68,8 +66,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     indyHolderService: IndyHolderService,
     connectionService: ConnectionService,
     didResolver: DidResolverService,
-    agentConfig: AgentConfig,
-    @inject(InjectionSymbols.Wallet) wallet: Wallet
+    @inject(InjectionSymbols.Logger) logger: Logger
   ) {
     super(credentialRepository, eventEmitter)
     this.indyIssuerService = indyIssuerService
@@ -77,8 +74,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     this.indyHolderService = indyHolderService
     this.connectionService = connectionService
     this.didResolver = didResolver
-    this.wallet = wallet
-    this.logger = agentConfig.logger
+    this.logger = logger
   }
 
   public readonly formatKey = 'indy' as const
@@ -91,10 +87,10 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
    * @returns object containing associated attachment, format and optionally the credential preview
    *
    */
-  public async createProposal({
-    credentialFormats,
-    credentialRecord,
-  }: FormatCreateProposalOptions<IndyCredentialFormat>): Promise<FormatCreateProposalReturn> {
+  public async createProposal(
+    agentContext: AgentContext,
+    { credentialFormats, credentialRecord }: FormatCreateProposalOptions<IndyCredentialFormat>
+  ): Promise<FormatCreateProposalReturn> {
     const format = new CredentialFormatSpec({
       format: INDY_CRED_FILTER,
     })
@@ -133,7 +129,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     return { format, attachment, previewAttributes }
   }
 
-  public async processProposal({ attachment }: FormatProcessOptions): Promise<void> {
+  public async processProposal(agentContext: AgentContext, { attachment }: FormatProcessOptions): Promise<void> {
     const credProposalJson = attachment.getDataAsJson()
 
     if (!credProposalJson) {
@@ -144,12 +140,15 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     MessageValidator.validateSync(credProposal)
   }
 
-  public async acceptProposal({
-    attachId,
-    credentialFormats,
-    credentialRecord,
-    proposalAttachment,
-  }: FormatAcceptProposalOptions<IndyCredentialFormat>): Promise<FormatCreateOfferReturn> {
+  public async acceptProposal(
+    agentContext: AgentContext,
+    {
+      attachId,
+      credentialFormats,
+      credentialRecord,
+      proposalAttachment,
+    }: FormatAcceptProposalOptions<IndyCredentialFormat>
+  ): Promise<FormatCreateOfferReturn> {
     const indyFormat = credentialFormats?.indy
 
     const credentialProposal = JsonTransformer.fromJSON(proposalAttachment.getDataAsJson(), IndyCredPropose)
@@ -167,7 +166,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       throw new AriesFrameworkError('No attributes in proposal or provided as input to accept proposal method.')
     }
 
-    const { format, attachment, previewAttributes } = await this.createIndyOffer({
+    const { format, attachment, previewAttributes } = await this.createIndyOffer(agentContext, {
       credentialRecord,
       attachId,
       attributes,
@@ -186,18 +185,17 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
    * @returns object containing associated attachment, formats and offersAttach elements
    *
    */
-  public async createOffer({
-    credentialFormats,
-    credentialRecord,
-    attachId,
-  }: FormatCreateOfferOptions<IndyCredentialFormat>): Promise<FormatCreateOfferReturn> {
+  public async createOffer(
+    agentContext: AgentContext,
+    { credentialFormats, credentialRecord, attachId }: FormatCreateOfferOptions<IndyCredentialFormat>
+  ): Promise<FormatCreateOfferReturn> {
     const indyFormat = credentialFormats.indy
 
     if (!indyFormat) {
       throw new AriesFrameworkError('Missing indy credentialFormat data')
     }
 
-    const { format, attachment, previewAttributes } = await this.createIndyOffer({
+    const { format, attachment, previewAttributes } = await this.createIndyOffer(agentContext, {
       credentialRecord,
       attachId,
       attributes: indyFormat.attributes,
@@ -208,7 +206,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     return { format, attachment, previewAttributes }
   }
 
-  public async processOffer({ attachment, credentialRecord }: FormatProcessOptions) {
+  public async processOffer(agentContext: AgentContext, { attachment, credentialRecord }: FormatProcessOptions) {
     this.logger.debug(`Processing indy credential offer for credential record ${credentialRecord.id}`)
 
     const credOffer = attachment.getDataAsJson<Indy.CredOffer>()
@@ -220,24 +218,28 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     }
   }
 
-  public async acceptOffer({
-    credentialFormats,
-    credentialRecord,
-    attachId,
-    offerAttachment,
-  }: FormatAcceptOfferOptions<IndyCredentialFormat>): Promise<FormatCreateReturn> {
+  public async acceptOffer(
+    agentContext: AgentContext,
+    { credentialFormats, credentialRecord, attachId, offerAttachment }: FormatAcceptOfferOptions<IndyCredentialFormat>
+  ): Promise<FormatCreateReturn> {
     const indyFormat = credentialFormats?.indy
 
-    const holderDid = indyFormat?.holderDid ?? (await this.getIndyHolderDid(credentialRecord))
+    const holderDid = indyFormat?.holderDid ?? (await this.getIndyHolderDid(agentContext, credentialRecord))
 
     const credentialOffer = offerAttachment.getDataAsJson<Indy.CredOffer>()
-    const credentialDefinition = await this.indyLedgerService.getCredentialDefinition(credentialOffer.cred_def_id)
+    const credentialDefinition = await this.indyLedgerService.getCredentialDefinition(
+      agentContext,
+      credentialOffer.cred_def_id
+    )
 
-    const [credentialRequest, credentialRequestMetadata] = await this.indyHolderService.createCredentialRequest({
-      holderDid,
-      credentialOffer,
-      credentialDefinition,
-    })
+    const [credentialRequest, credentialRequestMetadata] = await this.indyHolderService.createCredentialRequest(
+      agentContext,
+      {
+        holderDid,
+        credentialOffer,
+        credentialDefinition,
+      }
+    )
     credentialRecord.metadata.set(CredentialMetadataKeys.IndyRequest, credentialRequestMetadata)
     credentialRecord.metadata.set(CredentialMetadataKeys.IndyCredential, {
       credentialDefinitionId: credentialOffer.cred_def_id,
@@ -264,16 +266,14 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
    * We don't have any models to validate an indy request object, for now this method does nothing
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public async processRequest(options: FormatProcessOptions): Promise<void> {
+  public async processRequest(agentContext: AgentContext, options: FormatProcessOptions): Promise<void> {
     // not needed for Indy
   }
 
-  public async acceptRequest({
-    credentialRecord,
-    attachId,
-    offerAttachment,
-    requestAttachment,
-  }: FormatAcceptRequestOptions<IndyCredentialFormat>): Promise<FormatCreateReturn> {
+  public async acceptRequest(
+    agentContext: AgentContext,
+    { credentialRecord, attachId, offerAttachment, requestAttachment }: FormatAcceptRequestOptions<IndyCredentialFormat>
+  ): Promise<FormatCreateReturn> {
     // Assert credential attributes
     const credentialAttributes = credentialRecord.credentialAttributes
     if (!credentialAttributes) {
@@ -290,7 +290,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       throw new AriesFrameworkError('Missing indy credential offer or credential request in createCredential')
     }
 
-    const [credential, credentialRevocationId] = await this.indyIssuerService.createCredential({
+    const [credential, credentialRevocationId] = await this.indyIssuerService.createCredential(agentContext, {
       credentialOffer,
       credentialRequest,
       credentialValues: IndyCredentialUtils.convertAttributesToValues(credentialAttributes),
@@ -317,7 +317,10 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
    * @param options the issue credential message wrapped inside this object
    * @param credentialRecord the credential exchange record for this credential
    */
-  public async processCredential({ credentialRecord, attachment }: FormatProcessOptions): Promise<void> {
+  public async processCredential(
+    agentContext: AgentContext,
+    { credentialRecord, attachment }: FormatProcessOptions
+  ): Promise<void> {
     const credentialRequestMetadata = credentialRecord.metadata.get(CredentialMetadataKeys.IndyRequest)
 
     if (!credentialRequestMetadata) {
@@ -328,9 +331,12 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     }
 
     const indyCredential = attachment.getDataAsJson<Indy.Cred>()
-    const credentialDefinition = await this.indyLedgerService.getCredentialDefinition(indyCredential.cred_def_id)
+    const credentialDefinition = await this.indyLedgerService.getCredentialDefinition(
+      agentContext,
+      indyCredential.cred_def_id
+    )
     const revocationRegistry = indyCredential.rev_reg_id
-      ? await this.indyLedgerService.getRevocationRegistryDefinition(indyCredential.rev_reg_id)
+      ? await this.indyLedgerService.getRevocationRegistryDefinition(agentContext, indyCredential.rev_reg_id)
       : null
 
     if (!credentialRecord.credentialAttributes) {
@@ -343,7 +349,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     const recordCredentialValues = IndyCredentialUtils.convertAttributesToValues(credentialRecord.credentialAttributes)
     IndyCredentialUtils.assertValuesMatch(indyCredential.values, recordCredentialValues)
 
-    const credentialId = await this.indyHolderService.storeCredential({
+    const credentialId = await this.indyHolderService.storeCredential(agentContext, {
       credentialId: uuid(),
       credentialRequestMetadata,
       credential: indyCredential,
@@ -353,7 +359,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
 
     // If the credential is revocable, store the revocation identifiers in the credential record
     if (indyCredential.rev_reg_id) {
-      const credential = await this.indyHolderService.getCredential(credentialId)
+      const credential = await this.indyHolderService.getCredential(agentContext, credentialId)
 
       credentialRecord.metadata.add(CredentialMetadataKeys.IndyCredential, {
         indyCredentialRevocationId: credential.cred_rev_id,
@@ -390,11 +396,14 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     return supportedAttachments[0]
   }
 
-  public async deleteCredentialById(credentialRecordId: string): Promise<void> {
-    await this.indyHolderService.deleteCredential(credentialRecordId)
+  public async deleteCredentialById(agentContext: AgentContext, credentialRecordId: string): Promise<void> {
+    await this.indyHolderService.deleteCredential(agentContext, credentialRecordId)
   }
 
-  public shouldAutoRespondToProposal({ offerAttachment, proposalAttachment }: FormatAutoRespondProposalOptions) {
+  public shouldAutoRespondToProposal(
+    agentContext: AgentContext,
+    { offerAttachment, proposalAttachment }: FormatAutoRespondProposalOptions
+  ) {
     const credentialProposalJson = proposalAttachment.getDataAsJson()
     const credentialProposal = JsonTransformer.fromJSON(credentialProposalJson, IndyCredPropose)
 
@@ -406,7 +415,10 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     return credentialProposal.credentialDefinitionId === credentialOfferJson.cred_def_id
   }
 
-  public shouldAutoRespondToOffer({ offerAttachment, proposalAttachment }: FormatAutoRespondOfferOptions) {
+  public shouldAutoRespondToOffer(
+    agentContext: AgentContext,
+    { offerAttachment, proposalAttachment }: FormatAutoRespondOfferOptions
+  ) {
     const credentialProposalJson = proposalAttachment.getDataAsJson()
     const credentialProposal = JsonTransformer.fromJSON(credentialProposalJson, IndyCredPropose)
 
@@ -418,18 +430,20 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     return credentialProposal.credentialDefinitionId === credentialOfferJson.cred_def_id
   }
 
-  public shouldAutoRespondToRequest({ offerAttachment, requestAttachment }: FormatAutoRespondRequestOptions) {
+  public shouldAutoRespondToRequest(
+    agentContext: AgentContext,
+    { offerAttachment, requestAttachment }: FormatAutoRespondRequestOptions
+  ) {
     const credentialOfferJson = offerAttachment.getDataAsJson<Indy.CredOffer>()
     const credentialRequestJson = requestAttachment.getDataAsJson<Indy.CredReq>()
 
     return credentialOfferJson.cred_def_id == credentialRequestJson.cred_def_id
   }
 
-  public shouldAutoRespondToCredential({
-    credentialRecord,
-    requestAttachment,
-    credentialAttachment,
-  }: FormatAutoRespondCredentialOptions) {
+  public shouldAutoRespondToCredential(
+    agentContext: AgentContext,
+    { credentialRecord, requestAttachment, credentialAttachment }: FormatAutoRespondCredentialOptions
+  ) {
     const credentialJson = credentialAttachment.getDataAsJson<Indy.Cred>()
     const credentialRequestJson = requestAttachment.getDataAsJson<Indy.CredReq>()
 
@@ -444,33 +458,36 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     return IndyCredentialUtils.checkValuesMatch(attributeValues, credentialJson.values)
   }
 
-  private async createIndyOffer({
-    credentialRecord,
-    attachId,
-    credentialDefinitionId,
-    attributes,
-    linkedAttachments,
-  }: {
-    credentialDefinitionId: string
-    credentialRecord: CredentialExchangeRecord
-    attachId?: string
-    attributes: CredentialPreviewAttributeOptions[]
-    linkedAttachments?: LinkedAttachment[]
-  }): Promise<FormatCreateOfferReturn> {
+  private async createIndyOffer(
+    agentContext: AgentContext,
+    {
+      credentialRecord,
+      attachId,
+      credentialDefinitionId,
+      attributes,
+      linkedAttachments,
+    }: {
+      credentialDefinitionId: string
+      credentialRecord: CredentialExchangeRecord
+      attachId?: string
+      attributes: CredentialPreviewAttributeOptions[]
+      linkedAttachments?: LinkedAttachment[]
+    }
+  ): Promise<FormatCreateOfferReturn> {
     // if the proposal has an attachment Id use that, otherwise the generated id of the formats object
     const format = new CredentialFormatSpec({
       attachId: attachId,
       format: INDY_CRED_ABSTRACT,
     })
 
-    const offer = await this.indyIssuerService.createCredentialOffer(credentialDefinitionId)
+    const offer = await this.indyIssuerService.createCredentialOffer(agentContext, credentialDefinitionId)
 
     const { previewAttributes } = this.getCredentialLinkedAttachments(attributes, linkedAttachments)
     if (!previewAttributes) {
       throw new AriesFrameworkError('Missing required preview attributes for indy offer')
     }
 
-    await this.assertPreviewAttributesMatchSchemaAttributes(offer, previewAttributes)
+    await this.assertPreviewAttributesMatchSchemaAttributes(agentContext, offer, previewAttributes)
 
     credentialRecord.metadata.set(CredentialMetadataKeys.IndyCredential, {
       schemaId: offer.schema_id,
@@ -483,22 +500,23 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
   }
 
   private async assertPreviewAttributesMatchSchemaAttributes(
+    agentContext: AgentContext,
     offer: Indy.CredOffer,
     attributes: CredentialPreviewAttribute[]
   ): Promise<void> {
-    const schema = await this.indyLedgerService.getSchema(offer.schema_id)
+    const schema = await this.indyLedgerService.getSchema(agentContext, offer.schema_id)
 
     IndyCredentialUtils.checkAttributesMatch(schema, attributes)
   }
 
-  private async getIndyHolderDid(credentialRecord: CredentialExchangeRecord) {
+  private async getIndyHolderDid(agentContext: AgentContext, credentialRecord: CredentialExchangeRecord) {
     // If we have a connection id we try to extract the did from the connection did document.
     if (credentialRecord.connectionId) {
-      const connection = await this.connectionService.getById(credentialRecord.connectionId)
+      const connection = await this.connectionService.getById(agentContext, credentialRecord.connectionId)
       if (!connection.did) {
         throw new AriesFrameworkError(`Connection record ${connection.id} has no 'did'`)
       }
-      const resolved = await this.didResolver.resolve(connection.did)
+      const resolved = await this.didResolver.resolve(agentContext, connection.did)
 
       if (resolved.didDocument) {
         const verificationMethod = await findVerificationMethodByKeyType(
@@ -515,7 +533,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
     // If it wasn't successful to extract the did from the connection, we'll create a new key (e.g. if using connection-less)
     // FIXME: we already create a did for the exchange when using connection-less, but this is on a higher level. We should look at
     // a way to reuse this key, but for now this is easier.
-    const { did } = await this.wallet.createDid()
+    const { did } = await agentContext.wallet.createDid()
 
     return did
   }

--- a/packages/core/src/modules/credentials/protocol/revocation-notification/handlers/V1RevocationNotificationHandler.ts
+++ b/packages/core/src/modules/credentials/protocol/revocation-notification/handlers/V1RevocationNotificationHandler.ts
@@ -1,5 +1,5 @@
 import type { Handler, HandlerInboundMessage } from '../../../../../agent/Handler'
-import type { RevocationNotificationService } from '../../../services'
+import type { RevocationNotificationService } from '../services'
 
 import { V1RevocationNotificationMessage } from '../messages/V1RevocationNotificationMessage'
 

--- a/packages/core/src/modules/credentials/protocol/revocation-notification/handlers/V2RevocationNotificationHandler.ts
+++ b/packages/core/src/modules/credentials/protocol/revocation-notification/handlers/V2RevocationNotificationHandler.ts
@@ -1,5 +1,5 @@
 import type { Handler, HandlerInboundMessage } from '../../../../../agent/Handler'
-import type { RevocationNotificationService } from '../../../services'
+import type { RevocationNotificationService } from '../services'
 
 import { V2RevocationNotificationMessage } from '../messages/V2RevocationNotificationMessage'
 

--- a/packages/core/src/modules/credentials/protocol/revocation-notification/services/__tests__/RevocationNotificationService.test.ts
+++ b/packages/core/src/modules/credentials/protocol/revocation-notification/services/__tests__/RevocationNotificationService.test.ts
@@ -1,7 +1,10 @@
+import type { AgentContext } from '../../../../../../agent'
 import type { RevocationNotificationReceivedEvent } from '../../../../CredentialEvents'
 
+import { Subject } from 'rxjs'
+
 import { CredentialExchangeRecord, CredentialState, InboundMessageContext } from '../../../../../..'
-import { getAgentConfig, getMockConnection, mockFunction } from '../../../../../../../tests/helpers'
+import { getAgentConfig, getAgentContext, getMockConnection, mockFunction } from '../../../../../../../tests/helpers'
 import { Dispatcher } from '../../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../../agent/EventEmitter'
 import { DidExchangeState } from '../../../../../connections'
@@ -25,6 +28,7 @@ const connection = getMockConnection({
 
 describe('RevocationNotificationService', () => {
   let revocationNotificationService: RevocationNotificationService
+  let agentContext: AgentContext
   let eventEmitter: EventEmitter
 
   beforeEach(() => {
@@ -32,12 +36,14 @@ describe('RevocationNotificationService', () => {
       indyLedgers: [],
     })
 
-    eventEmitter = new EventEmitter(agentConfig)
+    agentContext = getAgentContext()
+
+    eventEmitter = new EventEmitter(agentConfig.agentDependencies, new Subject())
     revocationNotificationService = new RevocationNotificationService(
       credentialRepository,
       eventEmitter,
-      agentConfig,
-      dispatcher
+      dispatcher,
+      agentConfig.logger
     )
   })
 
@@ -82,6 +88,7 @@ describe('RevocationNotificationService', () => {
       })
       const messageContext = new InboundMessageContext(revocationNotificationMessage, {
         connection,
+        agentContext,
       })
 
       await revocationNotificationService.v1ProcessRevocationNotification(messageContext)
@@ -123,7 +130,7 @@ describe('RevocationNotificationService', () => {
         issueThread: revocationNotificationThreadId,
         comment: 'Credential has been revoked',
       })
-      const messageContext = new InboundMessageContext(revocationNotificationMessage, { connection })
+      const messageContext = new InboundMessageContext(revocationNotificationMessage, { connection, agentContext })
 
       await revocationNotificationService.v1ProcessRevocationNotification(messageContext)
 
@@ -143,7 +150,7 @@ describe('RevocationNotificationService', () => {
         issueThread: revocationNotificationThreadId,
         comment: 'Credential has been revoked',
       })
-      const messageContext = new InboundMessageContext(revocationNotificationMessage)
+      const messageContext = new InboundMessageContext(revocationNotificationMessage, { agentContext })
 
       await revocationNotificationService.v1ProcessRevocationNotification(messageContext)
 
@@ -187,9 +194,7 @@ describe('RevocationNotificationService', () => {
         revocationFormat: 'indy-anoncreds',
         comment: 'Credential has been revoked',
       })
-      const messageContext = new InboundMessageContext(revocationNotificationMessage, {
-        connection,
-      })
+      const messageContext = new InboundMessageContext(revocationNotificationMessage, { agentContext, connection })
 
       await revocationNotificationService.v2ProcessRevocationNotification(messageContext)
 
@@ -231,7 +236,7 @@ describe('RevocationNotificationService', () => {
         revocationFormat: 'indy-anoncreds',
         comment: 'Credential has been revoked',
       })
-      const messageContext = new InboundMessageContext(revocationNotificationMessage, { connection })
+      const messageContext = new InboundMessageContext(revocationNotificationMessage, { connection, agentContext })
 
       await revocationNotificationService.v2ProcessRevocationNotification(messageContext)
 
@@ -252,7 +257,7 @@ describe('RevocationNotificationService', () => {
         revocationFormat: 'indy-anoncreds',
         comment: 'Credential has been revoked',
       })
-      const messageContext = new InboundMessageContext(revocationNotificationMessage)
+      const messageContext = new InboundMessageContext(revocationNotificationMessage, { agentContext })
 
       await revocationNotificationService.v2ProcessRevocationNotification(messageContext)
 

--- a/packages/core/src/modules/credentials/protocol/v1/V1CredentialService.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/V1CredentialService.ts
@@ -1,5 +1,5 @@
+import type { AgentContext } from '../../../../agent'
 import type { AgentMessage } from '../../../../agent/AgentMessage'
-import type { HandlerInboundMessage } from '../../../../agent/Handler'
 import type { InboundMessageContext } from '../../../../agent/models/InboundMessageContext'
 import type { ProblemReportMessage } from '../../../problem-reports'
 import type {
@@ -18,12 +18,13 @@ import type { GetFormatDataReturn } from '../../CredentialsModuleOptions'
 import type { CredentialFormat } from '../../formats'
 import type { IndyCredentialFormat } from '../../formats/indy/IndyCredentialFormat'
 
-import { AgentConfig } from '../../../../agent/AgentConfig'
 import { Dispatcher } from '../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../agent/EventEmitter'
+import { InjectionSymbols } from '../../../../constants'
 import { Attachment, AttachmentData } from '../../../../decorators/attachment/Attachment'
 import { AriesFrameworkError } from '../../../../error'
-import { injectable } from '../../../../plugins'
+import { Logger } from '../../../../logger'
+import { inject, injectable } from '../../../../plugins'
 import { DidCommMessageRepository, DidCommMessageRole } from '../../../../storage'
 import { JsonTransformer } from '../../../../utils'
 import { isLinkedAttachment } from '../../../../utils/attachment'
@@ -36,7 +37,7 @@ import { IndyCredentialFormatService } from '../../formats/indy/IndyCredentialFo
 import { IndyCredPropose } from '../../formats/indy/models'
 import { AutoAcceptCredential } from '../../models/CredentialAutoAcceptType'
 import { CredentialState } from '../../models/CredentialState'
-import { CredentialRepository, CredentialExchangeRecord } from '../../repository'
+import { CredentialExchangeRecord, CredentialRepository } from '../../repository'
 import { CredentialService } from '../../services'
 import { composeAutoAccept } from '../../util/composeAutoAccept'
 import { arePreviewAttributesEqual } from '../../util/previewAttributes'
@@ -71,17 +72,16 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
   public constructor(
     connectionService: ConnectionService,
     didCommMessageRepository: DidCommMessageRepository,
-    agentConfig: AgentConfig,
+    @inject(InjectionSymbols.Logger) logger: Logger,
     routingService: RoutingService,
     dispatcher: Dispatcher,
     eventEmitter: EventEmitter,
     credentialRepository: CredentialRepository,
     formatService: IndyCredentialFormatService
   ) {
-    super(credentialRepository, didCommMessageRepository, eventEmitter, dispatcher, agentConfig)
+    super(credentialRepository, didCommMessageRepository, eventEmitter, dispatcher, logger)
     this.connectionService = connectionService
     this.formatService = formatService
-    this.didCommMessageRepository = didCommMessageRepository
     this.routingService = routingService
 
     this.registerHandlers()
@@ -110,12 +110,10 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @returns Object containing proposal message and associated credential record
    *
    */
-  public async createProposal({
-    connection,
-    credentialFormats,
-    comment,
-    autoAcceptCredential,
-  }: CreateProposalOptions<[IndyCredentialFormat]>): Promise<CredentialProtocolMsgReturnType<AgentMessage>> {
+  public async createProposal(
+    agentContext: AgentContext,
+    { connection, credentialFormats, comment, autoAcceptCredential }: CreateProposalOptions<[IndyCredentialFormat]>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>> {
     this.assertOnlyIndyFormat(credentialFormats)
 
     if (!credentialFormats.indy) {
@@ -137,7 +135,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     })
 
     // call create proposal for validation of the proposal and addition of linked attachments
-    const { previewAttributes, attachment } = await this.formatService.createProposal({
+    const { previewAttributes, attachment } = await this.formatService.createProposal(agentContext, {
       credentialFormats,
       credentialRecord,
     })
@@ -159,15 +157,15 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       comment,
     })
 
-    await this.didCommMessageRepository.saveAgentMessage({
+    await this.didCommMessageRepository.saveAgentMessage(agentContext, {
       agentMessage: message,
       role: DidCommMessageRole.Sender,
       associatedRecordId: credentialRecord.id,
     })
 
     credentialRecord.credentialAttributes = previewAttributes
-    await this.credentialRepository.save(credentialRecord)
-    this.emitStateChangedEvent(credentialRecord, null)
+    await this.credentialRepository.save(agentContext, credentialRecord)
+    this.emitStateChangedEvent(agentContext, credentialRecord, null)
 
     return { credentialRecord, message }
   }
@@ -189,7 +187,11 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     this.logger.debug(`Processing credential proposal with message id ${proposalMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(proposalMessage.threadId, connection?.id)
+    let credentialRecord = await this.findByThreadAndConnectionId(
+      messageContext.agentContext,
+      proposalMessage.threadId,
+      connection?.id
+    )
 
     // Credential record already exists, this is a response to an earlier message sent by us
     if (credentialRecord) {
@@ -199,11 +201,14 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       credentialRecord.assertProtocolVersion('v1')
       credentialRecord.assertState(CredentialState.OfferSent)
 
-      const proposalCredentialMessage = await this.didCommMessageRepository.findAgentMessage({
-        associatedRecordId: credentialRecord.id,
-        messageClass: V1ProposeCredentialMessage,
-      })
-      const offerCredentialMessage = await this.didCommMessageRepository.findAgentMessage({
+      const proposalCredentialMessage = await this.didCommMessageRepository.findAgentMessage(
+        messageContext.agentContext,
+        {
+          associatedRecordId: credentialRecord.id,
+          messageClass: V1ProposeCredentialMessage,
+        }
+      )
+      const offerCredentialMessage = await this.didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V1OfferCredentialMessage,
       })
@@ -213,7 +218,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
         previousSentMessage: offerCredentialMessage ?? undefined,
       })
 
-      await this.formatService.processProposal({
+      await this.formatService.processProposal(messageContext.agentContext, {
         credentialRecord,
         attachment: new Attachment({
           data: new AttachmentData({
@@ -223,8 +228,8 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       })
 
       // Update record
-      await this.updateState(credentialRecord, CredentialState.ProposalReceived)
-      await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+      await this.updateState(messageContext.agentContext, credentialRecord, CredentialState.ProposalReceived)
+      await this.didCommMessageRepository.saveOrUpdateAgentMessage(messageContext.agentContext, {
         agentMessage: proposalMessage,
         role: DidCommMessageRole.Receiver,
         associatedRecordId: credentialRecord.id,
@@ -244,10 +249,10 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       this.connectionService.assertConnectionOrServiceDecorator(messageContext)
 
       // Save record
-      await this.credentialRepository.save(credentialRecord)
-      this.emitStateChangedEvent(credentialRecord, null)
+      await this.credentialRepository.save(messageContext.agentContext, credentialRecord)
+      this.emitStateChangedEvent(messageContext.agentContext, credentialRecord, null)
 
-      await this.didCommMessageRepository.saveAgentMessage({
+      await this.didCommMessageRepository.saveAgentMessage(messageContext.agentContext, {
         agentMessage: proposalMessage,
         role: DidCommMessageRole.Receiver,
         associatedRecordId: credentialRecord.id,
@@ -261,20 +266,21 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @param options The object containing config options
    * @returns Object containing proposal message and associated credential record
    */
-  public async acceptProposal({
-    credentialRecord,
-    credentialFormats,
-    comment,
-    autoAcceptCredential,
-  }: AcceptProposalOptions<[IndyCredentialFormat]>): Promise<
-    CredentialProtocolMsgReturnType<V1OfferCredentialMessage>
-  > {
+  public async acceptProposal(
+    agentContext: AgentContext,
+    {
+      credentialRecord,
+      credentialFormats,
+      comment,
+      autoAcceptCredential,
+    }: AcceptProposalOptions<[IndyCredentialFormat]>
+  ): Promise<CredentialProtocolMsgReturnType<V1OfferCredentialMessage>> {
     // Assert
     credentialRecord.assertProtocolVersion('v1')
     credentialRecord.assertState(CredentialState.ProposalReceived)
     if (credentialFormats) this.assertOnlyIndyFormat(credentialFormats)
 
-    const proposalMessage = await this.didCommMessageRepository.getAgentMessage({
+    const proposalMessage = await this.didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1ProposeCredentialMessage,
     })
@@ -284,7 +290,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     // if the user provided other attributes in the credentialFormats array.
     credentialRecord.credentialAttributes = proposalMessage.credentialPreview?.attributes
 
-    const { attachment, previewAttributes } = await this.formatService.acceptProposal({
+    const { attachment, previewAttributes } = await this.formatService.acceptProposal(agentContext, {
       attachId: INDY_CREDENTIAL_OFFER_ATTACHMENT_ID,
       credentialFormats,
       credentialRecord,
@@ -312,9 +318,9 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     credentialRecord.credentialAttributes = previewAttributes
     credentialRecord.autoAcceptCredential = autoAcceptCredential ?? credentialRecord.autoAcceptCredential
-    await this.updateState(credentialRecord, CredentialState.OfferSent)
+    await this.updateState(agentContext, credentialRecord, CredentialState.OfferSent)
 
-    await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+    await this.didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
       role: DidCommMessageRole.Sender,
       associatedRecordId: credentialRecord.id,
@@ -331,20 +337,21 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @returns Credential record associated with the credential offer and the corresponding new offer message
    *
    */
-  public async negotiateProposal({
-    credentialFormats,
-    credentialRecord,
-    comment,
-    autoAcceptCredential,
-  }: NegotiateProposalOptions<[IndyCredentialFormat]>): Promise<
-    CredentialProtocolMsgReturnType<V1OfferCredentialMessage>
-  > {
+  public async negotiateProposal(
+    agentContext: AgentContext,
+    {
+      credentialFormats,
+      credentialRecord,
+      comment,
+      autoAcceptCredential,
+    }: NegotiateProposalOptions<[IndyCredentialFormat]>
+  ): Promise<CredentialProtocolMsgReturnType<V1OfferCredentialMessage>> {
     // Assert
     credentialRecord.assertProtocolVersion('v1')
     credentialRecord.assertState(CredentialState.ProposalReceived)
     if (credentialFormats) this.assertOnlyIndyFormat(credentialFormats)
 
-    const { attachment, previewAttributes } = await this.formatService.createOffer({
+    const { attachment, previewAttributes } = await this.formatService.createOffer(agentContext, {
       attachId: INDY_CREDENTIAL_OFFER_ATTACHMENT_ID,
       credentialFormats,
       credentialRecord,
@@ -366,9 +373,9 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     credentialRecord.credentialAttributes = previewAttributes
     credentialRecord.autoAcceptCredential = autoAcceptCredential ?? credentialRecord.autoAcceptCredential
-    await this.updateState(credentialRecord, CredentialState.OfferSent)
+    await this.updateState(agentContext, credentialRecord, CredentialState.OfferSent)
 
-    await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+    await this.didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
       role: DidCommMessageRole.Sender,
       associatedRecordId: credentialRecord.id,
@@ -385,12 +392,10 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @returns Object containing offer message and associated credential record
    *
    */
-  public async createOffer({
-    credentialFormats,
-    autoAcceptCredential,
-    comment,
-    connection,
-  }: CreateOfferOptions<[IndyCredentialFormat]>): Promise<CredentialProtocolMsgReturnType<V1OfferCredentialMessage>> {
+  public async createOffer(
+    agentContext: AgentContext,
+    { credentialFormats, autoAcceptCredential, comment, connection }: CreateOfferOptions<[IndyCredentialFormat]>
+  ): Promise<CredentialProtocolMsgReturnType<V1OfferCredentialMessage>> {
     // Assert
     if (credentialFormats) this.assertOnlyIndyFormat(credentialFormats)
 
@@ -410,7 +415,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       protocolVersion: 'v1',
     })
 
-    const { attachment, previewAttributes } = await this.formatService.createOffer({
+    const { attachment, previewAttributes } = await this.formatService.createOffer(agentContext, {
       attachId: INDY_CREDENTIAL_OFFER_ATTACHMENT_ID,
       credentialFormats,
       credentialRecord,
@@ -431,15 +436,15 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       attachments: credentialFormats.indy.linkedAttachments?.map((linkedAttachments) => linkedAttachments.attachment),
     })
 
-    await this.didCommMessageRepository.saveAgentMessage({
+    await this.didCommMessageRepository.saveAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       agentMessage: message,
       role: DidCommMessageRole.Sender,
     })
 
     credentialRecord.credentialAttributes = previewAttributes
-    await this.credentialRepository.save(credentialRecord)
-    this.emitStateChangedEvent(credentialRecord, null)
+    await this.credentialRepository.save(agentContext, credentialRecord)
+    this.emitStateChangedEvent(agentContext, credentialRecord, null)
 
     return { message, credentialRecord }
   }
@@ -455,13 +460,17 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    *
    */
   public async processOffer(
-    messageContext: HandlerInboundMessage<V1OfferCredentialHandler>
+    messageContext: InboundMessageContext<V1OfferCredentialMessage>
   ): Promise<CredentialExchangeRecord> {
     const { message: offerMessage, connection } = messageContext
 
     this.logger.debug(`Processing credential offer with id ${offerMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(offerMessage.threadId, connection?.id)
+    let credentialRecord = await this.findByThreadAndConnectionId(
+      messageContext.agentContext,
+      offerMessage.threadId,
+      connection?.id
+    )
 
     const offerAttachment = offerMessage.getOfferAttachmentById(INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
     if (!offerAttachment) {
@@ -471,11 +480,14 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     }
 
     if (credentialRecord) {
-      const proposalCredentialMessage = await this.didCommMessageRepository.findAgentMessage({
-        associatedRecordId: credentialRecord.id,
-        messageClass: V1ProposeCredentialMessage,
-      })
-      const offerCredentialMessage = await this.didCommMessageRepository.findAgentMessage({
+      const proposalCredentialMessage = await this.didCommMessageRepository.findAgentMessage(
+        messageContext.agentContext,
+        {
+          associatedRecordId: credentialRecord.id,
+          messageClass: V1ProposeCredentialMessage,
+        }
+      )
+      const offerCredentialMessage = await this.didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
         associatedRecordId: credentialRecord.id,
         messageClass: V1OfferCredentialMessage,
       })
@@ -488,17 +500,17 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
         previousSentMessage: proposalCredentialMessage ?? undefined,
       })
 
-      await this.formatService.processOffer({
+      await this.formatService.processOffer(messageContext.agentContext, {
         credentialRecord,
         attachment: offerAttachment,
       })
 
-      await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+      await this.didCommMessageRepository.saveOrUpdateAgentMessage(messageContext.agentContext, {
         agentMessage: offerMessage,
         role: DidCommMessageRole.Receiver,
         associatedRecordId: credentialRecord.id,
       })
-      await this.updateState(credentialRecord, CredentialState.OfferReceived)
+      await this.updateState(messageContext.agentContext, credentialRecord, CredentialState.OfferReceived)
 
       return credentialRecord
     } else {
@@ -513,19 +525,19 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       // Assert
       this.connectionService.assertConnectionOrServiceDecorator(messageContext)
 
-      await this.formatService.processOffer({
+      await this.formatService.processOffer(messageContext.agentContext, {
         credentialRecord,
         attachment: offerAttachment,
       })
 
       // Save in repository
-      await this.didCommMessageRepository.saveAgentMessage({
+      await this.didCommMessageRepository.saveAgentMessage(messageContext.agentContext, {
         agentMessage: offerMessage,
         role: DidCommMessageRole.Receiver,
         associatedRecordId: credentialRecord.id,
       })
-      await this.credentialRepository.save(credentialRecord)
-      this.emitStateChangedEvent(credentialRecord, null)
+      await this.credentialRepository.save(messageContext.agentContext, credentialRecord)
+      this.emitStateChangedEvent(messageContext.agentContext, credentialRecord, null)
 
       return credentialRecord
     }
@@ -538,17 +550,15 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @returns Object containing request message and associated credential record
    *
    */
-  public async acceptOffer({
-    credentialRecord,
-    credentialFormats,
-    comment,
-    autoAcceptCredential,
-  }: AcceptOfferOptions<[IndyCredentialFormat]>): Promise<CredentialProtocolMsgReturnType<V1RequestCredentialMessage>> {
+  public async acceptOffer(
+    agentContext: AgentContext,
+    { credentialRecord, credentialFormats, comment, autoAcceptCredential }: AcceptOfferOptions<[IndyCredentialFormat]>
+  ): Promise<CredentialProtocolMsgReturnType<V1RequestCredentialMessage>> {
     // Assert credential
     credentialRecord.assertProtocolVersion('v1')
     credentialRecord.assertState(CredentialState.OfferReceived)
 
-    const offerMessage = await this.didCommMessageRepository.getAgentMessage({
+    const offerMessage = await this.didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1OfferCredentialMessage,
     })
@@ -560,7 +570,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       )
     }
 
-    const { attachment } = await this.formatService.acceptOffer({
+    const { attachment } = await this.formatService.acceptOffer(agentContext, {
       credentialRecord,
       credentialFormats,
       attachId: INDY_CREDENTIAL_REQUEST_ATTACHMENT_ID,
@@ -580,12 +590,12 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       isLinkedAttachment(attachment)
     )
 
-    await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+    await this.didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: requestMessage,
       associatedRecordId: credentialRecord.id,
       role: DidCommMessageRole.Sender,
     })
-    await this.updateState(credentialRecord, CredentialState.RequestSent)
+    await this.updateState(agentContext, credentialRecord, CredentialState.RequestSent)
 
     return { message: requestMessage, credentialRecord }
   }
@@ -600,12 +610,15 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @returns credential record associated with the credential request message
    *
    */
-  public async negotiateOffer({
-    credentialFormats,
-    credentialRecord,
-    autoAcceptCredential,
-    comment,
-  }: NegotiateOfferOptions<[IndyCredentialFormat]>): Promise<CredentialProtocolMsgReturnType<AgentMessage>> {
+  public async negotiateOffer(
+    agentContext: AgentContext,
+    {
+      credentialFormats,
+      credentialRecord,
+      autoAcceptCredential,
+      comment,
+    }: NegotiateOfferOptions<[IndyCredentialFormat]>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>> {
     // Assert
     credentialRecord.assertProtocolVersion('v1')
     credentialRecord.assertState(CredentialState.OfferReceived)
@@ -624,7 +637,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     // call create proposal for validation of the proposal and addition of linked attachments
     // As the format is different for v1 of the issue credential protocol we won't be using the attachment
-    const { previewAttributes, attachment } = await this.formatService.createProposal({
+    const { previewAttributes, attachment } = await this.formatService.createProposal(agentContext, {
       credentialFormats,
       credentialRecord,
     })
@@ -647,7 +660,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     message.setThread({ threadId: credentialRecord.threadId })
 
-    await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+    await this.didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
       role: DidCommMessageRole.Sender,
       associatedRecordId: credentialRecord.id,
@@ -657,7 +670,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     credentialRecord.credentialAttributes = previewAttributes
     credentialRecord.linkedAttachments = linkedAttachments?.map((attachment) => attachment.attachment)
     credentialRecord.autoAcceptCredential = autoAcceptCredential ?? credentialRecord.autoAcceptCredential
-    await this.updateState(credentialRecord, CredentialState.ProposalSent)
+    await this.updateState(agentContext, credentialRecord, CredentialState.ProposalSent)
 
     return { credentialRecord, message }
   }
@@ -688,14 +701,18 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     this.logger.debug(`Processing credential request with id ${requestMessage.id}`)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(requestMessage.threadId, connection?.id)
+    const credentialRecord = await this.getByThreadAndConnectionId(
+      messageContext.agentContext,
+      requestMessage.threadId,
+      connection?.id
+    )
     this.logger.trace('Credential record found when processing credential request', credentialRecord)
 
-    const proposalMessage = await this.didCommMessageRepository.findAgentMessage({
+    const proposalMessage = await this.didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1ProposeCredentialMessage,
     })
-    const offerMessage = await this.didCommMessageRepository.findAgentMessage({
+    const offerMessage = await this.didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1OfferCredentialMessage,
     })
@@ -716,18 +733,18 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       )
     }
 
-    await this.formatService.processRequest({
+    await this.formatService.processRequest(messageContext.agentContext, {
       credentialRecord,
       attachment: requestAttachment,
     })
 
-    await this.didCommMessageRepository.saveAgentMessage({
+    await this.didCommMessageRepository.saveAgentMessage(messageContext.agentContext, {
       agentMessage: requestMessage,
       role: DidCommMessageRole.Receiver,
       associatedRecordId: credentialRecord.id,
     })
 
-    await this.updateState(credentialRecord, CredentialState.RequestReceived)
+    await this.updateState(messageContext.agentContext, credentialRecord, CredentialState.RequestReceived)
 
     return credentialRecord
   }
@@ -738,21 +755,19 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @returns Object containing issue credential message and associated credential record
    *
    */
-  public async acceptRequest({
-    credentialRecord,
-    credentialFormats,
-    comment,
-    autoAcceptCredential,
-  }: AcceptRequestOptions<[IndyCredentialFormat]>): Promise<CredentialProtocolMsgReturnType<V1IssueCredentialMessage>> {
+  public async acceptRequest(
+    agentContext: AgentContext,
+    { credentialRecord, credentialFormats, comment, autoAcceptCredential }: AcceptRequestOptions<[IndyCredentialFormat]>
+  ): Promise<CredentialProtocolMsgReturnType<V1IssueCredentialMessage>> {
     // Assert
     credentialRecord.assertProtocolVersion('v1')
     credentialRecord.assertState(CredentialState.RequestReceived)
 
-    const offerMessage = await this.didCommMessageRepository.getAgentMessage({
+    const offerMessage = await this.didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1OfferCredentialMessage,
     })
-    const requestMessage = await this.didCommMessageRepository.getAgentMessage({
+    const requestMessage = await this.didCommMessageRepository.getAgentMessage(agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1RequestCredentialMessage,
     })
@@ -766,7 +781,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       )
     }
 
-    const { attachment: credentialsAttach } = await this.formatService.acceptRequest({
+    const { attachment: credentialsAttach } = await this.formatService.acceptRequest(agentContext, {
       credentialRecord,
       requestAttachment,
       offerAttachment,
@@ -783,14 +798,14 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     issueMessage.setThread({ threadId: credentialRecord.threadId })
     issueMessage.setPleaseAck()
 
-    await this.didCommMessageRepository.saveAgentMessage({
+    await this.didCommMessageRepository.saveAgentMessage(agentContext, {
       agentMessage: issueMessage,
       associatedRecordId: credentialRecord.id,
       role: DidCommMessageRole.Sender,
     })
 
     credentialRecord.autoAcceptCredential = autoAcceptCredential ?? credentialRecord.autoAcceptCredential
-    await this.updateState(credentialRecord, CredentialState.CredentialIssued)
+    await this.updateState(agentContext, credentialRecord, CredentialState.CredentialIssued)
 
     return { message: issueMessage, credentialRecord }
   }
@@ -809,13 +824,17 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     this.logger.debug(`Processing credential with id ${issueMessage.id}`)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(issueMessage.threadId, connection?.id)
+    const credentialRecord = await this.getByThreadAndConnectionId(
+      messageContext.agentContext,
+      issueMessage.threadId,
+      connection?.id
+    )
 
-    const requestCredentialMessage = await this.didCommMessageRepository.findAgentMessage({
+    const requestCredentialMessage = await this.didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1RequestCredentialMessage,
     })
-    const offerCredentialMessage = await this.didCommMessageRepository.findAgentMessage({
+    const offerCredentialMessage = await this.didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1OfferCredentialMessage,
     })
@@ -833,18 +852,18 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       throw new AriesFrameworkError('Missing indy credential attachment in processCredential')
     }
 
-    await this.formatService.processCredential({
+    await this.formatService.processCredential(messageContext.agentContext, {
       attachment: issueAttachment,
       credentialRecord,
     })
 
-    await this.didCommMessageRepository.saveAgentMessage({
+    await this.didCommMessageRepository.saveAgentMessage(messageContext.agentContext, {
       agentMessage: issueMessage,
       role: DidCommMessageRole.Receiver,
       associatedRecordId: credentialRecord.id,
     })
 
-    await this.updateState(credentialRecord, CredentialState.CredentialReceived)
+    await this.updateState(messageContext.agentContext, credentialRecord, CredentialState.CredentialReceived)
 
     return credentialRecord
   }
@@ -856,9 +875,10 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @returns Object containing credential acknowledgement message and associated credential record
    *
    */
-  public async acceptCredential({
-    credentialRecord,
-  }: AcceptCredentialOptions): Promise<CredentialProtocolMsgReturnType<V1CredentialAckMessage>> {
+  public async acceptCredential(
+    agentContext: AgentContext,
+    { credentialRecord }: AcceptCredentialOptions
+  ): Promise<CredentialProtocolMsgReturnType<V1CredentialAckMessage>> {
     credentialRecord.assertProtocolVersion('v1')
     credentialRecord.assertState(CredentialState.CredentialReceived)
 
@@ -868,7 +888,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
       threadId: credentialRecord.threadId,
     })
 
-    await this.updateState(credentialRecord, CredentialState.Done)
+    await this.updateState(agentContext, credentialRecord, CredentialState.Done)
 
     return { message: ackMessage, credentialRecord }
   }
@@ -887,13 +907,17 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     this.logger.debug(`Processing credential ack with id ${ackMessage.id}`)
 
-    const credentialRecord = await this.getByThreadAndConnectionId(ackMessage.threadId, connection?.id)
+    const credentialRecord = await this.getByThreadAndConnectionId(
+      messageContext.agentContext,
+      ackMessage.threadId,
+      connection?.id
+    )
 
-    const requestCredentialMessage = await this.didCommMessageRepository.getAgentMessage({
+    const requestCredentialMessage = await this.didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1RequestCredentialMessage,
     })
-    const issueCredentialMessage = await this.didCommMessageRepository.getAgentMessage({
+    const issueCredentialMessage = await this.didCommMessageRepository.getAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V1IssueCredentialMessage,
     })
@@ -907,7 +931,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     })
 
     // Update record
-    await this.updateState(credentialRecord, CredentialState.Done)
+    await this.updateState(messageContext.agentContext, credentialRecord, CredentialState.Done)
 
     return credentialRecord
   }
@@ -919,7 +943,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
    * @returns a {@link V1CredentialProblemReportMessage}
    *
    */
-  public createProblemReport(options: CreateProblemReportOptions): ProblemReportMessage {
+  public createProblemReport(agentContext: AgentContext, options: CreateProblemReportOptions): ProblemReportMessage {
     return new V1CredentialProblemReportMessage({
       description: {
         en: options.message,
@@ -929,18 +953,24 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
   }
 
   // AUTO RESPOND METHODS
-  public async shouldAutoRespondToProposal(options: {
-    credentialRecord: CredentialExchangeRecord
-    proposalMessage: V1ProposeCredentialMessage
-  }): Promise<boolean> {
+  public async shouldAutoRespondToProposal(
+    agentContext: AgentContext,
+    options: {
+      credentialRecord: CredentialExchangeRecord
+      proposalMessage: V1ProposeCredentialMessage
+    }
+  ): Promise<boolean> {
     const { credentialRecord, proposalMessage } = options
-    const autoAccept = composeAutoAccept(credentialRecord.autoAcceptCredential, this.agentConfig.autoAcceptCredentials)
+    const autoAccept = composeAutoAccept(
+      credentialRecord.autoAcceptCredential,
+      agentContext.config.autoAcceptCredentials
+    )
 
     // Handle always / never cases
     if (autoAccept === AutoAcceptCredential.Always) return true
     if (autoAccept === AutoAcceptCredential.Never) return false
 
-    const offerMessage = await this.findOfferMessage(credentialRecord.id)
+    const offerMessage = await this.findOfferMessage(agentContext, credentialRecord.id)
 
     // Do not auto accept if missing properties
     if (!offerMessage || !offerMessage.credentialPreview) return false
@@ -959,18 +989,24 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     )
   }
 
-  public async shouldAutoRespondToOffer(options: {
-    credentialRecord: CredentialExchangeRecord
-    offerMessage: V1OfferCredentialMessage
-  }) {
+  public async shouldAutoRespondToOffer(
+    agentContext: AgentContext,
+    options: {
+      credentialRecord: CredentialExchangeRecord
+      offerMessage: V1OfferCredentialMessage
+    }
+  ) {
     const { credentialRecord, offerMessage } = options
-    const autoAccept = composeAutoAccept(credentialRecord.autoAcceptCredential, this.agentConfig.autoAcceptCredentials)
+    const autoAccept = composeAutoAccept(
+      credentialRecord.autoAcceptCredential,
+      agentContext.config.autoAcceptCredentials
+    )
 
     // Handle always / never cases
     if (autoAccept === AutoAcceptCredential.Always) return true
     if (autoAccept === AutoAcceptCredential.Never) return false
 
-    const proposalMessage = await this.findProposalMessage(credentialRecord.id)
+    const proposalMessage = await this.findProposalMessage(agentContext, credentialRecord.id)
 
     // Do not auto accept if missing properties
     if (!offerMessage.credentialPreview) return false
@@ -989,18 +1025,24 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     )
   }
 
-  public async shouldAutoRespondToRequest(options: {
-    credentialRecord: CredentialExchangeRecord
-    requestMessage: V1RequestCredentialMessage
-  }) {
+  public async shouldAutoRespondToRequest(
+    agentContext: AgentContext,
+    options: {
+      credentialRecord: CredentialExchangeRecord
+      requestMessage: V1RequestCredentialMessage
+    }
+  ) {
     const { credentialRecord, requestMessage } = options
-    const autoAccept = composeAutoAccept(credentialRecord.autoAcceptCredential, this.agentConfig.autoAcceptCredentials)
+    const autoAccept = composeAutoAccept(
+      credentialRecord.autoAcceptCredential,
+      agentContext.config.autoAcceptCredentials
+    )
 
     // Handle always / never cases
     if (autoAccept === AutoAcceptCredential.Always) return true
     if (autoAccept === AutoAcceptCredential.Never) return false
 
-    const offerMessage = await this.findOfferMessage(credentialRecord.id)
+    const offerMessage = await this.findOfferMessage(agentContext, credentialRecord.id)
     if (!offerMessage) return false
 
     const offerAttachment = offerMessage.getOfferAttachmentById(INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
@@ -1008,26 +1050,32 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     if (!offerAttachment || !requestAttachment) return false
 
-    return this.formatService.shouldAutoRespondToRequest({
+    return this.formatService.shouldAutoRespondToRequest(agentContext, {
       credentialRecord,
       offerAttachment,
       requestAttachment,
     })
   }
 
-  public async shouldAutoRespondToCredential(options: {
-    credentialRecord: CredentialExchangeRecord
-    credentialMessage: V1IssueCredentialMessage
-  }) {
+  public async shouldAutoRespondToCredential(
+    agentContext: AgentContext,
+    options: {
+      credentialRecord: CredentialExchangeRecord
+      credentialMessage: V1IssueCredentialMessage
+    }
+  ) {
     const { credentialRecord, credentialMessage } = options
-    const autoAccept = composeAutoAccept(credentialRecord.autoAcceptCredential, this.agentConfig.autoAcceptCredentials)
+    const autoAccept = composeAutoAccept(
+      credentialRecord.autoAcceptCredential,
+      agentContext.config.autoAcceptCredentials
+    )
 
     // Handle always / never cases
     if (autoAccept === AutoAcceptCredential.Always) return true
     if (autoAccept === AutoAcceptCredential.Never) return false
 
-    const requestMessage = await this.findRequestMessage(credentialRecord.id)
-    const offerMessage = await this.findOfferMessage(credentialRecord.id)
+    const requestMessage = await this.findRequestMessage(agentContext, credentialRecord.id)
+    const offerMessage = await this.findOfferMessage(agentContext, credentialRecord.id)
 
     const credentialAttachment = credentialMessage.getCredentialAttachmentById(INDY_CREDENTIAL_ATTACHMENT_ID)
     if (!credentialAttachment) return false
@@ -1037,7 +1085,7 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
 
     const offerAttachment = offerMessage?.getOfferAttachmentById(INDY_CREDENTIAL_OFFER_ATTACHMENT_ID)
 
-    return this.formatService.shouldAutoRespondToCredential({
+    return this.formatService.shouldAutoRespondToCredential(agentContext, {
       credentialRecord,
       credentialAttachment,
       requestAttachment,
@@ -1045,41 +1093,44 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
     })
   }
 
-  public async findProposalMessage(credentialExchangeId: string) {
-    return await this.didCommMessageRepository.findAgentMessage({
+  public async findProposalMessage(agentContext: AgentContext, credentialExchangeId: string) {
+    return await this.didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: credentialExchangeId,
       messageClass: V1ProposeCredentialMessage,
     })
   }
 
-  public async findOfferMessage(credentialExchangeId: string) {
-    return await this.didCommMessageRepository.findAgentMessage({
+  public async findOfferMessage(agentContext: AgentContext, credentialExchangeId: string) {
+    return await this.didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: credentialExchangeId,
       messageClass: V1OfferCredentialMessage,
     })
   }
 
-  public async findRequestMessage(credentialExchangeId: string) {
-    return await this.didCommMessageRepository.findAgentMessage({
+  public async findRequestMessage(agentContext: AgentContext, credentialExchangeId: string) {
+    return await this.didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: credentialExchangeId,
       messageClass: V1RequestCredentialMessage,
     })
   }
 
-  public async findCredentialMessage(credentialExchangeId: string) {
-    return await this.didCommMessageRepository.findAgentMessage({
+  public async findCredentialMessage(agentContext: AgentContext, credentialExchangeId: string) {
+    return await this.didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: credentialExchangeId,
       messageClass: V1IssueCredentialMessage,
     })
   }
 
-  public async getFormatData(credentialExchangeId: string): Promise<GetFormatDataReturn<CredentialFormat[]>> {
+  public async getFormatData(
+    agentContext: AgentContext,
+    credentialExchangeId: string
+  ): Promise<GetFormatDataReturn<CredentialFormat[]>> {
     // TODO: we could looking at fetching all record using a single query and then filtering based on the type of the message.
     const [proposalMessage, offerMessage, requestMessage, credentialMessage] = await Promise.all([
-      this.findProposalMessage(credentialExchangeId),
-      this.findOfferMessage(credentialExchangeId),
-      this.findRequestMessage(credentialExchangeId),
-      this.findCredentialMessage(credentialExchangeId),
+      this.findProposalMessage(agentContext, credentialExchangeId),
+      this.findOfferMessage(agentContext, credentialExchangeId),
+      this.findRequestMessage(agentContext, credentialExchangeId),
+      this.findCredentialMessage(agentContext, credentialExchangeId),
     ])
 
     const indyProposal = proposalMessage
@@ -1117,14 +1168,12 @@ export class V1CredentialService extends CredentialService<[IndyCredentialFormat
   }
 
   protected registerHandlers() {
-    this.dispatcher.registerHandler(new V1ProposeCredentialHandler(this, this.agentConfig))
+    this.dispatcher.registerHandler(new V1ProposeCredentialHandler(this, this.logger))
     this.dispatcher.registerHandler(
-      new V1OfferCredentialHandler(this, this.agentConfig, this.routingService, this.didCommMessageRepository)
+      new V1OfferCredentialHandler(this, this.routingService, this.didCommMessageRepository, this.logger)
     )
-    this.dispatcher.registerHandler(
-      new V1RequestCredentialHandler(this, this.agentConfig, this.didCommMessageRepository)
-    )
-    this.dispatcher.registerHandler(new V1IssueCredentialHandler(this, this.agentConfig, this.didCommMessageRepository))
+    this.dispatcher.registerHandler(new V1RequestCredentialHandler(this, this.didCommMessageRepository, this.logger))
+    this.dispatcher.registerHandler(new V1IssueCredentialHandler(this, this.didCommMessageRepository, this.logger))
     this.dispatcher.registerHandler(new V1CredentialAckHandler(this))
     this.dispatcher.registerHandler(new V1CredentialProblemReportHandler(this))
   }

--- a/packages/core/src/modules/credentials/protocol/v1/__tests__/V1CredentialServiceCred.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/__tests__/V1CredentialServiceCred.test.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../../../agent'
 import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { GetAgentMessageOptions } from '../../../../../storage/didcomm/DidCommMessageRepository'
 import type { CredentialStateChangedEvent } from '../../../CredentialEvents'
@@ -5,7 +6,9 @@ import type { IndyCredentialViewMetadata } from '../../../formats/indy/models'
 import type { CredentialPreviewAttribute } from '../../../models'
 import type { CustomCredentialTags } from '../../../repository/CredentialExchangeRecord'
 
-import { getAgentConfig, getMockConnection, mockFunction } from '../../../../../../tests/helpers'
+import { Subject } from 'rxjs'
+
+import { getAgentConfig, getAgentContext, getMockConnection, mockFunction } from '../../../../../../tests/helpers'
 import { Dispatcher } from '../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../agent/EventEmitter'
 import { InboundMessageContext } from '../../../../../agent/models/InboundMessageContext'
@@ -35,12 +38,12 @@ import {
   INDY_CREDENTIAL_OFFER_ATTACHMENT_ID,
   INDY_CREDENTIAL_REQUEST_ATTACHMENT_ID,
   V1CredentialAckMessage,
-  V1CredentialPreview,
   V1CredentialProblemReportMessage,
   V1IssueCredentialMessage,
   V1OfferCredentialMessage,
   V1ProposeCredentialMessage,
   V1RequestCredentialMessage,
+  V1CredentialPreview,
 } from '../messages'
 
 // Mock classes
@@ -132,7 +135,7 @@ const didCommMessageRecord = new DidCommMessageRecord({
 })
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getAgentMessageMock = async (options: GetAgentMessageOptions<any>) => {
+const getAgentMessageMock = async (agentContext: AgentContext, options: GetAgentMessageOptions<any>) => {
   if (options.messageClass === V1ProposeCredentialMessage) {
     return credentialProposalMessage
   }
@@ -218,12 +221,14 @@ const mockCredentialRecord = ({
 describe('V1CredentialService', () => {
   let eventEmitter: EventEmitter
   let agentConfig: AgentConfig
+  let agentContext: AgentContext
   let credentialService: V1CredentialService
 
   beforeEach(async () => {
     // real objects
     agentConfig = getAgentConfig('V1CredentialServiceCredTest')
-    eventEmitter = new EventEmitter(agentConfig)
+    agentContext = getAgentContext()
+    eventEmitter = new EventEmitter(agentConfig.agentDependencies, new Subject())
 
     // mock function implementations
     mockFunction(connectionService.getById).mockResolvedValue(connection)
@@ -238,7 +243,7 @@ describe('V1CredentialService', () => {
     credentialService = new V1CredentialService(
       connectionService,
       didCommMessageRepository,
-      agentConfig,
+      agentConfig.logger,
       routingService,
       dispatcher,
       eventEmitter,
@@ -276,7 +281,7 @@ describe('V1CredentialService', () => {
       })
 
       // when
-      const { message } = await credentialService.acceptOffer({
+      const { message } = await credentialService.acceptOffer(agentContext, {
         comment: 'hello',
         autoAcceptCredential: AutoAcceptCredential.Never,
         credentialRecord,
@@ -299,7 +304,7 @@ describe('V1CredentialService', () => {
         'requests~attach': [JsonTransformer.toJSON(requestAttachment)],
       })
       expect(credentialRepository.update).toHaveBeenCalledTimes(1)
-      expect(indyCredentialFormatService.acceptOffer).toHaveBeenCalledWith({
+      expect(indyCredentialFormatService.acceptOffer).toHaveBeenCalledWith(agentContext, {
         credentialRecord,
         attachId: INDY_CREDENTIAL_REQUEST_ATTACHMENT_ID,
         offerAttachment,
@@ -309,7 +314,7 @@ describe('V1CredentialService', () => {
           },
         },
       })
-      expect(didCommMessageRepository.saveOrUpdateAgentMessage).toHaveBeenCalledWith({
+      expect(didCommMessageRepository.saveOrUpdateAgentMessage).toHaveBeenCalledWith(agentContext, {
         agentMessage: message,
         associatedRecordId: '84353745-8bd9-42e1-8d81-238ca77c29d2',
         role: DidCommMessageRole.Sender,
@@ -333,12 +338,12 @@ describe('V1CredentialService', () => {
       })
 
       // when
-      await credentialService.acceptOffer({
+      await credentialService.acceptOffer(agentContext, {
         credentialRecord,
       })
 
       // then
-      expect(updateStateSpy).toHaveBeenCalledWith(credentialRecord, CredentialState.RequestSent)
+      expect(updateStateSpy).toHaveBeenCalledWith(agentContext, credentialRecord, CredentialState.RequestSent)
     })
 
     const validState = CredentialState.OfferReceived
@@ -347,7 +352,7 @@ describe('V1CredentialService', () => {
       await Promise.all(
         invalidCredentialStates.map(async (state) => {
           await expect(
-            credentialService.acceptOffer({ credentialRecord: mockCredentialRecord({ state }) })
+            credentialService.acceptOffer(agentContext, { credentialRecord: mockCredentialRecord({ state }) })
           ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
@@ -366,6 +371,7 @@ describe('V1CredentialService', () => {
       })
       credentialRequest.setThread({ threadId: 'somethreadid' })
       messageContext = new InboundMessageContext(credentialRequest, {
+        agentContext,
         connection,
       })
     })
@@ -380,7 +386,7 @@ describe('V1CredentialService', () => {
       const returnedCredentialRecord = await credentialService.processRequest(messageContext)
 
       // then
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
@@ -397,7 +403,7 @@ describe('V1CredentialService', () => {
       const returnedCredentialRecord = await credentialService.processRequest(messageContext)
 
       // then
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
@@ -438,10 +444,11 @@ describe('V1CredentialService', () => {
       })
 
       // when
-      await credentialService.acceptRequest({ credentialRecord })
+      await credentialService.acceptRequest(agentContext, { credentialRecord })
 
       // then
       expect(credentialRepository.update).toHaveBeenCalledWith(
+        agentContext,
         expect.objectContaining({
           state: CredentialState.CredentialIssued,
         })
@@ -470,7 +477,7 @@ describe('V1CredentialService', () => {
       eventEmitter.on<CredentialStateChangedEvent>(CredentialEventTypes.CredentialStateChanged, eventListenerMock)
 
       // when
-      await credentialService.acceptRequest({ credentialRecord })
+      await credentialService.acceptRequest(agentContext, { credentialRecord })
 
       // then
       expect(eventListenerMock).toHaveBeenCalledWith({
@@ -504,7 +511,7 @@ describe('V1CredentialService', () => {
       })
 
       // when
-      const { message } = await credentialService.acceptRequest({ credentialRecord, comment })
+      const { message } = await credentialService.acceptRequest(agentContext, { credentialRecord, comment })
 
       // then
       expect(message.toJSON()).toMatchObject({
@@ -518,7 +525,7 @@ describe('V1CredentialService', () => {
         '~please_ack': expect.any(Object),
       })
 
-      expect(indyCredentialFormatService.acceptRequest).toHaveBeenCalledWith({
+      expect(indyCredentialFormatService.acceptRequest).toHaveBeenCalledWith(agentContext, {
         credentialRecord,
         requestAttachment,
         offerAttachment,
@@ -538,9 +545,7 @@ describe('V1CredentialService', () => {
         credentialAttachments: [credentialAttachment],
       })
       credentialResponse.setThread({ threadId: 'somethreadid' })
-      const messageContext = new InboundMessageContext(credentialResponse, {
-        connection,
-      })
+      const messageContext = new InboundMessageContext(credentialResponse, { agentContext, connection })
 
       mockFunction(credentialRepository.getSingleByQuery).mockResolvedValue(credentialRecord)
 
@@ -548,18 +553,18 @@ describe('V1CredentialService', () => {
       await credentialService.processCredential(messageContext)
 
       // then
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
 
-      expect(didCommMessageRepository.saveAgentMessage).toHaveBeenCalledWith({
+      expect(didCommMessageRepository.saveAgentMessage).toHaveBeenCalledWith(agentContext, {
         agentMessage: credentialResponse,
         role: DidCommMessageRole.Receiver,
         associatedRecordId: credentialRecord.id,
       })
 
-      expect(indyCredentialFormatService.processCredential).toHaveBeenNthCalledWith(1, {
+      expect(indyCredentialFormatService.processCredential).toHaveBeenNthCalledWith(1, agentContext, {
         attachment: credentialAttachment,
         credentialRecord,
       })
@@ -583,11 +588,11 @@ describe('V1CredentialService', () => {
       const repositoryUpdateSpy = jest.spyOn(credentialRepository, 'update')
 
       // when
-      await credentialService.acceptCredential({ credentialRecord: credential })
+      await credentialService.acceptCredential(agentContext, { credentialRecord: credential })
 
       // then
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
-      const [[updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
+      const [[, updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
       expect(updatedCredentialRecord).toMatchObject({
         state: CredentialState.Done,
       })
@@ -598,7 +603,7 @@ describe('V1CredentialService', () => {
       eventEmitter.on<CredentialStateChangedEvent>(CredentialEventTypes.CredentialStateChanged, eventListenerMock)
 
       // when
-      await credentialService.acceptCredential({ credentialRecord: credential })
+      await credentialService.acceptCredential(agentContext, { credentialRecord: credential })
 
       // then
       expect(eventListenerMock).toHaveBeenCalledWith({
@@ -617,7 +622,9 @@ describe('V1CredentialService', () => {
       mockFunction(credentialRepository.getById).mockReturnValue(Promise.resolve(credential))
 
       // when
-      const { message: ackMessage } = await credentialService.acceptCredential({ credentialRecord: credential })
+      const { message: ackMessage } = await credentialService.acceptCredential(agentContext, {
+        credentialRecord: credential,
+      })
 
       // then
       expect(ackMessage.toJSON()).toMatchObject({
@@ -635,7 +642,7 @@ describe('V1CredentialService', () => {
       await Promise.all(
         invalidCredentialStates.map(async (state) => {
           await expect(
-            credentialService.acceptCredential({
+            credentialService.acceptCredential(agentContext, {
               credentialRecord: mockCredentialRecord({
                 state,
                 threadId,
@@ -661,9 +668,7 @@ describe('V1CredentialService', () => {
         status: AckStatus.OK,
         threadId: 'somethreadid',
       })
-      messageContext = new InboundMessageContext(credentialRequest, {
-        connection,
-      })
+      messageContext = new InboundMessageContext(credentialRequest, { agentContext, connection })
     })
 
     test(`updates state to ${CredentialState.Done} and returns credential record`, async () => {
@@ -679,12 +684,12 @@ describe('V1CredentialService', () => {
       const expectedCredentialRecord = {
         state: CredentialState.Done,
       }
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
-      const [[updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
+      const [[, updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
       expect(updatedCredentialRecord).toMatchObject(expectedCredentialRecord)
       expect(returnedCredentialRecord).toMatchObject(expectedCredentialRecord)
     })
@@ -708,7 +713,7 @@ describe('V1CredentialService', () => {
       mockFunction(credentialRepository.getById).mockReturnValue(Promise.resolve(credential))
 
       // when
-      const credentialProblemReportMessage = credentialService.createProblemReport({ message })
+      const credentialProblemReportMessage = credentialService.createProblemReport(agentContext, { message })
 
       credentialProblemReportMessage.setThread({ threadId })
       // then
@@ -742,9 +747,7 @@ describe('V1CredentialService', () => {
         },
       })
       credentialProblemReportMessage.setThread({ threadId: 'somethreadid' })
-      messageContext = new InboundMessageContext(credentialProblemReportMessage, {
-        connection,
-      })
+      messageContext = new InboundMessageContext(credentialProblemReportMessage, { agentContext, connection })
     })
 
     test(`updates problem report error message and returns credential record`, async () => {
@@ -760,12 +763,12 @@ describe('V1CredentialService', () => {
       const expectedCredentialRecord = {
         errorMessage: 'issuance-abandoned: Indy error',
       }
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
-      const [[updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
+      const [[, updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
       expect(updatedCredentialRecord).toMatchObject(expectedCredentialRecord)
       expect(returnedCredentialRecord).toMatchObject(expectedCredentialRecord)
     })
@@ -775,8 +778,8 @@ describe('V1CredentialService', () => {
     it('getById should return value from credentialRepository.getById', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.getById(expected.id)
-      expect(credentialRepository.getById).toBeCalledWith(expected.id)
+      const result = await credentialService.getById(agentContext, expected.id)
+      expect(credentialRepository.getById).toBeCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -784,8 +787,8 @@ describe('V1CredentialService', () => {
     it('getById should return value from credentialRepository.getSingleByQuery', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.getByThreadAndConnectionId('threadId', 'connectionId')
-      expect(credentialRepository.getSingleByQuery).toBeCalledWith({
+      const result = await credentialService.getByThreadAndConnectionId(agentContext, 'threadId', 'connectionId')
+      expect(credentialRepository.getSingleByQuery).toBeCalledWith(agentContext, {
         threadId: 'threadId',
         connectionId: 'connectionId',
       })
@@ -796,8 +799,8 @@ describe('V1CredentialService', () => {
     it('findById should return value from credentialRepository.findById', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.findById).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.findById(expected.id)
-      expect(credentialRepository.findById).toBeCalledWith(expected.id)
+      const result = await credentialService.findById(agentContext, expected.id)
+      expect(credentialRepository.findById).toBeCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -806,8 +809,8 @@ describe('V1CredentialService', () => {
       const expected = [mockCredentialRecord(), mockCredentialRecord()]
 
       mockFunction(credentialRepository.getAll).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.getAll()
-      expect(credentialRepository.getAll).toBeCalledWith()
+      const result = await credentialService.getAll(agentContext)
+      expect(credentialRepository.getAll).toBeCalledWith(agentContext)
 
       expect(result).toEqual(expect.arrayContaining(expected))
     })
@@ -819,8 +822,8 @@ describe('V1CredentialService', () => {
       mockFunction(credentialRepository.getById).mockReturnValue(Promise.resolve(credentialRecord))
 
       const repositoryDeleteSpy = jest.spyOn(credentialRepository, 'delete')
-      await credentialService.delete(credentialRecord)
-      expect(repositoryDeleteSpy).toHaveBeenNthCalledWith(1, credentialRecord)
+      await credentialService.delete(agentContext, credentialRecord)
+      expect(repositoryDeleteSpy).toHaveBeenNthCalledWith(1, agentContext, credentialRecord)
     })
 
     it('should call deleteCredentialById in indyCredentialFormatService if deleteAssociatedCredential is true', async () => {
@@ -829,12 +832,16 @@ describe('V1CredentialService', () => {
       const credentialRecord = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
-      await credentialService.delete(credentialRecord, {
+      await credentialService.delete(agentContext, credentialRecord, {
         deleteAssociatedCredentials: true,
         deleteAssociatedDidCommMessages: false,
       })
 
-      expect(deleteCredentialMock).toHaveBeenNthCalledWith(1, credentialRecord.credentials[0].credentialRecordId)
+      expect(deleteCredentialMock).toHaveBeenNthCalledWith(
+        1,
+        agentContext,
+        credentialRecord.credentials[0].credentialRecordId
+      )
     })
 
     it('should not call deleteCredentialById in indyCredentialFormatService if deleteAssociatedCredential is false', async () => {
@@ -843,7 +850,7 @@ describe('V1CredentialService', () => {
       const credentialRecord = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
-      await credentialService.delete(credentialRecord, {
+      await credentialService.delete(agentContext, credentialRecord, {
         deleteAssociatedCredentials: false,
         deleteAssociatedDidCommMessages: false,
       })
@@ -857,9 +864,13 @@ describe('V1CredentialService', () => {
       const credentialRecord = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
-      await credentialService.delete(credentialRecord)
+      await credentialService.delete(agentContext, credentialRecord)
 
-      expect(deleteCredentialMock).toHaveBeenNthCalledWith(1, credentialRecord.credentials[0].credentialRecordId)
+      expect(deleteCredentialMock).toHaveBeenNthCalledWith(
+        1,
+        agentContext,
+        credentialRecord.credentials[0].credentialRecordId
+      )
     })
     it('deleteAssociatedDidCommMessages should default to true', async () => {
       const deleteCredentialMock = mockFunction(indyCredentialFormatService.deleteCredentialById)
@@ -867,9 +878,13 @@ describe('V1CredentialService', () => {
       const credentialRecord = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
-      await credentialService.delete(credentialRecord)
+      await credentialService.delete(agentContext, credentialRecord)
 
-      expect(deleteCredentialMock).toHaveBeenNthCalledWith(1, credentialRecord.credentials[0].credentialRecordId)
+      expect(deleteCredentialMock).toHaveBeenNthCalledWith(
+        1,
+        agentContext,
+        credentialRecord.credentials[0].credentialRecordId
+      )
       expect(didCommMessageRepository.delete).toHaveBeenCalledTimes(3)
     })
   })
@@ -890,14 +905,18 @@ describe('V1CredentialService', () => {
       const repositoryUpdateSpy = jest.spyOn(credentialRepository, 'update')
 
       // when
-      await credentialService.declineOffer(credential)
+      await credentialService.declineOffer(agentContext, credential)
 
       // then
       const expectedCredentialState = {
         state: CredentialState.Declined,
       }
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
-      expect(repositoryUpdateSpy).toHaveBeenNthCalledWith(1, expect.objectContaining(expectedCredentialState))
+      expect(repositoryUpdateSpy).toHaveBeenNthCalledWith(
+        1,
+        agentContext,
+        expect.objectContaining(expectedCredentialState)
+      )
     })
 
     test(`emits stateChange event from ${CredentialState.OfferReceived} to ${CredentialState.Declined}`, async () => {
@@ -908,7 +927,7 @@ describe('V1CredentialService', () => {
       mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(Promise.resolve(credential))
 
       // when
-      await credentialService.declineOffer(credential)
+      await credentialService.declineOffer(agentContext, credential)
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1)
@@ -930,7 +949,7 @@ describe('V1CredentialService', () => {
       await Promise.all(
         invalidCredentialStates.map(async (state) => {
           await expect(
-            credentialService.declineOffer(mockCredentialRecord({ state, tags: { threadId } }))
+            credentialService.declineOffer(agentContext, mockCredentialRecord({ state, tags: { threadId } }))
           ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )

--- a/packages/core/src/modules/credentials/protocol/v1/__tests__/V1CredentialServiceProposeOffer.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/__tests__/V1CredentialServiceProposeOffer.test.ts
@@ -1,9 +1,10 @@
-import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { CredentialStateChangedEvent } from '../../../CredentialEvents'
 import type { CreateOfferOptions, CreateProposalOptions } from '../../../CredentialServiceOptions'
 import type { IndyCredentialFormat } from '../../../formats/indy/IndyCredentialFormat'
 
-import { getAgentConfig, getMockConnection, mockFunction } from '../../../../../../tests/helpers'
+import { Subject } from 'rxjs'
+
+import { getAgentConfig, getAgentContext, getMockConnection, mockFunction } from '../../../../../../tests/helpers'
 import { Dispatcher } from '../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../agent/EventEmitter'
 import { InboundMessageContext } from '../../../../../agent/models/InboundMessageContext'
@@ -51,6 +52,9 @@ const indyCredentialFormatService = new IndyCredentialFormatServiceMock()
 const dispatcher = new DispatcherMock()
 const connectionService = new ConnectionServiceMock()
 
+const agentConfig = getAgentConfig('V1CredentialServiceProposeOfferTest')
+const agentContext = getAgentContext()
+
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 indyCredentialFormatService.credentialRecordType = 'indy'
@@ -89,13 +93,11 @@ const proposalAttachment = new Attachment({
 
 describe('V1CredentialServiceProposeOffer', () => {
   let eventEmitter: EventEmitter
-  let agentConfig: AgentConfig
+
   let credentialService: V1CredentialService
 
   beforeEach(async () => {
-    // real objects
-    agentConfig = getAgentConfig('V1CredentialServiceProposeOfferTest')
-    eventEmitter = new EventEmitter(agentConfig)
+    eventEmitter = new EventEmitter(agentConfig.agentDependencies, new Subject())
 
     // mock function implementations
     mockFunction(connectionService.getById).mockResolvedValue(connection)
@@ -107,7 +109,7 @@ describe('V1CredentialServiceProposeOffer', () => {
     credentialService = new V1CredentialService(
       connectionService,
       didCommMessageRepository,
-      agentConfig,
+      agentConfig.logger,
       routingService,
       dispatcher,
       eventEmitter,
@@ -148,11 +150,12 @@ describe('V1CredentialServiceProposeOffer', () => {
         }),
       })
 
-      await credentialService.createProposal(proposeOptions)
+      await credentialService.createProposal(agentContext, proposeOptions)
 
       // then
       expect(repositorySaveSpy).toHaveBeenNthCalledWith(
         1,
+        agentContext,
         expect.objectContaining({
           type: CredentialExchangeRecord.type,
           id: expect.any(String),
@@ -175,7 +178,7 @@ describe('V1CredentialServiceProposeOffer', () => {
         }),
       })
 
-      await credentialService.createProposal(proposeOptions)
+      await credentialService.createProposal(agentContext, proposeOptions)
 
       expect(eventListenerMock).toHaveBeenCalledWith({
         type: 'CredentialStateChanged',
@@ -198,7 +201,7 @@ describe('V1CredentialServiceProposeOffer', () => {
         previewAttributes: credentialPreview.attributes,
       })
 
-      const { message } = await credentialService.createProposal(proposeOptions)
+      const { message } = await credentialService.createProposal(agentContext, proposeOptions)
 
       expect(message.toJSON()).toMatchObject({
         '@id': expect.any(String),
@@ -253,12 +256,12 @@ describe('V1CredentialServiceProposeOffer', () => {
 
       const repositorySaveSpy = jest.spyOn(credentialRepository, 'save')
 
-      await credentialService.createOffer(offerOptions)
+      await credentialService.createOffer(agentContext, offerOptions)
 
       // then
       expect(repositorySaveSpy).toHaveBeenCalledTimes(1)
 
-      const [[createdCredentialRecord]] = repositorySaveSpy.mock.calls
+      const [[, createdCredentialRecord]] = repositorySaveSpy.mock.calls
       expect(createdCredentialRecord).toMatchObject({
         type: CredentialExchangeRecord.type,
         id: expect.any(String),
@@ -282,7 +285,7 @@ describe('V1CredentialServiceProposeOffer', () => {
         previewAttributes: credentialPreview.attributes,
       })
 
-      await credentialService.createOffer(offerOptions)
+      await credentialService.createOffer(agentContext, offerOptions)
 
       expect(eventListenerMock).toHaveBeenCalledWith({
         type: 'CredentialStateChanged',
@@ -304,7 +307,7 @@ describe('V1CredentialServiceProposeOffer', () => {
         }),
       })
 
-      await expect(credentialService.createOffer(offerOptions)).rejects.toThrowError(
+      await expect(credentialService.createOffer(agentContext, offerOptions)).rejects.toThrowError(
         'Missing required credential preview from indy format service'
       )
     })
@@ -319,7 +322,7 @@ describe('V1CredentialServiceProposeOffer', () => {
         previewAttributes: credentialPreview.attributes,
       })
 
-      const { message: credentialOffer } = await credentialService.createOffer(offerOptions)
+      const { message: credentialOffer } = await credentialService.createOffer(agentContext, offerOptions)
       expect(credentialOffer.toJSON()).toMatchObject({
         '@id': expect.any(String),
         '@type': 'https://didcomm.org/issue-credential/1.0/offer-credential',
@@ -350,9 +353,7 @@ describe('V1CredentialServiceProposeOffer', () => {
       credentialPreview: credentialPreview,
       offerAttachments: [offerAttachment],
     })
-    const messageContext = new InboundMessageContext(credentialOfferMessage, {
-      connection,
-    })
+    const messageContext = new InboundMessageContext(credentialOfferMessage, { agentContext, connection })
 
     test(`creates and return credential record in ${CredentialState.OfferReceived} state with offer, thread ID`, async () => {
       // when
@@ -361,6 +362,7 @@ describe('V1CredentialServiceProposeOffer', () => {
       // then
       expect(credentialRepository.save).toHaveBeenNthCalledWith(
         1,
+        agentContext,
         expect.objectContaining({
           type: CredentialExchangeRecord.type,
           id: expect.any(String),

--- a/packages/core/src/modules/credentials/protocol/v1/__tests__/v1-credentials.e2e.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/__tests__/v1-credentials.e2e.test.ts
@@ -96,7 +96,7 @@ describe('v1 credentials', () => {
     })
 
     const didCommMessageRepository = faberAgent.dependencyManager.resolve(DidCommMessageRepository)
-    const offerMessageRecord = await didCommMessageRepository.findAgentMessage({
+    const offerMessageRecord = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberCredentialRecord.id,
       messageClass: V1OfferCredentialMessage,
     })

--- a/packages/core/src/modules/credentials/protocol/v1/handlers/V1OfferCredentialHandler.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/handlers/V1OfferCredentialHandler.ts
@@ -1,5 +1,5 @@
-import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../../../agent/Handler'
+import type { Logger } from '../../../../../logger'
 import type { DidCommMessageRepository } from '../../../../../storage'
 import type { RoutingService } from '../../../../routing/services/RoutingService'
 import type { CredentialExchangeRecord } from '../../../repository/CredentialExchangeRecord'
@@ -12,27 +12,27 @@ import { V1OfferCredentialMessage } from '../messages'
 
 export class V1OfferCredentialHandler implements Handler {
   private credentialService: V1CredentialService
-  private agentConfig: AgentConfig
   private routingService: RoutingService
   private didCommMessageRepository: DidCommMessageRepository
+  private logger: Logger
   public supportedMessages = [V1OfferCredentialMessage]
 
   public constructor(
     credentialService: V1CredentialService,
-    agentConfig: AgentConfig,
     routingService: RoutingService,
-    didCommMessageRepository: DidCommMessageRepository
+    didCommMessageRepository: DidCommMessageRepository,
+    logger: Logger
   ) {
     this.credentialService = credentialService
-    this.agentConfig = agentConfig
     this.routingService = routingService
     this.didCommMessageRepository = didCommMessageRepository
+    this.logger = logger
   }
 
   public async handle(messageContext: HandlerInboundMessage<V1OfferCredentialHandler>) {
     const credentialRecord = await this.credentialService.processOffer(messageContext)
 
-    const shouldAutoRespond = await this.credentialService.shouldAutoRespondToOffer({
+    const shouldAutoRespond = await this.credentialService.shouldAutoRespondToOffer(messageContext.agentContext, {
       credentialRecord,
       offerMessage: messageContext.message,
     })
@@ -46,15 +46,15 @@ export class V1OfferCredentialHandler implements Handler {
     credentialRecord: CredentialExchangeRecord,
     messageContext: HandlerInboundMessage<V1OfferCredentialHandler>
   ) {
-    this.agentConfig.logger.info(
-      `Automatically sending request with autoAccept on ${this.agentConfig.autoAcceptCredentials}`
+    this.logger.info(
+      `Automatically sending request with autoAccept on ${messageContext.agentContext.config.autoAcceptCredentials}`
     )
     if (messageContext.connection) {
-      const { message } = await this.credentialService.acceptOffer({ credentialRecord })
+      const { message } = await this.credentialService.acceptOffer(messageContext.agentContext, { credentialRecord })
 
       return createOutboundMessage(messageContext.connection, message)
     } else if (messageContext.message.service) {
-      const routing = await this.routingService.getRouting()
+      const routing = await this.routingService.getRouting(messageContext.agentContext)
       const ourService = new ServiceDecorator({
         serviceEndpoint: routing.endpoints[0],
         recipientKeys: [routing.recipientKey.publicKeyBase58],
@@ -62,7 +62,7 @@ export class V1OfferCredentialHandler implements Handler {
       })
       const recipientService = messageContext.message.service
 
-      const { message } = await this.credentialService.acceptOffer({
+      const { message } = await this.credentialService.acceptOffer(messageContext.agentContext, {
         credentialRecord,
         credentialFormats: {
           indy: {
@@ -73,7 +73,7 @@ export class V1OfferCredentialHandler implements Handler {
 
       // Set and save ~service decorator to record (to remember our verkey)
       message.service = ourService
-      await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+      await this.didCommMessageRepository.saveOrUpdateAgentMessage(messageContext.agentContext, {
         agentMessage: message,
         role: DidCommMessageRole.Sender,
         associatedRecordId: credentialRecord.id,
@@ -86,6 +86,6 @@ export class V1OfferCredentialHandler implements Handler {
       })
     }
 
-    this.agentConfig.logger.error(`Could not automatically create credential request`)
+    this.logger.error(`Could not automatically create credential request`)
   }
 }

--- a/packages/core/src/modules/credentials/protocol/v1/handlers/V1ProposeCredentialHandler.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/handlers/V1ProposeCredentialHandler.ts
@@ -1,5 +1,5 @@
-import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../../../agent/Handler'
+import type { Logger } from '../../../../../logger'
 import type { CredentialExchangeRecord } from '../../../repository/CredentialExchangeRecord'
 import type { V1CredentialService } from '../V1CredentialService'
 
@@ -8,21 +8,24 @@ import { V1ProposeCredentialMessage } from '../messages'
 
 export class V1ProposeCredentialHandler implements Handler {
   private credentialService: V1CredentialService
-  private agentConfig: AgentConfig
+  private logger: Logger
   public supportedMessages = [V1ProposeCredentialMessage]
 
-  public constructor(credentialService: V1CredentialService, agentConfig: AgentConfig) {
+  public constructor(credentialService: V1CredentialService, logger: Logger) {
     this.credentialService = credentialService
-    this.agentConfig = agentConfig
+    this.logger = logger
   }
 
   public async handle(messageContext: HandlerInboundMessage<V1ProposeCredentialHandler>) {
     const credentialRecord = await this.credentialService.processProposal(messageContext)
 
-    const shouldAutoAcceptProposal = await this.credentialService.shouldAutoRespondToProposal({
-      credentialRecord,
-      proposalMessage: messageContext.message,
-    })
+    const shouldAutoAcceptProposal = await this.credentialService.shouldAutoRespondToProposal(
+      messageContext.agentContext,
+      {
+        credentialRecord,
+        proposalMessage: messageContext.message,
+      }
+    )
 
     if (shouldAutoAcceptProposal) {
       return await this.acceptProposal(credentialRecord, messageContext)
@@ -33,16 +36,16 @@ export class V1ProposeCredentialHandler implements Handler {
     credentialRecord: CredentialExchangeRecord,
     messageContext: HandlerInboundMessage<V1ProposeCredentialHandler>
   ) {
-    this.agentConfig.logger.info(
-      `Automatically sending offer with autoAccept on ${this.agentConfig.autoAcceptCredentials}`
+    this.logger.info(
+      `Automatically sending offer with autoAccept on ${messageContext.agentContext.config.autoAcceptCredentials}`
     )
 
     if (!messageContext.connection) {
-      this.agentConfig.logger.error('No connection on the messageContext, aborting auto accept')
+      this.logger.error('No connection on the messageContext, aborting auto accept')
       return
     }
 
-    const { message } = await this.credentialService.acceptProposal({
+    const { message } = await this.credentialService.acceptProposal(messageContext.agentContext, {
       credentialRecord,
     })
 

--- a/packages/core/src/modules/credentials/protocol/v1/handlers/V1RequestCredentialHandler.ts
+++ b/packages/core/src/modules/credentials/protocol/v1/handlers/V1RequestCredentialHandler.ts
@@ -1,5 +1,5 @@
-import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../../../agent/Handler'
+import type { Logger } from '../../../../../logger'
 import type { DidCommMessageRepository } from '../../../../../storage'
 import type { CredentialExchangeRecord } from '../../../repository/CredentialExchangeRecord'
 import type { V1CredentialService } from '../V1CredentialService'
@@ -9,25 +9,25 @@ import { DidCommMessageRole } from '../../../../../storage'
 import { V1RequestCredentialMessage } from '../messages'
 
 export class V1RequestCredentialHandler implements Handler {
-  private agentConfig: AgentConfig
   private credentialService: V1CredentialService
   private didCommMessageRepository: DidCommMessageRepository
+  private logger: Logger
   public supportedMessages = [V1RequestCredentialMessage]
 
   public constructor(
     credentialService: V1CredentialService,
-    agentConfig: AgentConfig,
-    didCommMessageRepository: DidCommMessageRepository
+    didCommMessageRepository: DidCommMessageRepository,
+    logger: Logger
   ) {
     this.credentialService = credentialService
-    this.agentConfig = agentConfig
+    this.logger = logger
     this.didCommMessageRepository = didCommMessageRepository
   }
 
   public async handle(messageContext: HandlerInboundMessage<V1RequestCredentialHandler>) {
     const credentialRecord = await this.credentialService.processRequest(messageContext)
 
-    const shouldAutoRespond = await this.credentialService.shouldAutoRespondToRequest({
+    const shouldAutoRespond = await this.credentialService.shouldAutoRespondToRequest(messageContext.agentContext, {
       credentialRecord,
       requestMessage: messageContext.message,
     })
@@ -41,13 +41,13 @@ export class V1RequestCredentialHandler implements Handler {
     credentialRecord: CredentialExchangeRecord,
     messageContext: HandlerInboundMessage<V1RequestCredentialHandler>
   ) {
-    this.agentConfig.logger.info(
-      `Automatically sending credential with autoAccept on ${this.agentConfig.autoAcceptCredentials}`
+    this.logger.info(
+      `Automatically sending credential with autoAccept on ${messageContext.agentContext.config.autoAcceptCredentials}`
     )
 
-    const offerMessage = await this.credentialService.findOfferMessage(credentialRecord.id)
+    const offerMessage = await this.credentialService.findOfferMessage(messageContext.agentContext, credentialRecord.id)
 
-    const { message } = await this.credentialService.acceptRequest({
+    const { message } = await this.credentialService.acceptRequest(messageContext.agentContext, {
       credentialRecord,
     })
 
@@ -60,7 +60,7 @@ export class V1RequestCredentialHandler implements Handler {
       // Set ~service, update message in record (for later use)
       message.setService(ourService)
 
-      await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+      await this.didCommMessageRepository.saveOrUpdateAgentMessage(messageContext.agentContext, {
         agentMessage: message,
         role: DidCommMessageRole.Sender,
         associatedRecordId: credentialRecord.id,
@@ -73,6 +73,6 @@ export class V1RequestCredentialHandler implements Handler {
       })
     }
 
-    this.agentConfig.logger.error(`Could not automatically create credential request`)
+    this.logger.error(`Could not automatically create credential request`)
   }
 }

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialServiceCred.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/V2CredentialServiceCred.test.ts
@@ -1,12 +1,14 @@
 import type { IndyCredentialViewMetadata } from '../../../../..'
-import type { AgentConfig } from '../../../../../agent/AgentConfig'
+import type { AgentContext } from '../../../../../agent'
 import type { GetAgentMessageOptions } from '../../../../../storage'
 import type { CredentialStateChangedEvent } from '../../../CredentialEvents'
 import type { CredentialPreviewAttribute } from '../../../models/CredentialPreviewAttribute'
 import type { CustomCredentialTags } from '../../../repository/CredentialExchangeRecord'
 
+import { Subject } from 'rxjs'
+
 import { AriesFrameworkError, CredentialFormatSpec } from '../../../../..'
-import { getAgentConfig, getMockConnection, mockFunction } from '../../../../../../tests/helpers'
+import { getAgentConfig, getAgentContext, getMockConnection, mockFunction } from '../../../../../../tests/helpers'
 import { Dispatcher } from '../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../agent/EventEmitter'
 import { InboundMessageContext } from '../../../../../agent/models/InboundMessageContext'
@@ -62,6 +64,9 @@ const connectionService = new ConnectionServiceMock()
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 indyCredentialFormatService.formatKey = 'indy'
+
+const agentConfig = getAgentConfig('V2CredentialServiceCredTest')
+const agentContext = getAgentContext()
 
 const connection = getMockConnection({
   id: '123',
@@ -158,7 +163,7 @@ const didCommMessageRecord = new DidCommMessageRecord({
 })
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const getAgentMessageMock = async (options: GetAgentMessageOptions<any>) => {
+const getAgentMessageMock = async (agentContext: AgentContext, options: GetAgentMessageOptions<any>) => {
   if (options.messageClass === V2ProposeCredentialMessage) {
     return credentialProposalMessage
   }
@@ -231,12 +236,11 @@ const mockCredentialRecord = ({
 
 describe('CredentialService', () => {
   let eventEmitter: EventEmitter
-  let agentConfig: AgentConfig
+
   let credentialService: V2CredentialService
 
   beforeEach(async () => {
-    agentConfig = getAgentConfig('V2CredentialServiceCredTest')
-    eventEmitter = new EventEmitter(agentConfig)
+    eventEmitter = new EventEmitter(agentConfig.agentDependencies, new Subject())
 
     // mock function implementations
     mockFunction(connectionService.getById).mockResolvedValue(connection)
@@ -251,12 +255,12 @@ describe('CredentialService', () => {
     credentialService = new V2CredentialService(
       connectionService,
       didCommMessageRepository,
-      agentConfig,
       routingService,
       dispatcher,
       eventEmitter,
       credentialRepository,
-      indyCredentialFormatService
+      indyCredentialFormatService,
+      agentConfig.logger
     )
   })
 
@@ -279,7 +283,7 @@ describe('CredentialService', () => {
       })
 
       // when
-      await credentialService.acceptOffer({
+      await credentialService.acceptOffer(agentContext, {
         credentialRecord,
         credentialFormats: {
           indy: {
@@ -292,6 +296,7 @@ describe('CredentialService', () => {
       // then
       expect(credentialRepository.update).toHaveBeenNthCalledWith(
         1,
+        agentContext,
         expect.objectContaining({
           state: CredentialState.RequestSent,
         })
@@ -315,7 +320,10 @@ describe('CredentialService', () => {
       })
 
       // when
-      const { message: credentialRequest } = await credentialService.acceptOffer({ credentialRecord, comment })
+      const { message: credentialRequest } = await credentialService.acceptOffer(agentContext, {
+        credentialRecord,
+        comment,
+      })
 
       // then
       expect(credentialRequest.toJSON()).toMatchObject({
@@ -336,7 +344,7 @@ describe('CredentialService', () => {
       await Promise.all(
         invalidCredentialStates.map(async (state) => {
           await expect(
-            credentialService.acceptOffer({ credentialRecord: mockCredentialRecord({ state }) })
+            credentialService.acceptOffer(agentContext, { credentialRecord: mockCredentialRecord({ state }) })
           ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
@@ -350,6 +358,7 @@ describe('CredentialService', () => {
       const credentialRecord = mockCredentialRecord({ state: CredentialState.OfferSent })
       const messageContext = new InboundMessageContext(credentialRequestMessage, {
         connection,
+        agentContext,
       })
 
       // given
@@ -359,7 +368,7 @@ describe('CredentialService', () => {
       const returnedCredentialRecord = await credentialService.processRequest(messageContext)
 
       // then
-      expect(credentialRepository.findSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(credentialRepository.findSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
@@ -373,6 +382,7 @@ describe('CredentialService', () => {
       const credentialRecord = mockCredentialRecord({ state: CredentialState.OfferSent })
       const messageContext = new InboundMessageContext(credentialRequestMessage, {
         connection,
+        agentContext,
       })
 
       const eventListenerMock = jest.fn()
@@ -383,10 +393,15 @@ describe('CredentialService', () => {
       const returnedCredentialRecord = await credentialService.processRequest(messageContext)
 
       // then
-      expect(credentialRepository.findSingleByQuery).toHaveBeenNthCalledWith(1, {
-        threadId: 'somethreadid',
-        connectionId: connection.id,
-      })
+      expect(credentialRepository.findSingleByQuery).toHaveBeenNthCalledWith(
+        1,
+        agentContext,
+
+        {
+          threadId: 'somethreadid',
+          connectionId: connection.id,
+        }
+      )
       expect(eventListenerMock).toHaveBeenCalled()
       expect(returnedCredentialRecord.state).toEqual(CredentialState.RequestReceived)
     })
@@ -398,6 +413,7 @@ describe('CredentialService', () => {
 
       const messageContext = new InboundMessageContext(credentialRequestMessage, {
         connection,
+        agentContext,
       })
 
       await Promise.all(
@@ -426,7 +442,7 @@ describe('CredentialService', () => {
         connectionId: 'b1e2f039-aa39-40be-8643-6ce2797b5190',
       })
 
-      await credentialService.acceptRequest({
+      await credentialService.acceptRequest(agentContext, {
         credentialRecord,
         comment: 'credential response comment',
       })
@@ -434,6 +450,7 @@ describe('CredentialService', () => {
       // then
       expect(credentialRepository.update).toHaveBeenNthCalledWith(
         1,
+        agentContext,
         expect.objectContaining({
           state: CredentialState.CredentialIssued,
         })
@@ -459,7 +476,7 @@ describe('CredentialService', () => {
       eventEmitter.on<CredentialStateChangedEvent>(CredentialEventTypes.CredentialStateChanged, eventListenerMock)
 
       // when
-      await credentialService.acceptRequest({
+      await credentialService.acceptRequest(agentContext, {
         credentialRecord,
         comment: 'credential response comment',
       })
@@ -493,7 +510,7 @@ describe('CredentialService', () => {
       const comment = 'credential response comment'
 
       // when
-      const { message: credentialResponse } = await credentialService.acceptRequest({
+      const { message: credentialResponse } = await credentialService.acceptRequest(agentContext, {
         comment: 'credential response comment',
         credentialRecord,
       })
@@ -523,6 +540,7 @@ describe('CredentialService', () => {
 
       const messageContext = new InboundMessageContext(credentialIssueMessage, {
         connection,
+        agentContext,
       })
 
       // given
@@ -544,11 +562,12 @@ describe('CredentialService', () => {
       })
 
       // when
-      await credentialService.acceptCredential({ credentialRecord })
+      await credentialService.acceptCredential(agentContext, { credentialRecord })
 
       // then
       expect(credentialRepository.update).toHaveBeenNthCalledWith(
         1,
+        agentContext,
         expect.objectContaining({
           state: CredentialState.Done,
         })
@@ -566,7 +585,7 @@ describe('CredentialService', () => {
       eventEmitter.on<CredentialStateChangedEvent>(CredentialEventTypes.CredentialStateChanged, eventListenerMock)
 
       // when
-      await credentialService.acceptCredential({ credentialRecord })
+      await credentialService.acceptCredential(agentContext, { credentialRecord })
 
       // then
       expect(eventListenerMock).toHaveBeenCalledWith({
@@ -591,7 +610,7 @@ describe('CredentialService', () => {
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
       // when
-      const { message: ackMessage } = await credentialService.acceptCredential({ credentialRecord })
+      const { message: ackMessage } = await credentialService.acceptCredential(agentContext, { credentialRecord })
 
       // then
       expect(ackMessage.toJSON()).toMatchObject({
@@ -609,7 +628,7 @@ describe('CredentialService', () => {
       await Promise.all(
         invalidCredentialStates.map(async (state) => {
           await expect(
-            credentialService.acceptCredential({
+            credentialService.acceptCredential(agentContext, {
               credentialRecord: mockCredentialRecord({
                 state,
                 threadId: 'somethreadid',
@@ -627,9 +646,7 @@ describe('CredentialService', () => {
       status: AckStatus.OK,
       threadId: 'somethreadid',
     })
-    const messageContext = new InboundMessageContext(credentialRequest, {
-      connection,
-    })
+    const messageContext = new InboundMessageContext(credentialRequest, { agentContext, connection })
 
     test(`updates state to ${CredentialState.Done} and returns credential record`, async () => {
       const credentialRecord = mockCredentialRecord({
@@ -642,7 +659,7 @@ describe('CredentialService', () => {
       // when
       const returnedCredentialRecord = await credentialService.processAck(messageContext)
 
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
@@ -663,7 +680,7 @@ describe('CredentialService', () => {
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
       // when
-      const credentialProblemReportMessage = credentialService.createProblemReport({ message })
+      const credentialProblemReportMessage = credentialService.createProblemReport(agentContext, { message })
 
       credentialProblemReportMessage.setThread({ threadId: 'somethreadid' })
       // then
@@ -691,6 +708,7 @@ describe('CredentialService', () => {
     credentialProblemReportMessage.setThread({ threadId: 'somethreadid' })
     const messageContext = new InboundMessageContext(credentialProblemReportMessage, {
       connection,
+      agentContext,
     })
 
     test(`updates problem report error message and returns credential record`, async () => {
@@ -706,7 +724,7 @@ describe('CredentialService', () => {
 
       // then
 
-      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(credentialRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
@@ -719,8 +737,8 @@ describe('CredentialService', () => {
     it('getById should return value from credentialRepository.getById', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.getById(expected.id)
-      expect(credentialRepository.getById).toBeCalledWith(expected.id)
+      const result = await credentialService.getById(agentContext, expected.id)
+      expect(credentialRepository.getById).toBeCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -728,8 +746,8 @@ describe('CredentialService', () => {
     it('getById should return value from credentialRepository.getSingleByQuery', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.getSingleByQuery).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.getByThreadAndConnectionId('threadId', 'connectionId')
-      expect(credentialRepository.getSingleByQuery).toBeCalledWith({
+      const result = await credentialService.getByThreadAndConnectionId(agentContext, 'threadId', 'connectionId')
+      expect(credentialRepository.getSingleByQuery).toBeCalledWith(agentContext, {
         threadId: 'threadId',
         connectionId: 'connectionId',
       })
@@ -740,8 +758,8 @@ describe('CredentialService', () => {
     it('findById should return value from credentialRepository.findById', async () => {
       const expected = mockCredentialRecord()
       mockFunction(credentialRepository.findById).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.findById(expected.id)
-      expect(credentialRepository.findById).toBeCalledWith(expected.id)
+      const result = await credentialService.findById(agentContext, expected.id)
+      expect(credentialRepository.findById).toBeCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -750,8 +768,8 @@ describe('CredentialService', () => {
       const expected = [mockCredentialRecord(), mockCredentialRecord()]
 
       mockFunction(credentialRepository.getAll).mockReturnValue(Promise.resolve(expected))
-      const result = await credentialService.getAll()
-      expect(credentialRepository.getAll).toBeCalledWith()
+      const result = await credentialService.getAll(agentContext)
+      expect(credentialRepository.getAll).toBeCalledWith(agentContext)
 
       expect(result).toEqual(expect.arrayContaining(expected))
     })
@@ -763,8 +781,8 @@ describe('CredentialService', () => {
       mockFunction(credentialRepository.getById).mockReturnValue(Promise.resolve(credentialRecord))
 
       const repositoryDeleteSpy = jest.spyOn(credentialRepository, 'delete')
-      await credentialService.delete(credentialRecord)
-      expect(repositoryDeleteSpy).toHaveBeenNthCalledWith(1, credentialRecord)
+      await credentialService.delete(agentContext, credentialRecord)
+      expect(repositoryDeleteSpy).toHaveBeenNthCalledWith(1, agentContext, credentialRecord)
     })
 
     it('should call deleteCredentialById in indyCredentialFormatService if deleteAssociatedCredential is true', async () => {
@@ -773,12 +791,16 @@ describe('CredentialService', () => {
       const credentialRecord = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
-      await credentialService.delete(credentialRecord, {
+      await credentialService.delete(agentContext, credentialRecord, {
         deleteAssociatedCredentials: true,
         deleteAssociatedDidCommMessages: false,
       })
 
-      expect(deleteCredentialMock).toHaveBeenNthCalledWith(1, credentialRecord.credentials[0].credentialRecordId)
+      expect(deleteCredentialMock).toHaveBeenNthCalledWith(
+        1,
+        agentContext,
+        credentialRecord.credentials[0].credentialRecordId
+      )
     })
 
     it('should not call deleteCredentialById in indyCredentialFormatService if deleteAssociatedCredential is false', async () => {
@@ -787,7 +809,7 @@ describe('CredentialService', () => {
       const credentialRecord = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
-      await credentialService.delete(credentialRecord, {
+      await credentialService.delete(agentContext, credentialRecord, {
         deleteAssociatedCredentials: false,
         deleteAssociatedDidCommMessages: false,
       })
@@ -801,9 +823,13 @@ describe('CredentialService', () => {
       const credentialRecord = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
-      await credentialService.delete(credentialRecord)
+      await credentialService.delete(agentContext, credentialRecord)
 
-      expect(deleteCredentialMock).toHaveBeenNthCalledWith(1, credentialRecord.credentials[0].credentialRecordId)
+      expect(deleteCredentialMock).toHaveBeenNthCalledWith(
+        1,
+        agentContext,
+        credentialRecord.credentials[0].credentialRecordId
+      )
     })
     it('deleteAssociatedDidCommMessages should default to true', async () => {
       const deleteCredentialMock = mockFunction(indyCredentialFormatService.deleteCredentialById)
@@ -811,9 +837,13 @@ describe('CredentialService', () => {
       const credentialRecord = mockCredentialRecord()
       mockFunction(credentialRepository.getById).mockResolvedValue(credentialRecord)
 
-      await credentialService.delete(credentialRecord)
+      await credentialService.delete(agentContext, credentialRecord)
 
-      expect(deleteCredentialMock).toHaveBeenNthCalledWith(1, credentialRecord.credentials[0].credentialRecordId)
+      expect(deleteCredentialMock).toHaveBeenNthCalledWith(
+        1,
+        agentContext,
+        credentialRecord.credentials[0].credentialRecordId
+      )
       expect(didCommMessageRepository.delete).toHaveBeenCalledTimes(3)
     })
   })
@@ -825,12 +855,13 @@ describe('CredentialService', () => {
       })
 
       // when
-      await credentialService.declineOffer(credentialRecord)
+      await credentialService.declineOffer(agentContext, credentialRecord)
 
       // then
 
       expect(credentialRepository.update).toHaveBeenNthCalledWith(
         1,
+        agentContext,
         expect.objectContaining({
           state: CredentialState.Declined,
         })
@@ -849,7 +880,7 @@ describe('CredentialService', () => {
       mockFunction(credentialRepository.getSingleByQuery).mockResolvedValue(credentialRecord)
 
       // when
-      await credentialService.declineOffer(credentialRecord)
+      await credentialService.declineOffer(agentContext, credentialRecord)
 
       // then
       expect(eventListenerMock).toHaveBeenCalledTimes(1)
@@ -870,9 +901,9 @@ describe('CredentialService', () => {
     test(`throws an error when state transition is invalid`, async () => {
       await Promise.all(
         invalidCredentialStates.map(async (state) => {
-          await expect(credentialService.declineOffer(mockCredentialRecord({ state }))).rejects.toThrowError(
-            `Credential record is in invalid state ${state}. Valid states are: ${validState}.`
-          )
+          await expect(
+            credentialService.declineOffer(agentContext, mockCredentialRecord({ state }))
+          ).rejects.toThrowError(`Credential record is in invalid state ${state}. Valid states are: ${validState}.`)
         })
       )
     })

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2-credentials.e2e.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2-credentials.e2e.test.ts
@@ -115,7 +115,7 @@ describe('v2 credentials', () => {
     })
 
     const didCommMessageRepository = faberAgent.dependencyManager.resolve(DidCommMessageRepository)
-    const offerMessage = await didCommMessageRepository.findAgentMessage({
+    const offerMessage = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberCredentialRecord.id,
       messageClass: V2OfferCredentialMessage,
     })
@@ -227,7 +227,11 @@ describe('v2 credentials', () => {
       deleteAssociatedCredentials: true,
       deleteAssociatedDidCommMessages: true,
     })
-    expect(deleteCredentialSpy).toHaveBeenNthCalledWith(1, holderCredential.credentials[0].credentialRecordId)
+    expect(deleteCredentialSpy).toHaveBeenNthCalledWith(
+      1,
+      aliceAgent.context,
+      holderCredential.credentials[0].credentialRecordId
+    )
 
     return expect(aliceAgent.credentials.getById(holderCredential.id)).rejects.toThrowError(
       `CredentialRecord: record with id ${holderCredential.id} not found.`

--- a/packages/core/src/modules/credentials/protocol/v2/handlers/V2IssueCredentialHandler.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/handlers/V2IssueCredentialHandler.ts
@@ -1,6 +1,6 @@
-import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../../../agent/Handler'
 import type { InboundMessageContext } from '../../../../../agent/models/InboundMessageContext'
+import type { Logger } from '../../../../../logger'
 import type { DidCommMessageRepository } from '../../../../../storage'
 import type { CredentialExchangeRecord } from '../../../repository/CredentialExchangeRecord'
 import type { V2CredentialService } from '../V2CredentialService'
@@ -11,24 +11,25 @@ import { V2RequestCredentialMessage } from '../messages/V2RequestCredentialMessa
 
 export class V2IssueCredentialHandler implements Handler {
   private credentialService: V2CredentialService
-  private agentConfig: AgentConfig
   private didCommMessageRepository: DidCommMessageRepository
+  private logger: Logger
 
   public supportedMessages = [V2IssueCredentialMessage]
 
   public constructor(
     credentialService: V2CredentialService,
-    agentConfig: AgentConfig,
-    didCommMessageRepository: DidCommMessageRepository
+    didCommMessageRepository: DidCommMessageRepository,
+    logger: Logger
   ) {
     this.credentialService = credentialService
-    this.agentConfig = agentConfig
     this.didCommMessageRepository = didCommMessageRepository
+    this.logger = logger
   }
+
   public async handle(messageContext: InboundMessageContext<V2IssueCredentialMessage>) {
     const credentialRecord = await this.credentialService.processCredential(messageContext)
 
-    const shouldAutoRespond = await this.credentialService.shouldAutoRespondToCredential({
+    const shouldAutoRespond = await this.credentialService.shouldAutoRespondToCredential(messageContext.agentContext, {
       credentialRecord,
       credentialMessage: messageContext.message,
     })
@@ -42,16 +43,16 @@ export class V2IssueCredentialHandler implements Handler {
     credentialRecord: CredentialExchangeRecord,
     messageContext: HandlerInboundMessage<V2IssueCredentialHandler>
   ) {
-    this.agentConfig.logger.info(
-      `Automatically sending acknowledgement with autoAccept on ${this.agentConfig.autoAcceptCredentials}`
+    this.logger.info(
+      `Automatically sending acknowledgement with autoAccept on ${messageContext.agentContext.config.autoAcceptCredentials}`
     )
 
-    const requestMessage = await this.didCommMessageRepository.findAgentMessage({
+    const requestMessage = await this.didCommMessageRepository.findAgentMessage(messageContext.agentContext, {
       associatedRecordId: credentialRecord.id,
       messageClass: V2RequestCredentialMessage,
     })
 
-    const { message } = await this.credentialService.acceptCredential({
+    const { message } = await this.credentialService.acceptCredential(messageContext.agentContext, {
       credentialRecord,
     })
 
@@ -68,6 +69,6 @@ export class V2IssueCredentialHandler implements Handler {
       })
     }
 
-    this.agentConfig.logger.error(`Could not automatically create credential ack`)
+    this.logger.error(`Could not automatically create credential ack`)
   }
 }

--- a/packages/core/src/modules/credentials/services/CredentialService.ts
+++ b/packages/core/src/modules/credentials/services/CredentialService.ts
@@ -1,4 +1,4 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
+import type { AgentContext } from '../../../agent'
 import type { AgentMessage } from '../../../agent/AgentMessage'
 import type { Dispatcher } from '../../../agent/Dispatcher'
 import type { EventEmitter } from '../../../agent/EventEmitter'
@@ -35,7 +35,6 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
   protected didCommMessageRepository: DidCommMessageRepository
   protected eventEmitter: EventEmitter
   protected dispatcher: Dispatcher
-  protected agentConfig: AgentConfig
   protected logger: Logger
 
   public constructor(
@@ -43,14 +42,13 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
     didCommMessageRepository: DidCommMessageRepository,
     eventEmitter: EventEmitter,
     dispatcher: Dispatcher,
-    agentConfig: AgentConfig
+    logger: Logger
   ) {
     this.credentialRepository = credentialRepository
     this.didCommMessageRepository = didCommMessageRepository
     this.eventEmitter = eventEmitter
     this.dispatcher = dispatcher
-    this.agentConfig = agentConfig
-    this.logger = this.agentConfig.logger
+    this.logger = logger
   }
 
   abstract readonly version: string
@@ -60,48 +58,76 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
   ): CredentialFormatService<CFs[number]>
 
   // methods for proposal
-  abstract createProposal(options: CreateProposalOptions<CFs>): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
+  abstract createProposal(
+    agentContext: AgentContext,
+    options: CreateProposalOptions<CFs>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
   abstract processProposal(messageContext: InboundMessageContext<AgentMessage>): Promise<CredentialExchangeRecord>
-  abstract acceptProposal(options: AcceptProposalOptions<CFs>): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
+  abstract acceptProposal(
+    agentContext: AgentContext,
+    options: AcceptProposalOptions<CFs>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
   abstract negotiateProposal(
+    agentContext: AgentContext,
     options: NegotiateProposalOptions<CFs>
   ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
 
   // methods for offer
-  abstract createOffer(options: CreateOfferOptions<CFs>): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
+  abstract createOffer(
+    agentContext: AgentContext,
+    options: CreateOfferOptions<CFs>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
   abstract processOffer(messageContext: InboundMessageContext<AgentMessage>): Promise<CredentialExchangeRecord>
-  abstract acceptOffer(options: AcceptOfferOptions<CFs>): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
-  abstract negotiateOffer(options: NegotiateOfferOptions<CFs>): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
+  abstract acceptOffer(
+    agentContext: AgentContext,
+    options: AcceptOfferOptions<CFs>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
+  abstract negotiateOffer(
+    agentContext: AgentContext,
+    options: NegotiateOfferOptions<CFs>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
 
   // methods for request
-  abstract createRequest(options: CreateRequestOptions<CFs>): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
+  abstract createRequest(
+    agentContext: AgentContext,
+    options: CreateRequestOptions<CFs>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
   abstract processRequest(messageContext: InboundMessageContext<AgentMessage>): Promise<CredentialExchangeRecord>
-  abstract acceptRequest(options: AcceptRequestOptions<CFs>): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
+  abstract acceptRequest(
+    agentContext: AgentContext,
+    options: AcceptRequestOptions<CFs>
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
 
   // methods for issue
   abstract processCredential(messageContext: InboundMessageContext<AgentMessage>): Promise<CredentialExchangeRecord>
-  abstract acceptCredential(options: AcceptCredentialOptions): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
+  abstract acceptCredential(
+    agentContext: AgentContext,
+    options: AcceptCredentialOptions
+  ): Promise<CredentialProtocolMsgReturnType<AgentMessage>>
 
   // methods for ack
   abstract processAck(messageContext: InboundMessageContext<AgentMessage>): Promise<CredentialExchangeRecord>
 
   // methods for problem-report
-  abstract createProblemReport(options: CreateProblemReportOptions): ProblemReportMessage
+  abstract createProblemReport(agentContext: AgentContext, options: CreateProblemReportOptions): ProblemReportMessage
 
-  abstract findProposalMessage(credentialExchangeId: string): Promise<AgentMessage | null>
-  abstract findOfferMessage(credentialExchangeId: string): Promise<AgentMessage | null>
-  abstract findRequestMessage(credentialExchangeId: string): Promise<AgentMessage | null>
-  abstract findCredentialMessage(credentialExchangeId: string): Promise<AgentMessage | null>
-  abstract getFormatData(credentialExchangeId: string): Promise<GetFormatDataReturn<CFs>>
+  abstract findProposalMessage(agentContext: AgentContext, credentialExchangeId: string): Promise<AgentMessage | null>
+  abstract findOfferMessage(agentContext: AgentContext, credentialExchangeId: string): Promise<AgentMessage | null>
+  abstract findRequestMessage(agentContext: AgentContext, credentialExchangeId: string): Promise<AgentMessage | null>
+  abstract findCredentialMessage(agentContext: AgentContext, credentialExchangeId: string): Promise<AgentMessage | null>
+  abstract getFormatData(agentContext: AgentContext, credentialExchangeId: string): Promise<GetFormatDataReturn<CFs>>
 
   /**
    * Decline a credential offer
    * @param credentialRecord The credential to be declined
    */
-  public async declineOffer(credentialRecord: CredentialExchangeRecord): Promise<CredentialExchangeRecord> {
+  public async declineOffer(
+    agentContext: AgentContext,
+    credentialRecord: CredentialExchangeRecord
+  ): Promise<CredentialExchangeRecord> {
     credentialRecord.assertState(CredentialState.OfferReceived)
 
-    await this.updateState(credentialRecord, CredentialState.Declined)
+    await this.updateState(agentContext, credentialRecord, CredentialState.Declined)
 
     return credentialRecord
   }
@@ -122,13 +148,14 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
     this.logger.debug(`Processing problem report with id ${credentialProblemReportMessage.id}`)
 
     const credentialRecord = await this.getByThreadAndConnectionId(
+      messageContext.agentContext,
       credentialProblemReportMessage.threadId,
       connection.id
     )
 
     // Update record
     credentialRecord.errorMessage = `${credentialProblemReportMessage.description.code}: ${credentialProblemReportMessage.description.en}`
-    await this.update(credentialRecord)
+    await this.update(messageContext.agentContext, credentialRecord)
     return credentialRecord
   }
 
@@ -140,22 +167,30 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
    * @param newState The state to update to
    *
    */
-  public async updateState(credentialRecord: CredentialExchangeRecord, newState: CredentialState) {
+  public async updateState(
+    agentContext: AgentContext,
+    credentialRecord: CredentialExchangeRecord,
+    newState: CredentialState
+  ) {
     this.logger.debug(
       `Updating credential record ${credentialRecord.id} to state ${newState} (previous=${credentialRecord.state})`
     )
 
     const previousState = credentialRecord.state
     credentialRecord.state = newState
-    await this.credentialRepository.update(credentialRecord)
+    await this.credentialRepository.update(agentContext, credentialRecord)
 
-    this.emitStateChangedEvent(credentialRecord, previousState)
+    this.emitStateChangedEvent(agentContext, credentialRecord, previousState)
   }
 
-  protected emitStateChangedEvent(credentialRecord: CredentialExchangeRecord, previousState: CredentialState | null) {
+  protected emitStateChangedEvent(
+    agentContext: AgentContext,
+    credentialRecord: CredentialExchangeRecord,
+    previousState: CredentialState | null
+  ) {
     const clonedCredential = JsonTransformer.clone(credentialRecord)
 
-    this.eventEmitter.emit<CredentialStateChangedEvent>({
+    this.eventEmitter.emit<CredentialStateChangedEvent>(agentContext, {
       type: CredentialEventTypes.CredentialStateChanged,
       payload: {
         credentialRecord: clonedCredential,
@@ -172,8 +207,8 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
    * @return The credential record
    *
    */
-  public getById(credentialRecordId: string): Promise<CredentialExchangeRecord> {
-    return this.credentialRepository.getById(credentialRecordId)
+  public getById(agentContext: AgentContext, credentialRecordId: string): Promise<CredentialExchangeRecord> {
+    return this.credentialRepository.getById(agentContext, credentialRecordId)
   }
 
   /**
@@ -181,8 +216,8 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
    *
    * @returns List containing all credential records
    */
-  public getAll(): Promise<CredentialExchangeRecord[]> {
-    return this.credentialRepository.getAll()
+  public getAll(agentContext: AgentContext): Promise<CredentialExchangeRecord[]> {
+    return this.credentialRepository.getAll(agentContext)
   }
 
   /**
@@ -191,12 +226,16 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
    * @param credentialRecordId the credential record id
    * @returns The credential record or null if not found
    */
-  public findById(connectionId: string): Promise<CredentialExchangeRecord | null> {
-    return this.credentialRepository.findById(connectionId)
+  public findById(agentContext: AgentContext, connectionId: string): Promise<CredentialExchangeRecord | null> {
+    return this.credentialRepository.findById(agentContext, connectionId)
   }
 
-  public async delete(credentialRecord: CredentialExchangeRecord, options?: DeleteCredentialOptions): Promise<void> {
-    await this.credentialRepository.delete(credentialRecord)
+  public async delete(
+    agentContext: AgentContext,
+    credentialRecord: CredentialExchangeRecord,
+    options?: DeleteCredentialOptions
+  ): Promise<void> {
+    await this.credentialRepository.delete(agentContext, credentialRecord)
 
     const deleteAssociatedCredentials = options?.deleteAssociatedCredentials ?? true
     const deleteAssociatedDidCommMessages = options?.deleteAssociatedDidCommMessages ?? true
@@ -204,16 +243,16 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
     if (deleteAssociatedCredentials) {
       for (const credential of credentialRecord.credentials) {
         const formatService = this.getFormatServiceForRecordType(credential.credentialRecordType)
-        await formatService.deleteCredentialById(credential.credentialRecordId)
+        await formatService.deleteCredentialById(agentContext, credential.credentialRecordId)
       }
     }
 
     if (deleteAssociatedDidCommMessages) {
-      const didCommMessages = await this.didCommMessageRepository.findByQuery({
+      const didCommMessages = await this.didCommMessageRepository.findByQuery(agentContext, {
         associatedRecordId: credentialRecord.id,
       })
       for (const didCommMessage of didCommMessages) {
-        await this.didCommMessageRepository.delete(didCommMessage)
+        await this.didCommMessageRepository.delete(agentContext, didCommMessage)
       }
     }
   }
@@ -227,8 +266,12 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The credential record
    */
-  public getByThreadAndConnectionId(threadId: string, connectionId?: string): Promise<CredentialExchangeRecord> {
-    return this.credentialRepository.getSingleByQuery({
+  public getByThreadAndConnectionId(
+    agentContext: AgentContext,
+    threadId: string,
+    connectionId?: string
+  ): Promise<CredentialExchangeRecord> {
+    return this.credentialRepository.getSingleByQuery(agentContext, {
       connectionId,
       threadId,
     })
@@ -242,16 +285,17 @@ export abstract class CredentialService<CFs extends CredentialFormat[] = Credent
    * @returns The credential record
    */
   public findByThreadAndConnectionId(
+    agentContext: AgentContext,
     threadId: string,
     connectionId?: string
   ): Promise<CredentialExchangeRecord | null> {
-    return this.credentialRepository.findSingleByQuery({
+    return this.credentialRepository.findSingleByQuery(agentContext, {
       connectionId,
       threadId,
     })
   }
 
-  public async update(credentialRecord: CredentialExchangeRecord) {
-    return await this.credentialRepository.update(credentialRecord)
+  public async update(agentContext: AgentContext, credentialRecord: CredentialExchangeRecord) {
+    return await this.credentialRepository.update(agentContext, credentialRecord)
   }
 }

--- a/packages/core/src/modules/credentials/services/index.ts
+++ b/packages/core/src/modules/credentials/services/index.ts
@@ -1,2 +1,1 @@
 export * from './CredentialService'
-export * from '../protocol/revocation-notification/services/RevocationNotificationService'

--- a/packages/core/src/modules/dids/DidsModule.ts
+++ b/packages/core/src/modules/dids/DidsModule.ts
@@ -2,6 +2,7 @@ import type { Key } from '../../crypto'
 import type { DependencyManager } from '../../plugins'
 import type { DidResolutionOptions } from './types'
 
+import { AgentContext } from '../../agent'
 import { injectable, module } from '../../plugins'
 
 import { DidRepository } from './repository'
@@ -12,26 +13,28 @@ import { DidResolverService } from './services/DidResolverService'
 export class DidsModule {
   private resolverService: DidResolverService
   private didRepository: DidRepository
+  private agentContext: AgentContext
 
-  public constructor(resolverService: DidResolverService, didRepository: DidRepository) {
+  public constructor(resolverService: DidResolverService, didRepository: DidRepository, agentContext: AgentContext) {
     this.resolverService = resolverService
     this.didRepository = didRepository
+    this.agentContext = agentContext
   }
 
   public resolve(didUrl: string, options?: DidResolutionOptions) {
-    return this.resolverService.resolve(didUrl, options)
+    return this.resolverService.resolve(this.agentContext, didUrl, options)
   }
 
   public resolveDidDocument(didUrl: string) {
-    return this.resolverService.resolveDidDocument(didUrl)
+    return this.resolverService.resolveDidDocument(this.agentContext, didUrl)
   }
 
   public findByRecipientKey(recipientKey: Key) {
-    return this.didRepository.findByRecipientKey(recipientKey)
+    return this.didRepository.findByRecipientKey(this.agentContext, recipientKey)
   }
 
   public findAllByRecipientKey(recipientKey: Key) {
-    return this.didRepository.findAllByRecipientKey(recipientKey)
+    return this.didRepository.findAllByRecipientKey(this.agentContext, recipientKey)
   }
 
   /**

--- a/packages/core/src/modules/dids/__tests__/peer-did.test.ts
+++ b/packages/core/src/modules/dids/__tests__/peer-did.test.ts
@@ -1,6 +1,9 @@
+import type { AgentContext } from '../../../agent'
 import type { IndyLedgerService } from '../../ledger'
 
-import { getAgentConfig } from '../../../../tests/helpers'
+import { Subject } from 'rxjs'
+
+import { getAgentConfig, getAgentContext } from '../../../../tests/helpers'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { Key, KeyType } from '../../../crypto'
 import { IndyStorageService } from '../../../storage/IndyStorageService'
@@ -24,19 +27,21 @@ describe('peer dids', () => {
   let didRepository: DidRepository
   let didResolverService: DidResolverService
   let wallet: IndyWallet
+  let agentContext: AgentContext
   let eventEmitter: EventEmitter
 
   beforeEach(async () => {
-    wallet = new IndyWallet(config)
+    wallet = new IndyWallet(config.agentDependencies, config.logger)
+    agentContext = getAgentContext({ wallet })
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await wallet.createAndOpen(config.walletConfig!)
 
-    const storageService = new IndyStorageService<DidRecord>(wallet, config)
-    eventEmitter = new EventEmitter(config)
+    const storageService = new IndyStorageService<DidRecord>(config.agentDependencies)
+    eventEmitter = new EventEmitter(config.agentDependencies, new Subject())
     didRepository = new DidRepository(storageService, eventEmitter)
 
     // Mocking IndyLedgerService as we're only interested in the did:peer resolver
-    didResolverService = new DidResolverService(config, {} as unknown as IndyLedgerService, didRepository)
+    didResolverService = new DidResolverService({} as unknown as IndyLedgerService, didRepository, config.logger)
   })
 
   afterEach(async () => {
@@ -124,7 +129,7 @@ describe('peer dids', () => {
       },
     })
 
-    await didRepository.save(didDocumentRecord)
+    await didRepository.save(agentContext, didDocumentRecord)
   })
 
   test('receive a did and did document', async () => {
@@ -161,13 +166,13 @@ describe('peer dids', () => {
       },
     })
 
-    await didRepository.save(didDocumentRecord)
+    await didRepository.save(agentContext, didDocumentRecord)
 
     // Then we save the did (not the did document) in the connection record
     // connectionRecord.theirDid = didPeer.did
 
     // Then when we want to send a message we can resolve the did document
-    const { didDocument: resolvedDidDocument } = await didResolverService.resolve(did)
+    const { didDocument: resolvedDidDocument } = await didResolverService.resolve(agentContext, did)
     expect(resolvedDidDocument).toBeInstanceOf(DidDocument)
     expect(resolvedDidDocument?.toJSON()).toMatchObject(didPeer1zQmY)
   })

--- a/packages/core/src/modules/dids/domain/DidResolver.ts
+++ b/packages/core/src/modules/dids/domain/DidResolver.ts
@@ -1,6 +1,12 @@
+import type { AgentContext } from '../../../agent'
 import type { ParsedDid, DidResolutionResult, DidResolutionOptions } from '../types'
 
 export interface DidResolver {
   readonly supportedMethods: string[]
-  resolve(did: string, parsed: ParsedDid, didResolutionOptions: DidResolutionOptions): Promise<DidResolutionResult>
+  resolve(
+    agentContext: AgentContext,
+    did: string,
+    parsed: ParsedDid,
+    didResolutionOptions: DidResolutionOptions
+  ): Promise<DidResolutionResult>
 }

--- a/packages/core/src/modules/dids/methods/key/KeyDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/key/KeyDidResolver.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../../agent'
 import type { DidResolver } from '../../domain/DidResolver'
 import type { DidResolutionResult } from '../../types'
 
@@ -6,7 +7,7 @@ import { DidKey } from './DidKey'
 export class KeyDidResolver implements DidResolver {
   public readonly supportedMethods = ['key']
 
-  public async resolve(did: string): Promise<DidResolutionResult> {
+  public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 
     try {

--- a/packages/core/src/modules/dids/methods/key/__tests__/KeyDidResolver.test.ts
+++ b/packages/core/src/modules/dids/methods/key/__tests__/KeyDidResolver.test.ts
@@ -1,3 +1,6 @@
+import type { AgentContext } from '../../../../../agent'
+
+import { getAgentContext } from '../../../../../../tests/helpers'
 import { JsonTransformer } from '../../../../../utils/JsonTransformer'
 import didKeyEd25519Fixture from '../../../__tests__/__fixtures__/didKeyEd25519.json'
 import { DidKey } from '../DidKey'
@@ -6,14 +9,19 @@ import { KeyDidResolver } from '../KeyDidResolver'
 describe('DidResolver', () => {
   describe('KeyDidResolver', () => {
     let keyDidResolver: KeyDidResolver
+    let agentContext: AgentContext
 
     beforeEach(() => {
       keyDidResolver = new KeyDidResolver()
+      agentContext = getAgentContext()
     })
 
     it('should correctly resolve a did:key document', async () => {
       const fromDidSpy = jest.spyOn(DidKey, 'fromDid')
-      const result = await keyDidResolver.resolve('did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th')
+      const result = await keyDidResolver.resolve(
+        agentContext,
+        'did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th'
+      )
 
       expect(JsonTransformer.toJSON(result)).toMatchObject({
         didDocument: didKeyEd25519Fixture,
@@ -26,7 +34,10 @@ describe('DidResolver', () => {
     })
 
     it('should return did resolution metadata with error if the did contains an unsupported multibase', async () => {
-      const result = await keyDidResolver.resolve('did:key:asdfkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th')
+      const result = await keyDidResolver.resolve(
+        agentContext,
+        'did:key:asdfkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th'
+      )
 
       expect(result).toEqual({
         didDocument: null,
@@ -39,7 +50,10 @@ describe('DidResolver', () => {
     })
 
     it('should return did resolution metadata with error if the did contains an unsupported multibase', async () => {
-      const result = await keyDidResolver.resolve('did:key:z6MkmjYasdfasfd8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th')
+      const result = await keyDidResolver.resolve(
+        agentContext,
+        'did:key:z6MkmjYasdfasfd8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th'
+      )
 
       expect(result).toEqual({
         didDocument: null,

--- a/packages/core/src/modules/dids/methods/peer/PeerDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/peer/PeerDidResolver.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../../agent'
 import type { DidDocument } from '../../domain'
 import type { DidResolver } from '../../domain/DidResolver'
 import type { DidRepository } from '../../repository'
@@ -18,7 +19,7 @@ export class PeerDidResolver implements DidResolver {
     this.didRepository = didRepository
   }
 
-  public async resolve(did: string): Promise<DidResolutionResult> {
+  public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 
     try {
@@ -36,7 +37,7 @@ export class PeerDidResolver implements DidResolver {
       }
       // For Method 1, retrieve from storage
       else if (numAlgo === PeerDidNumAlgo.GenesisDoc) {
-        const didDocumentRecord = await this.didRepository.getById(did)
+        const didDocumentRecord = await this.didRepository.getById(agentContext, did)
 
         if (!didDocumentRecord.didDocument) {
           throw new AriesFrameworkError(`Found did record for method 1 peer did (${did}), but no did document.`)

--- a/packages/core/src/modules/dids/methods/sov/SovDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/sov/SovDidResolver.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../../agent'
 import type { IndyEndpointAttrib, IndyLedgerService } from '../../../ledger'
 import type { DidResolver } from '../../domain/DidResolver'
 import type { ParsedDid, DidResolutionResult } from '../../types'
@@ -22,12 +23,12 @@ export class SovDidResolver implements DidResolver {
 
   public readonly supportedMethods = ['sov']
 
-  public async resolve(did: string, parsed: ParsedDid): Promise<DidResolutionResult> {
+  public async resolve(agentContext: AgentContext, did: string, parsed: ParsedDid): Promise<DidResolutionResult> {
     const didDocumentMetadata = {}
 
     try {
-      const nym = await this.indyLedgerService.getPublicDid(parsed.id)
-      const endpoints = await this.indyLedgerService.getEndpointsForDid(did)
+      const nym = await this.indyLedgerService.getPublicDid(agentContext, parsed.id)
+      const endpoints = await this.indyLedgerService.getEndpointsForDid(agentContext, did)
 
       const verificationMethodId = `${parsed.did}#key-1`
       const keyAgreementId = `${parsed.did}#key-agreement-1`

--- a/packages/core/src/modules/dids/methods/sov/__tests__/SovDidResolver.test.ts
+++ b/packages/core/src/modules/dids/methods/sov/__tests__/SovDidResolver.test.ts
@@ -1,7 +1,8 @@
+import type { AgentContext } from '../../../../../agent'
 import type { IndyEndpointAttrib } from '../../../../ledger/services/IndyLedgerService'
 import type { GetNymResponse } from 'indy-sdk'
 
-import { mockFunction } from '../../../../../../tests/helpers'
+import { getAgentContext, mockFunction } from '../../../../../../tests/helpers'
 import { JsonTransformer } from '../../../../../utils/JsonTransformer'
 import { IndyLedgerService } from '../../../../ledger/services/IndyLedgerService'
 import didSovR1xKJw17sUoXhejEpugMYJFixture from '../../../__tests__/__fixtures__/didSovR1xKJw17sUoXhejEpugMYJ.json'
@@ -16,10 +17,12 @@ describe('DidResolver', () => {
   describe('SovDidResolver', () => {
     let ledgerService: IndyLedgerService
     let sovDidResolver: SovDidResolver
+    let agentContext: AgentContext
 
     beforeEach(() => {
       ledgerService = new IndyLedgerServiceMock()
       sovDidResolver = new SovDidResolver(ledgerService)
+      agentContext = getAgentContext()
     })
 
     it('should correctly resolve a did:sov document', async () => {
@@ -40,7 +43,7 @@ describe('DidResolver', () => {
       mockFunction(ledgerService.getPublicDid).mockResolvedValue(nymResponse)
       mockFunction(ledgerService.getEndpointsForDid).mockResolvedValue(endpoints)
 
-      const result = await sovDidResolver.resolve(did, parseDid(did))
+      const result = await sovDidResolver.resolve(agentContext, did, parseDid(did))
 
       expect(JsonTransformer.toJSON(result)).toMatchObject({
         didDocument: didSovR1xKJw17sUoXhejEpugMYJFixture,
@@ -69,7 +72,7 @@ describe('DidResolver', () => {
       mockFunction(ledgerService.getPublicDid).mockReturnValue(Promise.resolve(nymResponse))
       mockFunction(ledgerService.getEndpointsForDid).mockReturnValue(Promise.resolve(endpoints))
 
-      const result = await sovDidResolver.resolve(did, parseDid(did))
+      const result = await sovDidResolver.resolve(agentContext, did, parseDid(did))
 
       expect(JsonTransformer.toJSON(result)).toMatchObject({
         didDocument: didSovWJz9mHyW9BZksioQnRsrAoFixture,
@@ -85,7 +88,7 @@ describe('DidResolver', () => {
 
       mockFunction(ledgerService.getPublicDid).mockRejectedValue(new Error('Error retrieving did'))
 
-      const result = await sovDidResolver.resolve(did, parseDid(did))
+      const result = await sovDidResolver.resolve(agentContext, did, parseDid(did))
 
       expect(result).toMatchObject({
         didDocument: null,

--- a/packages/core/src/modules/dids/methods/web/WebDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/web/WebDidResolver.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../../agent'
 import type { DidResolver } from '../../domain/DidResolver'
 import type { ParsedDid, DidResolutionResult, DidResolutionOptions } from '../../types'
 
@@ -19,6 +20,7 @@ export class WebDidResolver implements DidResolver {
   }
 
   public async resolve(
+    agentContext: AgentContext,
     did: string,
     parsed: ParsedDid,
     didResolutionOptions: DidResolutionOptions

--- a/packages/core/src/modules/dids/repository/DidRepository.ts
+++ b/packages/core/src/modules/dids/repository/DidRepository.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../agent'
 import type { Key } from '../../../crypto'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
@@ -17,11 +18,11 @@ export class DidRepository extends Repository<DidRecord> {
     super(DidRecord, storageService, eventEmitter)
   }
 
-  public findByRecipientKey(recipientKey: Key) {
-    return this.findSingleByQuery({ recipientKeyFingerprints: [recipientKey.fingerprint] })
+  public findByRecipientKey(agentContext: AgentContext, recipientKey: Key) {
+    return this.findSingleByQuery(agentContext, { recipientKeyFingerprints: [recipientKey.fingerprint] })
   }
 
-  public findAllByRecipientKey(recipientKey: Key) {
-    return this.findByQuery({ recipientKeyFingerprints: [recipientKey.fingerprint] })
+  public findAllByRecipientKey(agentContext: AgentContext, recipientKey: Key) {
+    return this.findByQuery(agentContext, { recipientKeyFingerprints: [recipientKey.fingerprint] })
   }
 }

--- a/packages/core/src/modules/dids/services/DidResolverService.ts
+++ b/packages/core/src/modules/dids/services/DidResolverService.ts
@@ -1,10 +1,11 @@
-import type { Logger } from '../../../logger'
+import type { AgentContext } from '../../../agent'
 import type { DidResolver } from '../domain/DidResolver'
 import type { DidResolutionOptions, DidResolutionResult, ParsedDid } from '../types'
 
-import { AgentConfig } from '../../../agent/AgentConfig'
+import { InjectionSymbols } from '../../../constants'
 import { AriesFrameworkError } from '../../../error'
-import { injectable } from '../../../plugins'
+import { Logger } from '../../../logger'
+import { injectable, inject } from '../../../plugins'
 import { IndyLedgerService } from '../../ledger'
 import { parseDid } from '../domain/parse'
 import { KeyDidResolver } from '../methods/key/KeyDidResolver'
@@ -18,8 +19,12 @@ export class DidResolverService {
   private logger: Logger
   private resolvers: DidResolver[]
 
-  public constructor(agentConfig: AgentConfig, indyLedgerService: IndyLedgerService, didRepository: DidRepository) {
-    this.logger = agentConfig.logger
+  public constructor(
+    indyLedgerService: IndyLedgerService,
+    didRepository: DidRepository,
+    @inject(InjectionSymbols.Logger) logger: Logger
+  ) {
+    this.logger = logger
 
     this.resolvers = [
       new SovDidResolver(indyLedgerService),
@@ -29,7 +34,11 @@ export class DidResolverService {
     ]
   }
 
-  public async resolve(didUrl: string, options: DidResolutionOptions = {}): Promise<DidResolutionResult> {
+  public async resolve(
+    agentContext: AgentContext,
+    didUrl: string,
+    options: DidResolutionOptions = {}
+  ): Promise<DidResolutionResult> {
     this.logger.debug(`resolving didUrl ${didUrl}`)
 
     const result = {
@@ -56,14 +65,14 @@ export class DidResolverService {
       }
     }
 
-    return resolver.resolve(parsed.did, parsed, options)
+    return resolver.resolve(agentContext, parsed.did, parsed, options)
   }
 
-  public async resolveDidDocument(did: string) {
+  public async resolveDidDocument(agentContext: AgentContext, did: string) {
     const {
       didDocument,
       didResolutionMetadata: { error, message },
-    } = await this.resolve(did)
+    } = await this.resolve(agentContext, did)
 
     if (!didDocument) {
       throw new AriesFrameworkError(`Unable to resolve did document for did '${did}': ${error} ${message}`)

--- a/packages/core/src/modules/generic-records/GenericRecordsModule.ts
+++ b/packages/core/src/modules/generic-records/GenericRecordsModule.ts
@@ -1,9 +1,10 @@
-import type { Logger } from '../../logger'
 import type { DependencyManager } from '../../plugins'
 import type { GenericRecord, GenericRecordTags, SaveGenericRecordOption } from './repository/GenericRecord'
 
-import { AgentConfig } from '../../agent/AgentConfig'
-import { injectable, module } from '../../plugins'
+import { AgentContext } from '../../agent'
+import { InjectionSymbols } from '../../constants'
+import { Logger } from '../../logger'
+import { inject, injectable, module } from '../../plugins'
 
 import { GenericRecordsRepository } from './repository/GenericRecordsRepository'
 import { GenericRecordService } from './service/GenericRecordService'
@@ -17,14 +18,21 @@ export type ContentType = {
 export class GenericRecordsModule {
   private genericRecordsService: GenericRecordService
   private logger: Logger
-  public constructor(agentConfig: AgentConfig, genericRecordsService: GenericRecordService) {
+  private agentContext: AgentContext
+
+  public constructor(
+    genericRecordsService: GenericRecordService,
+    @inject(InjectionSymbols.Logger) logger: Logger,
+    agentContext: AgentContext
+  ) {
     this.genericRecordsService = genericRecordsService
-    this.logger = agentConfig.logger
+    this.logger = logger
+    this.agentContext = agentContext
   }
 
   public async save({ content, tags }: SaveGenericRecordOption) {
     try {
-      const record = await this.genericRecordsService.save({
+      const record = await this.genericRecordsService.save(this.agentContext, {
         content: content,
         tags: tags,
       })
@@ -41,7 +49,7 @@ export class GenericRecordsModule {
 
   public async delete(record: GenericRecord): Promise<void> {
     try {
-      await this.genericRecordsService.delete(record)
+      await this.genericRecordsService.delete(this.agentContext, record)
     } catch (error) {
       this.logger.error('Error while saving generic-record', {
         error,
@@ -54,7 +62,7 @@ export class GenericRecordsModule {
 
   public async update(record: GenericRecord): Promise<void> {
     try {
-      await this.genericRecordsService.update(record)
+      await this.genericRecordsService.update(this.agentContext, record)
     } catch (error) {
       this.logger.error('Error while update generic-record', {
         error,
@@ -66,15 +74,15 @@ export class GenericRecordsModule {
   }
 
   public async findById(id: string) {
-    return this.genericRecordsService.findById(id)
+    return this.genericRecordsService.findById(this.agentContext, id)
   }
 
   public async findAllByQuery(query: Partial<GenericRecordTags>): Promise<GenericRecord[]> {
-    return this.genericRecordsService.findAllByQuery(query)
+    return this.genericRecordsService.findAllByQuery(this.agentContext, query)
   }
 
   public async getAll(): Promise<GenericRecord[]> {
-    return this.genericRecordsService.getAll()
+    return this.genericRecordsService.getAll(this.agentContext)
   }
 
   /**

--- a/packages/core/src/modules/generic-records/service/GenericRecordService.ts
+++ b/packages/core/src/modules/generic-records/service/GenericRecordService.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../agent'
 import type { GenericRecordTags, SaveGenericRecordOption } from '../repository/GenericRecord'
 
 import { AriesFrameworkError } from '../../../error'
@@ -13,14 +14,14 @@ export class GenericRecordService {
     this.genericRecordsRepository = genericRecordsRepository
   }
 
-  public async save({ content, tags }: SaveGenericRecordOption) {
+  public async save(agentContext: AgentContext, { content, tags }: SaveGenericRecordOption) {
     const genericRecord = new GenericRecord({
       content: content,
       tags: tags,
     })
 
     try {
-      await this.genericRecordsRepository.save(genericRecord)
+      await this.genericRecordsRepository.save(agentContext, genericRecord)
       return genericRecord
     } catch (error) {
       throw new AriesFrameworkError(
@@ -29,31 +30,31 @@ export class GenericRecordService {
     }
   }
 
-  public async delete(record: GenericRecord): Promise<void> {
+  public async delete(agentContext: AgentContext, record: GenericRecord): Promise<void> {
     try {
-      await this.genericRecordsRepository.delete(record)
+      await this.genericRecordsRepository.delete(agentContext, record)
     } catch (error) {
       throw new AriesFrameworkError(`Unable to delete the genericRecord record with id ${record.id}. Message: ${error}`)
     }
   }
 
-  public async update(record: GenericRecord): Promise<void> {
+  public async update(agentContext: AgentContext, record: GenericRecord): Promise<void> {
     try {
-      await this.genericRecordsRepository.update(record)
+      await this.genericRecordsRepository.update(agentContext, record)
     } catch (error) {
       throw new AriesFrameworkError(`Unable to update the genericRecord record with id ${record.id}. Message: ${error}`)
     }
   }
 
-  public async findAllByQuery(query: Partial<GenericRecordTags>) {
-    return this.genericRecordsRepository.findByQuery(query)
+  public async findAllByQuery(agentContext: AgentContext, query: Partial<GenericRecordTags>) {
+    return this.genericRecordsRepository.findByQuery(agentContext, query)
   }
 
-  public async findById(id: string): Promise<GenericRecord | null> {
-    return this.genericRecordsRepository.findById(id)
+  public async findById(agentContext: AgentContext, id: string): Promise<GenericRecord | null> {
+    return this.genericRecordsRepository.findById(agentContext, id)
   }
 
-  public async getAll() {
-    return this.genericRecordsRepository.getAll()
+  public async getAll(agentContext: AgentContext) {
+    return this.genericRecordsRepository.getAll(agentContext)
   }
 }

--- a/packages/core/src/modules/indy/services/IndyUtilitiesService.ts
+++ b/packages/core/src/modules/indy/services/IndyUtilitiesService.ts
@@ -1,11 +1,12 @@
-import type { Logger } from '../../../logger'
-import type { FileSystem } from '../../../storage/FileSystem'
-import type { default as Indy, BlobReaderHandle } from 'indy-sdk'
+import type { BlobReaderHandle, default as Indy } from 'indy-sdk'
 
-import { AgentConfig } from '../../../agent/AgentConfig'
+import { AgentDependencies } from '../../../agent/AgentDependencies'
+import { InjectionSymbols } from '../../../constants'
 import { AriesFrameworkError } from '../../../error'
 import { IndySdkError } from '../../../error/IndySdkError'
-import { injectable } from '../../../plugins'
+import { Logger } from '../../../logger'
+import { injectable, inject } from '../../../plugins'
+import { FileSystem } from '../../../storage/FileSystem'
 import { isIndyError } from '../../../utils/indyError'
 import { getDirFromFilePath } from '../../../utils/path'
 
@@ -15,10 +16,14 @@ export class IndyUtilitiesService {
   private logger: Logger
   private fileSystem: FileSystem
 
-  public constructor(agentConfig: AgentConfig) {
-    this.indy = agentConfig.agentDependencies.indy
-    this.logger = agentConfig.logger
-    this.fileSystem = agentConfig.fileSystem
+  public constructor(
+    @inject(InjectionSymbols.Logger) logger: Logger,
+    @inject(InjectionSymbols.FileSystem) fileSystem: FileSystem,
+    @inject(InjectionSymbols.AgentDependencies) agentDependencies: AgentDependencies
+  ) {
+    this.indy = agentDependencies.indy
+    this.logger = logger
+    this.fileSystem = fileSystem
   }
 
   /**

--- a/packages/core/src/modules/indy/services/IndyVerifierService.ts
+++ b/packages/core/src/modules/indy/services/IndyVerifierService.ts
@@ -1,8 +1,10 @@
+import type { AgentContext } from '../../../agent'
 import type * as Indy from 'indy-sdk'
 
-import { AgentConfig } from '../../../agent/AgentConfig'
+import { AgentDependencies } from '../../../agent/AgentDependencies'
+import { InjectionSymbols } from '../../../constants'
 import { IndySdkError } from '../../../error'
-import { injectable } from '../../../plugins'
+import { injectable, inject } from '../../../plugins'
 import { isIndyError } from '../../../utils/indyError'
 import { IndyLedgerService } from '../../ledger/services/IndyLedgerService'
 
@@ -11,19 +13,23 @@ export class IndyVerifierService {
   private indy: typeof Indy
   private ledgerService: IndyLedgerService
 
-  public constructor(agentConfig: AgentConfig, ledgerService: IndyLedgerService) {
-    this.indy = agentConfig.agentDependencies.indy
+  public constructor(
+    ledgerService: IndyLedgerService,
+    @inject(InjectionSymbols.AgentDependencies) agentDependencies: AgentDependencies
+  ) {
+    this.indy = agentDependencies.indy
     this.ledgerService = ledgerService
   }
 
-  public async verifyProof({
-    proofRequest,
-    proof,
-    schemas,
-    credentialDefinitions,
-  }: VerifyProofOptions): Promise<boolean> {
+  public async verifyProof(
+    agentContext: AgentContext,
+    { proofRequest, proof, schemas, credentialDefinitions }: VerifyProofOptions
+  ): Promise<boolean> {
     try {
-      const { revocationRegistryDefinitions, revocationRegistryStates } = await this.getRevocationRegistries(proof)
+      const { revocationRegistryDefinitions, revocationRegistryStates } = await this.getRevocationRegistries(
+        agentContext,
+        proof
+      )
 
       return await this.indy.verifierVerifyProof(
         proofRequest,
@@ -38,7 +44,7 @@ export class IndyVerifierService {
     }
   }
 
-  private async getRevocationRegistries(proof: Indy.IndyProof) {
+  private async getRevocationRegistries(agentContext: AgentContext, proof: Indy.IndyProof) {
     const revocationRegistryDefinitions: Indy.RevocRegDefs = {}
     const revocationRegistryStates: Indy.RevStates = Object.create(null)
     for (const identifier of proof.identifiers) {
@@ -48,6 +54,7 @@ export class IndyVerifierService {
       //Fetch Revocation Registry Definition if not already fetched
       if (revocationRegistryId && !revocationRegistryDefinitions[revocationRegistryId]) {
         const { revocationRegistryDefinition } = await this.ledgerService.getRevocationRegistryDefinition(
+          agentContext,
           revocationRegistryId
         )
         revocationRegistryDefinitions[revocationRegistryId] = revocationRegistryDefinition
@@ -58,7 +65,11 @@ export class IndyVerifierService {
         if (!revocationRegistryStates[revocationRegistryId]) {
           revocationRegistryStates[revocationRegistryId] = Object.create(null)
         }
-        const { revocationRegistry } = await this.ledgerService.getRevocationRegistry(revocationRegistryId, timestamp)
+        const { revocationRegistry } = await this.ledgerService.getRevocationRegistry(
+          agentContext,
+          revocationRegistryId,
+          timestamp
+        )
         revocationRegistryStates[revocationRegistryId][timestamp] = revocationRegistry
       }
     }

--- a/packages/core/src/modules/indy/services/__mocks__/IndyHolderService.ts
+++ b/packages/core/src/modules/indy/services/__mocks__/IndyHolderService.ts
@@ -1,11 +1,11 @@
 import type { CreateCredentialRequestOptions, StoreCredentialOptions } from '../IndyHolderService'
 
 export const IndyHolderService = jest.fn(() => ({
-  storeCredential: jest.fn(({ credentialId }: StoreCredentialOptions) =>
+  storeCredential: jest.fn((_, { credentialId }: StoreCredentialOptions) =>
     Promise.resolve(credentialId ?? 'some-random-uuid')
   ),
   deleteCredential: jest.fn(() => Promise.resolve()),
-  createCredentialRequest: jest.fn(({ holderDid, credentialDefinition }: CreateCredentialRequestOptions) =>
+  createCredentialRequest: jest.fn((_, { holderDid, credentialDefinition }: CreateCredentialRequestOptions) =>
     Promise.resolve([
       {
         prover_did: holderDid,

--- a/packages/core/src/modules/indy/services/__mocks__/IndyIssuerService.ts
+++ b/packages/core/src/modules/indy/services/__mocks__/IndyIssuerService.ts
@@ -13,7 +13,7 @@ export const IndyIssuerService = jest.fn(() => ({
     ])
   ),
 
-  createCredentialOffer: jest.fn((credentialDefinitionId: string) =>
+  createCredentialOffer: jest.fn((_, credentialDefinitionId: string) =>
     Promise.resolve({
       schema_id: 'aaa',
       cred_def_id: credentialDefinitionId,

--- a/packages/core/src/modules/ledger/IndyPool.ts
+++ b/packages/core/src/modules/ledger/IndyPool.ts
@@ -1,7 +1,8 @@
-import type { AgentConfig } from '../../agent/AgentConfig'
+import type { AgentDependencies } from '../../agent/AgentDependencies'
 import type { Logger } from '../../logger'
 import type { FileSystem } from '../../storage/FileSystem'
 import type * as Indy from 'indy-sdk'
+import type { Subject } from 'rxjs'
 
 import { AriesFrameworkError, IndySdkError } from '../../error'
 import { isIndyError } from '../../utils/indyError'
@@ -31,14 +32,20 @@ export class IndyPool {
   private poolConnected?: Promise<number>
   public authorAgreement?: AuthorAgreement | null
 
-  public constructor(agentConfig: AgentConfig, poolConfig: IndyPoolConfig) {
-    this.indy = agentConfig.agentDependencies.indy
+  public constructor(
+    poolConfig: IndyPoolConfig,
+    agentDependencies: AgentDependencies,
+    logger: Logger,
+    stop$: Subject<boolean>,
+    fileSystem: FileSystem
+  ) {
+    this.indy = agentDependencies.indy
+    this.fileSystem = fileSystem
     this.poolConfig = poolConfig
-    this.fileSystem = agentConfig.fileSystem
-    this.logger = agentConfig.logger
+    this.logger = logger
 
     // Listen to stop$ (shutdown) and close pool
-    agentConfig.stop$.subscribe(async () => {
+    stop$.subscribe(async () => {
       if (this._poolHandle) {
         await this.close()
       }

--- a/packages/core/src/modules/ledger/LedgerModule.ts
+++ b/packages/core/src/modules/ledger/LedgerModule.ts
@@ -1,23 +1,27 @@
 import type { DependencyManager } from '../../plugins'
-import type { SchemaTemplate, CredentialDefinitionTemplate } from './services'
+import type { IndyPoolConfig } from './IndyPool'
+import type { CredentialDefinitionTemplate, SchemaTemplate } from './services'
 import type { NymRole } from 'indy-sdk'
 
-import { InjectionSymbols } from '../../constants'
+import { AgentContext } from '../../agent'
 import { AriesFrameworkError } from '../../error'
-import { injectable, module, inject } from '../../plugins'
-import { Wallet } from '../../wallet/Wallet'
+import { injectable, module } from '../../plugins'
 
-import { IndyPoolService, IndyLedgerService } from './services'
+import { IndyLedgerService, IndyPoolService } from './services'
 
 @module()
 @injectable()
 export class LedgerModule {
   private ledgerService: IndyLedgerService
-  private wallet: Wallet
+  private agentContext: AgentContext
 
-  public constructor(@inject(InjectionSymbols.Wallet) wallet: Wallet, ledgerService: IndyLedgerService) {
+  public constructor(ledgerService: IndyLedgerService, agentContext: AgentContext) {
     this.ledgerService = ledgerService
-    this.wallet = wallet
+    this.agentContext = agentContext
+  }
+
+  public setPools(poolConfigs: IndyPoolConfig[]) {
+    return this.ledgerService.setPools(poolConfigs)
   }
 
   /**
@@ -28,54 +32,54 @@ export class LedgerModule {
   }
 
   public async registerPublicDid(did: string, verkey: string, alias: string, role?: NymRole) {
-    const myPublicDid = this.wallet.publicDid?.did
+    const myPublicDid = this.agentContext.wallet.publicDid?.did
 
     if (!myPublicDid) {
       throw new AriesFrameworkError('Agent has no public DID.')
     }
 
-    return this.ledgerService.registerPublicDid(myPublicDid, did, verkey, alias, role)
+    return this.ledgerService.registerPublicDid(this.agentContext, myPublicDid, did, verkey, alias, role)
   }
 
   public async getPublicDid(did: string) {
-    return this.ledgerService.getPublicDid(did)
+    return this.ledgerService.getPublicDid(this.agentContext, did)
   }
 
   public async registerSchema(schema: SchemaTemplate) {
-    const did = this.wallet.publicDid?.did
+    const did = this.agentContext.wallet.publicDid?.did
 
     if (!did) {
       throw new AriesFrameworkError('Agent has no public DID.')
     }
 
-    return this.ledgerService.registerSchema(did, schema)
+    return this.ledgerService.registerSchema(this.agentContext, did, schema)
   }
 
   public async getSchema(id: string) {
-    return this.ledgerService.getSchema(id)
+    return this.ledgerService.getSchema(this.agentContext, id)
   }
 
   public async registerCredentialDefinition(
     credentialDefinitionTemplate: Omit<CredentialDefinitionTemplate, 'signatureType'>
   ) {
-    const did = this.wallet.publicDid?.did
+    const did = this.agentContext.wallet.publicDid?.did
 
     if (!did) {
       throw new AriesFrameworkError('Agent has no public DID.')
     }
 
-    return this.ledgerService.registerCredentialDefinition(did, {
+    return this.ledgerService.registerCredentialDefinition(this.agentContext, did, {
       ...credentialDefinitionTemplate,
       signatureType: 'CL',
     })
   }
 
   public async getCredentialDefinition(id: string) {
-    return this.ledgerService.getCredentialDefinition(id)
+    return this.ledgerService.getCredentialDefinition(this.agentContext, id)
   }
 
   public async getRevocationRegistryDefinition(revocationRegistryDefinitionId: string) {
-    return this.ledgerService.getRevocationRegistryDefinition(revocationRegistryDefinitionId)
+    return this.ledgerService.getRevocationRegistryDefinition(this.agentContext, revocationRegistryDefinitionId)
   }
 
   public async getRevocationRegistryDelta(
@@ -83,7 +87,12 @@ export class LedgerModule {
     fromSeconds = 0,
     toSeconds = new Date().getTime()
   ) {
-    return this.ledgerService.getRevocationRegistryDelta(revocationRegistryDefinitionId, fromSeconds, toSeconds)
+    return this.ledgerService.getRevocationRegistryDelta(
+      this.agentContext,
+      revocationRegistryDefinitionId,
+      fromSeconds,
+      toSeconds
+    )
   }
 
   /**

--- a/packages/core/src/modules/ledger/__tests__/IndyPoolService.test.ts
+++ b/packages/core/src/modules/ledger/__tests__/IndyPoolService.test.ts
@@ -1,7 +1,11 @@
+import type { AgentContext } from '../../../agent'
 import type { IndyPoolConfig } from '../IndyPool'
 import type { CachedDidResponse } from '../services/IndyPoolService'
 
-import { getAgentConfig, mockFunction } from '../../../../tests/helpers'
+import { Subject } from 'rxjs'
+
+import { NodeFileSystem } from '../../../../../node/src/NodeFileSystem'
+import { agentDependencies, getAgentConfig, getAgentContext, mockFunction } from '../../../../tests/helpers'
 import { CacheRecord } from '../../../cache'
 import { CacheRepository } from '../../../cache/CacheRepository'
 import { AriesFrameworkError } from '../../../error/AriesFrameworkError'
@@ -53,12 +57,14 @@ describe('IndyPoolService', () => {
   const config = getAgentConfig('IndyPoolServiceTest', {
     indyLedgers: pools,
   })
+  let agentContext: AgentContext
   let wallet: IndyWallet
   let poolService: IndyPoolService
   let cacheRepository: CacheRepository
 
   beforeAll(async () => {
-    wallet = new IndyWallet(config)
+    wallet = new IndyWallet(config.agentDependencies, config.logger)
+    agentContext = getAgentContext()
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await wallet.createAndOpen(config.walletConfig!)
   })
@@ -71,7 +77,15 @@ describe('IndyPoolService', () => {
     cacheRepository = new CacheRepositoryMock()
     mockFunction(cacheRepository.findById).mockResolvedValue(null)
 
-    poolService = new IndyPoolService(config, cacheRepository)
+    poolService = new IndyPoolService(
+      cacheRepository,
+      agentDependencies,
+      config.logger,
+      new Subject<boolean>(),
+      new NodeFileSystem()
+    )
+
+    poolService.setPools(pools)
   })
 
   describe('ledgerWritePool', () => {
@@ -79,20 +93,18 @@ describe('IndyPoolService', () => {
       expect(poolService.ledgerWritePool).toBe(poolService.pools[0])
     })
 
-    it('should throw a LedgerNotConfiguredError error if no pools are configured on the agent', async () => {
-      const config = getAgentConfig('IndyPoolServiceTest', { indyLedgers: [] })
-      poolService = new IndyPoolService(config, cacheRepository)
+    it('should throw a LedgerNotConfiguredError error if no pools are configured on the pool service', async () => {
+      poolService.setPools([])
 
       expect(() => poolService.ledgerWritePool).toThrow(LedgerNotConfiguredError)
     })
   })
 
   describe('getPoolForDid', () => {
-    it('should throw a LedgerNotConfiguredError error if no pools are configured on the agent', async () => {
-      const config = getAgentConfig('IndyPoolServiceTest', { indyLedgers: [] })
-      poolService = new IndyPoolService(config, cacheRepository)
+    it('should throw a LedgerNotConfiguredError error if no pools are configured on the pool service', async () => {
+      poolService.setPools([])
 
-      expect(poolService.getPoolForDid('some-did')).rejects.toThrow(LedgerNotConfiguredError)
+      expect(poolService.getPoolForDid(agentContext, 'some-did')).rejects.toThrow(LedgerNotConfiguredError)
     })
 
     it('should throw a LedgerError if all ledger requests throw an error other than NotFoundError', async () => {
@@ -103,7 +115,7 @@ describe('IndyPoolService', () => {
         spy.mockImplementationOnce(() => Promise.reject(new AriesFrameworkError('Something went wrong')))
       })
 
-      expect(poolService.getPoolForDid(did)).rejects.toThrowError(LedgerError)
+      expect(poolService.getPoolForDid(agentContext, did)).rejects.toThrowError(LedgerError)
     })
 
     it('should throw a LedgerNotFoundError if all pools did not find the did on the ledger', async () => {
@@ -116,7 +128,7 @@ describe('IndyPoolService', () => {
         spy.mockImplementationOnce(responses[index])
       })
 
-      expect(poolService.getPoolForDid(did)).rejects.toThrowError(LedgerNotFoundError)
+      expect(poolService.getPoolForDid(agentContext, did)).rejects.toThrowError(LedgerNotFoundError)
     })
 
     it('should return the pool if the did was only found on one ledger', async () => {
@@ -131,7 +143,7 @@ describe('IndyPoolService', () => {
         spy.mockImplementationOnce(responses[index])
       })
 
-      const { pool } = await poolService.getPoolForDid(did)
+      const { pool } = await poolService.getPoolForDid(agentContext, did)
 
       expect(pool.config.id).toBe('sovrinMain')
     })
@@ -150,7 +162,7 @@ describe('IndyPoolService', () => {
         spy.mockImplementationOnce(responses[index])
       })
 
-      const { pool } = await poolService.getPoolForDid(did)
+      const { pool } = await poolService.getPoolForDid(agentContext, did)
 
       expect(pool.config.id).toBe('sovrinBuilder')
     })
@@ -168,7 +180,7 @@ describe('IndyPoolService', () => {
         spy.mockImplementationOnce(responses[index])
       })
 
-      const { pool } = await poolService.getPoolForDid(did)
+      const { pool } = await poolService.getPoolForDid(agentContext, did)
 
       expect(pool.config.id).toBe('indicioMain')
     })
@@ -186,7 +198,7 @@ describe('IndyPoolService', () => {
         spy.mockImplementationOnce(responses[index])
       })
 
-      const { pool } = await poolService.getPoolForDid(did)
+      const { pool } = await poolService.getPoolForDid(agentContext, did)
 
       expect(pool.config.id).toBe('sovrinMain')
     })
@@ -205,7 +217,7 @@ describe('IndyPoolService', () => {
         spy.mockImplementationOnce(responses[index])
       })
 
-      const { pool } = await poolService.getPoolForDid(did)
+      const { pool } = await poolService.getPoolForDid(agentContext, did)
 
       expect(pool.config.id).toBe('sovrinBuilder')
     })
@@ -238,9 +250,7 @@ describe('IndyPoolService', () => {
         })
       )
 
-      poolService = new IndyPoolService(config, cacheRepository)
-
-      const { pool } = await poolService.getPoolForDid(did)
+      const { pool } = await poolService.getPoolForDid(agentContext, did)
 
       expect(pool.config.id).toBe(pool.id)
     })
@@ -261,17 +271,16 @@ describe('IndyPoolService', () => {
 
       const spy = mockFunction(cacheRepository.update).mockResolvedValue()
 
-      poolService = new IndyPoolService(config, cacheRepository)
       poolService.pools.forEach((pool, index) => {
         const spy = jest.spyOn(pool, 'submitReadRequest')
         spy.mockImplementationOnce(responses[index])
       })
 
-      const { pool } = await poolService.getPoolForDid(did)
+      const { pool } = await poolService.getPoolForDid(agentContext, did)
 
       expect(pool.config.id).toBe('sovrinBuilder')
 
-      const cacheRecord = spy.mock.calls[0][0]
+      const cacheRecord = spy.mock.calls[0][1]
       expect(cacheRecord.entries.length).toBe(1)
       expect(cacheRecord.entries[0].key).toBe(did)
       expect(cacheRecord.entries[0].value).toEqual({

--- a/packages/core/src/modules/ledger/services/IndyLedgerService.ts
+++ b/packages/core/src/modules/ledger/services/IndyLedgerService.ts
@@ -1,8 +1,8 @@
-import type { Logger } from '../../../logger'
-import type { AcceptanceMechanisms, AuthorAgreement, IndyPool } from '../IndyPool'
+import type { AgentContext } from '../../../agent'
+import type { AcceptanceMechanisms, AuthorAgreement, IndyPool, IndyPoolConfig } from '../IndyPool'
 import type {
-  default as Indy,
   CredDef,
+  default as Indy,
   LedgerReadReplyResponse,
   LedgerRequest,
   LedgerWriteReplyResponse,
@@ -10,16 +10,18 @@ import type {
   Schema,
 } from 'indy-sdk'
 
-import { AgentConfig } from '../../../agent/AgentConfig'
+import { AgentDependencies } from '../../../agent/AgentDependencies'
+import { InjectionSymbols } from '../../../constants'
 import { IndySdkError } from '../../../error/IndySdkError'
-import { injectable } from '../../../plugins'
+import { Logger } from '../../../logger'
+import { injectable, inject } from '../../../plugins'
 import {
-  didFromSchemaId,
   didFromCredentialDefinitionId,
   didFromRevocationRegistryDefinitionId,
+  didFromSchemaId,
 } from '../../../utils/did'
 import { isIndyError } from '../../../utils/indyError'
-import { IndyWallet } from '../../../wallet/IndyWallet'
+import { assertIndyWallet } from '../../../wallet/util/assertIndyWallet'
 import { IndyIssuerService } from '../../indy/services/IndyIssuerService'
 import { LedgerError } from '../error/LedgerError'
 
@@ -27,7 +29,6 @@ import { IndyPoolService } from './IndyPoolService'
 
 @injectable()
 export class IndyLedgerService {
-  private wallet: IndyWallet
   private indy: typeof Indy
   private logger: Logger
 
@@ -35,16 +36,19 @@ export class IndyLedgerService {
   private indyPoolService: IndyPoolService
 
   public constructor(
-    wallet: IndyWallet,
-    agentConfig: AgentConfig,
+    @inject(InjectionSymbols.AgentDependencies) agentDependencies: AgentDependencies,
+    @inject(InjectionSymbols.Logger) logger: Logger,
     indyIssuer: IndyIssuerService,
     indyPoolService: IndyPoolService
   ) {
-    this.wallet = wallet
-    this.indy = agentConfig.agentDependencies.indy
-    this.logger = agentConfig.logger
+    this.indy = agentDependencies.indy
+    this.logger = logger
     this.indyIssuer = indyIssuer
     this.indyPoolService = indyPoolService
+  }
+
+  public setPools(poolConfigs: IndyPoolConfig[]) {
+    return this.indyPoolService.setPools(poolConfigs)
   }
 
   public async connectToPools() {
@@ -52,6 +56,7 @@ export class IndyLedgerService {
   }
 
   public async registerPublicDid(
+    agentContext: AgentContext,
     submitterDid: string,
     targetDid: string,
     verkey: string,
@@ -65,7 +70,7 @@ export class IndyLedgerService {
 
       const request = await this.indy.buildNymRequest(submitterDid, targetDid, verkey, alias, role || null)
 
-      const response = await this.submitWriteRequest(pool, request, submitterDid)
+      const response = await this.submitWriteRequest(agentContext, pool, request, submitterDid)
 
       this.logger.debug(`Registered public did '${targetDid}' on ledger '${pool.id}'`, {
         response,
@@ -87,15 +92,15 @@ export class IndyLedgerService {
     }
   }
 
-  public async getPublicDid(did: string) {
+  public async getPublicDid(agentContext: AgentContext, did: string) {
     // Getting the pool for a did also retrieves the DID. We can just use that
-    const { did: didResponse } = await this.indyPoolService.getPoolForDid(did)
+    const { did: didResponse } = await this.indyPoolService.getPoolForDid(agentContext, did)
 
     return didResponse
   }
 
-  public async getEndpointsForDid(did: string) {
-    const { pool } = await this.indyPoolService.getPoolForDid(did)
+  public async getEndpointsForDid(agentContext: AgentContext, did: string) {
+    const { pool } = await this.indyPoolService.getPoolForDid(agentContext, did)
 
     try {
       this.logger.debug(`Get endpoints for did '${did}' from ledger '${pool.id}'`)
@@ -123,17 +128,21 @@ export class IndyLedgerService {
     }
   }
 
-  public async registerSchema(did: string, schemaTemplate: SchemaTemplate): Promise<Schema> {
+  public async registerSchema(
+    agentContext: AgentContext,
+    did: string,
+    schemaTemplate: SchemaTemplate
+  ): Promise<Schema> {
     const pool = this.indyPoolService.ledgerWritePool
 
     try {
       this.logger.debug(`Register schema on ledger '${pool.id}' with did '${did}'`, schemaTemplate)
       const { name, attributes, version } = schemaTemplate
-      const schema = await this.indyIssuer.createSchema({ originDid: did, name, version, attributes })
+      const schema = await this.indyIssuer.createSchema(agentContext, { originDid: did, name, version, attributes })
 
       const request = await this.indy.buildSchemaRequest(did, schema)
 
-      const response = await this.submitWriteRequest(pool, request, did)
+      const response = await this.submitWriteRequest(agentContext, pool, request, did)
       this.logger.debug(`Registered schema '${schema.id}' on ledger '${pool.id}'`, {
         response,
         schema,
@@ -153,9 +162,9 @@ export class IndyLedgerService {
     }
   }
 
-  public async getSchema(schemaId: string) {
+  public async getSchema(agentContext: AgentContext, schemaId: string) {
     const did = didFromSchemaId(schemaId)
-    const { pool } = await this.indyPoolService.getPoolForDid(did)
+    const { pool } = await this.indyPoolService.getPoolForDid(agentContext, did)
 
     try {
       this.logger.debug(`Getting schema '${schemaId}' from ledger '${pool.id}'`)
@@ -186,6 +195,7 @@ export class IndyLedgerService {
   }
 
   public async registerCredentialDefinition(
+    agentContext: AgentContext,
     did: string,
     credentialDefinitionTemplate: CredentialDefinitionTemplate
   ): Promise<CredDef> {
@@ -198,7 +208,7 @@ export class IndyLedgerService {
       )
       const { schema, tag, signatureType, supportRevocation } = credentialDefinitionTemplate
 
-      const credentialDefinition = await this.indyIssuer.createCredentialDefinition({
+      const credentialDefinition = await this.indyIssuer.createCredentialDefinition(agentContext, {
         issuerDid: did,
         schema,
         tag,
@@ -208,7 +218,7 @@ export class IndyLedgerService {
 
       const request = await this.indy.buildCredDefRequest(did, credentialDefinition)
 
-      const response = await this.submitWriteRequest(pool, request, did)
+      const response = await this.submitWriteRequest(agentContext, pool, request, did)
 
       this.logger.debug(`Registered credential definition '${credentialDefinition.id}' on ledger '${pool.id}'`, {
         response,
@@ -230,9 +240,9 @@ export class IndyLedgerService {
     }
   }
 
-  public async getCredentialDefinition(credentialDefinitionId: string) {
+  public async getCredentialDefinition(agentContext: AgentContext, credentialDefinitionId: string) {
     const did = didFromCredentialDefinitionId(credentialDefinitionId)
-    const { pool } = await this.indyPoolService.getPoolForDid(did)
+    const { pool } = await this.indyPoolService.getPoolForDid(agentContext, did)
 
     this.logger.debug(`Using ledger '${pool.id}' to retrieve credential definition '${credentialDefinitionId}'`)
 
@@ -266,10 +276,11 @@ export class IndyLedgerService {
   }
 
   public async getRevocationRegistryDefinition(
+    agentContext: AgentContext,
     revocationRegistryDefinitionId: string
   ): Promise<ParseRevocationRegistryDefinitionTemplate> {
     const did = didFromRevocationRegistryDefinitionId(revocationRegistryDefinitionId)
-    const { pool } = await this.indyPoolService.getPoolForDid(did)
+    const { pool } = await this.indyPoolService.getPoolForDid(agentContext, did)
 
     this.logger.debug(
       `Using ledger '${pool.id}' to retrieve revocation registry definition '${revocationRegistryDefinitionId}'`
@@ -313,15 +324,16 @@ export class IndyLedgerService {
     }
   }
 
-  //Retrieves the accumulated state of a revocation registry by id given a revocation interval from & to (used primarily for proof creation)
+  // Retrieves the accumulated state of a revocation registry by id given a revocation interval from & to (used primarily for proof creation)
   public async getRevocationRegistryDelta(
+    agentContext: AgentContext,
     revocationRegistryDefinitionId: string,
     to: number = new Date().getTime(),
     from = 0
   ): Promise<ParseRevocationRegistryDeltaTemplate> {
     //TODO - implement a cache
     const did = didFromRevocationRegistryDefinitionId(revocationRegistryDefinitionId)
-    const { pool } = await this.indyPoolService.getPoolForDid(did)
+    const { pool } = await this.indyPoolService.getPoolForDid(agentContext, did)
 
     this.logger.debug(
       `Using ledger '${pool.id}' to retrieve revocation registry delta with revocation registry definition id: '${revocationRegistryDefinitionId}'`,
@@ -369,14 +381,15 @@ export class IndyLedgerService {
     }
   }
 
-  //Retrieves the accumulated state of a revocation registry by id given a timestamp (used primarily for verification)
+  // Retrieves the accumulated state of a revocation registry by id given a timestamp (used primarily for verification)
   public async getRevocationRegistry(
+    agentContext: AgentContext,
     revocationRegistryDefinitionId: string,
     timestamp: number
   ): Promise<ParseRevocationRegistryTemplate> {
     //TODO - implement a cache
     const did = didFromRevocationRegistryDefinitionId(revocationRegistryDefinitionId)
-    const { pool } = await this.indyPoolService.getPoolForDid(did)
+    const { pool } = await this.indyPoolService.getPoolForDid(agentContext, did)
 
     this.logger.debug(
       `Using ledger '${pool.id}' to retrieve revocation registry accumulated state with revocation registry definition id: '${revocationRegistryDefinitionId}'`,
@@ -417,13 +430,14 @@ export class IndyLedgerService {
   }
 
   private async submitWriteRequest(
+    agentContext: AgentContext,
     pool: IndyPool,
     request: LedgerRequest,
     signDid: string
   ): Promise<LedgerWriteReplyResponse> {
     try {
       const requestWithTaa = await this.appendTaa(pool, request)
-      const signedRequestWithTaa = await this.signRequest(signDid, requestWithTaa)
+      const signedRequestWithTaa = await this.signRequest(agentContext, signDid, requestWithTaa)
 
       const response = await pool.submitWriteRequest(signedRequestWithTaa)
 
@@ -443,9 +457,11 @@ export class IndyLedgerService {
     }
   }
 
-  private async signRequest(did: string, request: LedgerRequest): Promise<LedgerRequest> {
+  private async signRequest(agentContext: AgentContext, did: string, request: LedgerRequest): Promise<LedgerRequest> {
+    assertIndyWallet(agentContext.wallet)
+
     try {
-      return this.indy.signRequest(this.wallet.handle, did, request)
+      return this.indy.signRequest(agentContext.wallet.handle, did, request)
     } catch (error) {
       throw isIndyError(error) ? new IndySdkError(error) : error
     }

--- a/packages/core/src/modules/oob/OutOfBandModule.ts
+++ b/packages/core/src/modules/oob/OutOfBandModule.ts
@@ -2,7 +2,6 @@ import type { AgentMessage } from '../../agent/AgentMessage'
 import type { AgentMessageReceivedEvent } from '../../agent/Events'
 import type { Key } from '../../crypto'
 import type { Attachment } from '../../decorators/attachment/Attachment'
-import type { Logger } from '../../logger'
 import type { ConnectionInvitationMessage, ConnectionRecord, Routing } from '../../modules/connections'
 import type { DependencyManager } from '../../plugins'
 import type { PlaintextMessage } from '../../types'
@@ -10,16 +9,18 @@ import type { HandshakeReusedEvent } from './domain/OutOfBandEvents'
 
 import { catchError, EmptyError, first, firstValueFrom, map, of, timeout } from 'rxjs'
 
-import { AgentConfig } from '../../agent/AgentConfig'
+import { AgentContext } from '../../agent'
 import { Dispatcher } from '../../agent/Dispatcher'
 import { EventEmitter } from '../../agent/EventEmitter'
 import { AgentEventTypes } from '../../agent/Events'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
+import { InjectionSymbols } from '../../constants'
 import { ServiceDecorator } from '../../decorators/service/ServiceDecorator'
 import { AriesFrameworkError } from '../../error'
+import { Logger } from '../../logger'
 import { ConnectionsModule, DidExchangeState, HandshakeProtocol } from '../../modules/connections'
-import { injectable, module } from '../../plugins'
+import { inject, injectable, module } from '../../plugins'
 import { DidCommMessageRepository, DidCommMessageRole } from '../../storage'
 import { JsonEncoder, JsonTransformer } from '../../utils'
 import { parseMessageType, supportsIncomingMessageType } from '../../utils/messageType'
@@ -87,22 +88,23 @@ export class OutOfBandModule {
   private dispatcher: Dispatcher
   private messageSender: MessageSender
   private eventEmitter: EventEmitter
-  private agentConfig: AgentConfig
+  private agentContext: AgentContext
   private logger: Logger
 
   public constructor(
     dispatcher: Dispatcher,
-    agentConfig: AgentConfig,
     outOfBandService: OutOfBandService,
     routingService: RoutingService,
     connectionsModule: ConnectionsModule,
     didCommMessageRepository: DidCommMessageRepository,
     messageSender: MessageSender,
-    eventEmitter: EventEmitter
+    eventEmitter: EventEmitter,
+    @inject(InjectionSymbols.Logger) logger: Logger,
+    agentContext: AgentContext
   ) {
     this.dispatcher = dispatcher
-    this.agentConfig = agentConfig
-    this.logger = agentConfig.logger
+    this.agentContext = agentContext
+    this.logger = logger
     this.outOfBandService = outOfBandService
     this.routingService = routingService
     this.connectionsModule = connectionsModule
@@ -131,11 +133,11 @@ export class OutOfBandModule {
     const multiUseInvitation = config.multiUseInvitation ?? false
     const handshake = config.handshake ?? true
     const customHandshakeProtocols = config.handshakeProtocols
-    const autoAcceptConnection = config.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections
+    const autoAcceptConnection = config.autoAcceptConnection ?? this.agentContext.config.autoAcceptConnections
     // We don't want to treat an empty array as messages being provided
     const messages = config.messages && config.messages.length > 0 ? config.messages : undefined
-    const label = config.label ?? this.agentConfig.label
-    const imageUrl = config.imageUrl ?? this.agentConfig.connectionImageUrl
+    const label = config.label ?? this.agentContext.config.label
+    const imageUrl = config.imageUrl ?? this.agentContext.config.connectionImageUrl
     const appendedAttachments =
       config.appendedAttachments && config.appendedAttachments.length > 0 ? config.appendedAttachments : undefined
 
@@ -167,7 +169,7 @@ export class OutOfBandModule {
       }
     }
 
-    const routing = config.routing ?? (await this.routingService.getRouting({}))
+    const routing = config.routing ?? (await this.routingService.getRouting(this.agentContext, {}))
 
     const services = routing.endpoints.map((endpoint, index) => {
       return new OutOfBandDidCommService({
@@ -209,8 +211,8 @@ export class OutOfBandModule {
       autoAcceptConnection,
     })
 
-    await this.outOfBandService.save(outOfBandRecord)
-    this.outOfBandService.emitStateChangedEvent(outOfBandRecord, null)
+    await this.outOfBandService.save(this.agentContext, outOfBandRecord)
+    this.outOfBandService.emitStateChangedEvent(this.agentContext, outOfBandRecord, null)
 
     return outOfBandRecord
   }
@@ -239,7 +241,7 @@ export class OutOfBandModule {
     domain: string
   }): Promise<{ message: Message; invitationUrl: string }> {
     // Create keys (and optionally register them at the mediator)
-    const routing = await this.routingService.getRouting()
+    const routing = await this.routingService.getRouting(this.agentContext)
 
     // Set the service on the message
     config.message.service = new ServiceDecorator({
@@ -250,7 +252,7 @@ export class OutOfBandModule {
 
     // We need to update the message with the new service, so we can
     // retrieve it from storage later on.
-    await this.didCommMessageRepository.saveOrUpdateAgentMessage({
+    await this.didCommMessageRepository.saveOrUpdateAgentMessage(this.agentContext, {
       agentMessage: config.message,
       associatedRecordId: config.recordId,
       role: DidCommMessageRole.Sender,
@@ -318,9 +320,9 @@ export class OutOfBandModule {
     const autoAcceptInvitation = config.autoAcceptInvitation ?? true
     const autoAcceptConnection = config.autoAcceptConnection ?? true
     const reuseConnection = config.reuseConnection ?? false
-    const label = config.label ?? this.agentConfig.label
+    const label = config.label ?? this.agentContext.config.label
     const alias = config.alias
-    const imageUrl = config.imageUrl ?? this.agentConfig.connectionImageUrl
+    const imageUrl = config.imageUrl ?? this.agentContext.config.connectionImageUrl
 
     const messages = outOfBandInvitation.getRequests()
 
@@ -344,8 +346,8 @@ export class OutOfBandModule {
       outOfBandInvitation: outOfBandInvitation,
       autoAcceptConnection,
     })
-    await this.outOfBandService.save(outOfBandRecord)
-    this.outOfBandService.emitStateChangedEvent(outOfBandRecord, null)
+    await this.outOfBandService.save(this.agentContext, outOfBandRecord)
+    this.outOfBandService.emitStateChangedEvent(this.agentContext, outOfBandRecord, null)
 
     if (autoAcceptInvitation) {
       return await this.acceptInvitation(outOfBandRecord.id, {
@@ -387,7 +389,7 @@ export class OutOfBandModule {
       routing?: Routing
     }
   ) {
-    const outOfBandRecord = await this.outOfBandService.getById(outOfBandId)
+    const outOfBandRecord = await this.outOfBandService.getById(this.agentContext, outOfBandId)
 
     const { outOfBandInvitation } = outOfBandRecord
     const { label, alias, imageUrl, autoAcceptConnection, reuseConnection, routing } = config
@@ -396,7 +398,7 @@ export class OutOfBandModule {
 
     const existingConnection = await this.findExistingConnection(services)
 
-    await this.outOfBandService.updateState(outOfBandRecord, OutOfBandState.PrepareResponse)
+    await this.outOfBandService.updateState(this.agentContext, outOfBandRecord, OutOfBandState.PrepareResponse)
 
     if (handshakeProtocols) {
       this.logger.debug('Out of band message contains handshake protocols.')
@@ -478,11 +480,11 @@ export class OutOfBandModule {
   }
 
   public async findByRecipientKey(recipientKey: Key) {
-    return this.outOfBandService.findByRecipientKey(recipientKey)
+    return this.outOfBandService.findByRecipientKey(this.agentContext, recipientKey)
   }
 
   public async findByInvitationId(invitationId: string) {
-    return this.outOfBandService.findByInvitationId(invitationId)
+    return this.outOfBandService.findByInvitationId(this.agentContext, invitationId)
   }
 
   /**
@@ -491,7 +493,7 @@ export class OutOfBandModule {
    * @returns List containing all  out of band records
    */
   public getAll() {
-    return this.outOfBandService.getAll()
+    return this.outOfBandService.getAll(this.agentContext)
   }
 
   /**
@@ -503,7 +505,7 @@ export class OutOfBandModule {
    *
    */
   public getById(outOfBandId: string): Promise<OutOfBandRecord> {
-    return this.outOfBandService.getById(outOfBandId)
+    return this.outOfBandService.getById(this.agentContext, outOfBandId)
   }
 
   /**
@@ -513,7 +515,7 @@ export class OutOfBandModule {
    * @returns The out of band record or null if not found
    */
   public findById(outOfBandId: string): Promise<OutOfBandRecord | null> {
-    return this.outOfBandService.findById(outOfBandId)
+    return this.outOfBandService.findById(this.agentContext, outOfBandId)
   }
 
   /**
@@ -522,7 +524,7 @@ export class OutOfBandModule {
    * @param outOfBandId the out of band record id
    */
   public async deleteById(outOfBandId: string) {
-    return this.outOfBandService.deleteById(outOfBandId)
+    return this.outOfBandService.deleteById(this.agentContext, outOfBandId)
   }
 
   private assertHandshakeProtocols(handshakeProtocols: HandshakeProtocol[]) {
@@ -605,7 +607,7 @@ export class OutOfBandModule {
 
     this.logger.debug(`Message with type ${plaintextMessage['@type']} can be processed.`)
 
-    this.eventEmitter.emit<AgentMessageReceivedEvent>({
+    this.eventEmitter.emit<AgentMessageReceivedEvent>(this.agentContext, {
       type: AgentEventTypes.AgentMessageReceived,
       payload: {
         message: plaintextMessage,
@@ -646,7 +648,7 @@ export class OutOfBandModule {
     })
 
     plaintextMessage['~service'] = JsonTransformer.toJSON(serviceDecorator)
-    this.eventEmitter.emit<AgentMessageReceivedEvent>({
+    this.eventEmitter.emit<AgentMessageReceivedEvent>(this.agentContext, {
       type: AgentEventTypes.AgentMessageReceived,
       payload: {
         message: plaintextMessage,
@@ -655,7 +657,11 @@ export class OutOfBandModule {
   }
 
   private async handleHandshakeReuse(outOfBandRecord: OutOfBandRecord, connectionRecord: ConnectionRecord) {
-    const reuseMessage = await this.outOfBandService.createHandShakeReuse(outOfBandRecord, connectionRecord)
+    const reuseMessage = await this.outOfBandService.createHandShakeReuse(
+      this.agentContext,
+      outOfBandRecord,
+      connectionRecord
+    )
 
     const reuseAcceptedEventPromise = firstValueFrom(
       this.eventEmitter.observable<HandshakeReusedEvent>(OutOfBandEventTypes.HandshakeReused).pipe(
@@ -676,7 +682,7 @@ export class OutOfBandModule {
     )
 
     const outbound = createOutboundMessage(connectionRecord, reuseMessage)
-    await this.messageSender.sendMessage(outbound)
+    await this.messageSender.sendMessage(this.agentContext, outbound)
 
     return reuseAcceptedEventPromise
   }

--- a/packages/core/src/modules/oob/OutOfBandService.ts
+++ b/packages/core/src/modules/oob/OutOfBandService.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../agent'
 import type { InboundMessageContext } from '../../agent/models/InboundMessageContext'
 import type { Key } from '../../crypto'
 import type { ConnectionRecord } from '../connections'
@@ -34,7 +35,7 @@ export class OutOfBandService {
       throw new AriesFrameworkError('handshake-reuse message must have a parent thread id')
     }
 
-    const outOfBandRecord = await this.findByInvitationId(parentThreadId)
+    const outOfBandRecord = await this.findByInvitationId(messageContext.agentContext, parentThreadId)
     if (!outOfBandRecord) {
       throw new AriesFrameworkError('No out of band record found for handshake-reuse message')
     }
@@ -49,7 +50,7 @@ export class OutOfBandService {
     }
 
     const reusedConnection = messageContext.assertReadyConnection()
-    this.eventEmitter.emit<HandshakeReusedEvent>({
+    this.eventEmitter.emit<HandshakeReusedEvent>(messageContext.agentContext, {
       type: OutOfBandEventTypes.HandshakeReused,
       payload: {
         reuseThreadId: reuseMessage.threadId,
@@ -60,7 +61,7 @@ export class OutOfBandService {
 
     // If the out of band record is not reusable we can set the state to done
     if (!outOfBandRecord.reusable) {
-      await this.updateState(outOfBandRecord, OutOfBandState.Done)
+      await this.updateState(messageContext.agentContext, outOfBandRecord, OutOfBandState.Done)
     }
 
     const reuseAcceptedMessage = new HandshakeReuseAcceptedMessage({
@@ -79,7 +80,7 @@ export class OutOfBandService {
       throw new AriesFrameworkError('handshake-reuse-accepted message must have a parent thread id')
     }
 
-    const outOfBandRecord = await this.findByInvitationId(parentThreadId)
+    const outOfBandRecord = await this.findByInvitationId(messageContext.agentContext, parentThreadId)
     if (!outOfBandRecord) {
       throw new AriesFrameworkError('No out of band record found for handshake-reuse-accepted message')
     }
@@ -100,7 +101,7 @@ export class OutOfBandService {
       throw new AriesFrameworkError('handshake-reuse-accepted is not in response to a handshake-reuse message.')
     }
 
-    this.eventEmitter.emit<HandshakeReusedEvent>({
+    this.eventEmitter.emit<HandshakeReusedEvent>(messageContext.agentContext, {
       type: OutOfBandEventTypes.HandshakeReused,
       payload: {
         reuseThreadId: reuseAcceptedMessage.threadId,
@@ -110,35 +111,43 @@ export class OutOfBandService {
     })
 
     // receiver role is never reusable, so we can set the state to done
-    await this.updateState(outOfBandRecord, OutOfBandState.Done)
+    await this.updateState(messageContext.agentContext, outOfBandRecord, OutOfBandState.Done)
   }
 
-  public async createHandShakeReuse(outOfBandRecord: OutOfBandRecord, connectionRecord: ConnectionRecord) {
+  public async createHandShakeReuse(
+    agentContext: AgentContext,
+    outOfBandRecord: OutOfBandRecord,
+    connectionRecord: ConnectionRecord
+  ) {
     const reuseMessage = new HandshakeReuseMessage({ parentThreadId: outOfBandRecord.outOfBandInvitation.id })
 
     // Store the reuse connection id
     outOfBandRecord.reuseConnectionId = connectionRecord.id
-    await this.outOfBandRepository.update(outOfBandRecord)
+    await this.outOfBandRepository.update(agentContext, outOfBandRecord)
 
     return reuseMessage
   }
 
-  public async save(outOfBandRecord: OutOfBandRecord) {
-    return this.outOfBandRepository.save(outOfBandRecord)
+  public async save(agentContext: AgentContext, outOfBandRecord: OutOfBandRecord) {
+    return this.outOfBandRepository.save(agentContext, outOfBandRecord)
   }
 
-  public async updateState(outOfBandRecord: OutOfBandRecord, newState: OutOfBandState) {
+  public async updateState(agentContext: AgentContext, outOfBandRecord: OutOfBandRecord, newState: OutOfBandState) {
     const previousState = outOfBandRecord.state
     outOfBandRecord.state = newState
-    await this.outOfBandRepository.update(outOfBandRecord)
+    await this.outOfBandRepository.update(agentContext, outOfBandRecord)
 
-    this.emitStateChangedEvent(outOfBandRecord, previousState)
+    this.emitStateChangedEvent(agentContext, outOfBandRecord, previousState)
   }
 
-  public emitStateChangedEvent(outOfBandRecord: OutOfBandRecord, previousState: OutOfBandState | null) {
+  public emitStateChangedEvent(
+    agentContext: AgentContext,
+    outOfBandRecord: OutOfBandRecord,
+    previousState: OutOfBandState | null
+  ) {
     const clonedOutOfBandRecord = JsonTransformer.clone(outOfBandRecord)
 
-    this.eventEmitter.emit<OutOfBandStateChangedEvent>({
+    this.eventEmitter.emit<OutOfBandStateChangedEvent>(agentContext, {
       type: OutOfBandEventTypes.OutOfBandStateChanged,
       payload: {
         outOfBandRecord: clonedOutOfBandRecord,
@@ -147,28 +156,30 @@ export class OutOfBandService {
     })
   }
 
-  public async findById(outOfBandRecordId: string) {
-    return this.outOfBandRepository.findById(outOfBandRecordId)
+  public async findById(agentContext: AgentContext, outOfBandRecordId: string) {
+    return this.outOfBandRepository.findById(agentContext, outOfBandRecordId)
   }
 
-  public async getById(outOfBandRecordId: string) {
-    return this.outOfBandRepository.getById(outOfBandRecordId)
+  public async getById(agentContext: AgentContext, outOfBandRecordId: string) {
+    return this.outOfBandRepository.getById(agentContext, outOfBandRecordId)
   }
 
-  public async findByInvitationId(invitationId: string) {
-    return this.outOfBandRepository.findSingleByQuery({ invitationId })
+  public async findByInvitationId(agentContext: AgentContext, invitationId: string) {
+    return this.outOfBandRepository.findSingleByQuery(agentContext, { invitationId })
   }
 
-  public async findByRecipientKey(recipientKey: Key) {
-    return this.outOfBandRepository.findSingleByQuery({ recipientKeyFingerprints: [recipientKey.fingerprint] })
+  public async findByRecipientKey(agentContext: AgentContext, recipientKey: Key) {
+    return this.outOfBandRepository.findSingleByQuery(agentContext, {
+      recipientKeyFingerprints: [recipientKey.fingerprint],
+    })
   }
 
-  public async getAll() {
-    return this.outOfBandRepository.getAll()
+  public async getAll(agentContext: AgentContext) {
+    return this.outOfBandRepository.getAll(agentContext)
   }
 
-  public async deleteById(outOfBandId: string) {
-    const outOfBandRecord = await this.getById(outOfBandId)
-    return this.outOfBandRepository.delete(outOfBandRecord)
+  public async deleteById(agentContext: AgentContext, outOfBandId: string) {
+    const outOfBandRecord = await this.getById(agentContext, outOfBandId)
+    return this.outOfBandRepository.delete(agentContext, outOfBandRecord)
   }
 }

--- a/packages/core/src/modules/oob/__tests__/OutOfBandService.test.ts
+++ b/packages/core/src/modules/oob/__tests__/OutOfBandService.test.ts
@@ -1,6 +1,16 @@
+import type { AgentContext } from '../../../agent'
 import type { Wallet } from '../../../wallet/Wallet'
 
-import { getAgentConfig, getMockConnection, getMockOutOfBand, mockFunction } from '../../../../tests/helpers'
+import { Subject } from 'rxjs'
+
+import {
+  agentDependencies,
+  getAgentConfig,
+  getAgentContext,
+  getMockConnection,
+  getMockOutOfBand,
+  mockFunction,
+} from '../../../../tests/helpers'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
 import { KeyType, Key } from '../../../crypto'
@@ -26,9 +36,11 @@ describe('OutOfBandService', () => {
   let outOfBandRepository: OutOfBandRepository
   let outOfBandService: OutOfBandService
   let eventEmitter: EventEmitter
+  let agentContext: AgentContext
 
   beforeAll(async () => {
-    wallet = new IndyWallet(agentConfig)
+    wallet = new IndyWallet(agentConfig.agentDependencies, agentConfig.logger)
+    agentContext = getAgentContext()
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await wallet.createAndOpen(agentConfig.walletConfig!)
   })
@@ -38,7 +50,7 @@ describe('OutOfBandService', () => {
   })
 
   beforeEach(async () => {
-    eventEmitter = new EventEmitter(agentConfig)
+    eventEmitter = new EventEmitter(agentDependencies, new Subject())
     outOfBandRepository = new OutOfBandRepositoryMock()
     outOfBandService = new OutOfBandService(outOfBandRepository, eventEmitter)
   })
@@ -54,6 +66,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -69,6 +82,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -84,6 +98,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -112,6 +127,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -134,6 +150,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -158,6 +175,7 @@ describe('OutOfBandService', () => {
 
       const connection = getMockConnection({ state: DidExchangeState.Completed })
       const messageContext = new InboundMessageContext(reuseMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
         connection,
@@ -192,6 +210,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
         connection: getMockConnection({ state: DidExchangeState.Completed }),
@@ -213,7 +232,7 @@ describe('OutOfBandService', () => {
       // Non-reusable should update state
       mockOob.reusable = false
       await outOfBandService.processHandshakeReuse(messageContext)
-      expect(updateStateSpy).toHaveBeenCalledWith(mockOob, OutOfBandState.Done)
+      expect(updateStateSpy).toHaveBeenCalledWith(agentContext, mockOob, OutOfBandState.Done)
     })
 
     it('returns a handshake-reuse-accepted message', async () => {
@@ -222,6 +241,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
         connection: getMockConnection({ state: DidExchangeState.Completed }),
@@ -255,6 +275,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseAcceptedMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -271,6 +292,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseAcceptedMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -287,6 +309,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseAcceptedMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -316,6 +339,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseAcceptedMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
       })
@@ -338,6 +362,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseAcceptedMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
         connection: getMockConnection({ state: DidExchangeState.Completed, id: 'connectionId' }),
@@ -365,6 +390,7 @@ describe('OutOfBandService', () => {
 
       const connection = getMockConnection({ state: DidExchangeState.Completed, id: 'connectionId' })
       const messageContext = new InboundMessageContext(reuseAcceptedMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
         connection,
@@ -401,6 +427,7 @@ describe('OutOfBandService', () => {
       })
 
       const messageContext = new InboundMessageContext(reuseAcceptedMessage, {
+        agentContext,
         senderKey: key,
         recipientKey: key,
         connection: getMockConnection({ state: DidExchangeState.Completed, id: 'connectionId' }),
@@ -417,7 +444,7 @@ describe('OutOfBandService', () => {
       const updateStateSpy = jest.spyOn(outOfBandService, 'updateState')
 
       await outOfBandService.processHandshakeReuseAccepted(messageContext)
-      expect(updateStateSpy).toHaveBeenCalledWith(mockOob, OutOfBandState.Done)
+      expect(updateStateSpy).toHaveBeenCalledWith(agentContext, mockOob, OutOfBandState.Done)
     })
   })
 
@@ -427,7 +454,7 @@ describe('OutOfBandService', () => {
         state: OutOfBandState.Initial,
       })
 
-      await outOfBandService.updateState(mockOob, OutOfBandState.Done)
+      await outOfBandService.updateState(agentContext, mockOob, OutOfBandState.Done)
 
       expect(mockOob.state).toEqual(OutOfBandState.Done)
     })
@@ -437,9 +464,9 @@ describe('OutOfBandService', () => {
         state: OutOfBandState.Initial,
       })
 
-      await outOfBandService.updateState(mockOob, OutOfBandState.Done)
+      await outOfBandService.updateState(agentContext, mockOob, OutOfBandState.Done)
 
-      expect(outOfBandRepository.update).toHaveBeenCalledWith(mockOob)
+      expect(outOfBandRepository.update).toHaveBeenCalledWith(agentContext, mockOob)
     })
 
     test('emits an OutOfBandStateChangedEvent', async () => {
@@ -450,7 +477,7 @@ describe('OutOfBandService', () => {
       })
 
       eventEmitter.on(OutOfBandEventTypes.OutOfBandStateChanged, stateChangedListener)
-      await outOfBandService.updateState(mockOob, OutOfBandState.Done)
+      await outOfBandService.updateState(agentContext, mockOob, OutOfBandState.Done)
       eventEmitter.off(OutOfBandEventTypes.OutOfBandStateChanged, stateChangedListener)
 
       expect(stateChangedListener).toHaveBeenCalledTimes(1)
@@ -470,8 +497,8 @@ describe('OutOfBandService', () => {
     it('getById should return value from outOfBandRepository.getById', async () => {
       const expected = getMockOutOfBand()
       mockFunction(outOfBandRepository.getById).mockReturnValue(Promise.resolve(expected))
-      const result = await outOfBandService.getById(expected.id)
-      expect(outOfBandRepository.getById).toBeCalledWith(expected.id)
+      const result = await outOfBandService.getById(agentContext, expected.id)
+      expect(outOfBandRepository.getById).toBeCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -479,8 +506,8 @@ describe('OutOfBandService', () => {
     it('findById should return value from outOfBandRepository.findById', async () => {
       const expected = getMockOutOfBand()
       mockFunction(outOfBandRepository.findById).mockReturnValue(Promise.resolve(expected))
-      const result = await outOfBandService.findById(expected.id)
-      expect(outOfBandRepository.findById).toBeCalledWith(expected.id)
+      const result = await outOfBandService.findById(agentContext, expected.id)
+      expect(outOfBandRepository.findById).toBeCalledWith(agentContext, expected.id)
 
       expect(result).toBe(expected)
     })
@@ -489,8 +516,8 @@ describe('OutOfBandService', () => {
       const expected = [getMockOutOfBand(), getMockOutOfBand()]
 
       mockFunction(outOfBandRepository.getAll).mockReturnValue(Promise.resolve(expected))
-      const result = await outOfBandService.getAll()
-      expect(outOfBandRepository.getAll).toBeCalledWith()
+      const result = await outOfBandService.getAll(agentContext)
+      expect(outOfBandRepository.getAll).toBeCalledWith(agentContext)
 
       expect(result).toEqual(expect.arrayContaining(expected))
     })

--- a/packages/core/src/modules/proofs/ProofResponseCoordinator.ts
+++ b/packages/core/src/modules/proofs/ProofResponseCoordinator.ts
@@ -1,6 +1,6 @@
+import type { AgentContext } from '../../agent/AgentContext'
 import type { ProofRecord } from './repository'
 
-import { AgentConfig } from '../../agent/AgentConfig'
 import { injectable } from '../../plugins'
 
 import { AutoAcceptProof } from './ProofAutoAcceptType'
@@ -11,12 +11,6 @@ import { AutoAcceptProof } from './ProofAutoAcceptType'
  */
 @injectable()
 export class ProofResponseCoordinator {
-  private agentConfig: AgentConfig
-
-  public constructor(agentConfig: AgentConfig) {
-    this.agentConfig = agentConfig
-  }
-
   /**
    * Returns the proof auto accept config based on priority:
    *	- The record config takes first priority
@@ -33,10 +27,10 @@ export class ProofResponseCoordinator {
   /**
    * Checks whether it should automatically respond to a proposal
    */
-  public shouldAutoRespondToProposal(proofRecord: ProofRecord) {
+  public shouldAutoRespondToProposal(agentContext: AgentContext, proofRecord: ProofRecord) {
     const autoAccept = ProofResponseCoordinator.composeAutoAccept(
       proofRecord.autoAcceptProof,
-      this.agentConfig.autoAcceptProofs
+      agentContext.config.autoAcceptProofs
     )
 
     if (autoAccept === AutoAcceptProof.Always) {
@@ -48,10 +42,10 @@ export class ProofResponseCoordinator {
   /**
    * Checks whether it should automatically respond to a request
    */
-  public shouldAutoRespondToRequest(proofRecord: ProofRecord) {
+  public shouldAutoRespondToRequest(agentContext: AgentContext, proofRecord: ProofRecord) {
     const autoAccept = ProofResponseCoordinator.composeAutoAccept(
       proofRecord.autoAcceptProof,
-      this.agentConfig.autoAcceptProofs
+      agentContext.config.autoAcceptProofs
     )
 
     if (
@@ -67,10 +61,10 @@ export class ProofResponseCoordinator {
   /**
    * Checks whether it should automatically respond to a presentation of proof
    */
-  public shouldAutoRespondToPresentation(proofRecord: ProofRecord) {
+  public shouldAutoRespondToPresentation(agentContext: AgentContext, proofRecord: ProofRecord) {
     const autoAccept = ProofResponseCoordinator.composeAutoAccept(
       proofRecord.autoAcceptProof,
-      this.agentConfig.autoAcceptProofs
+      agentContext.config.autoAcceptProofs
     )
 
     if (

--- a/packages/core/src/modules/proofs/__tests__/ProofService.test.ts
+++ b/packages/core/src/modules/proofs/__tests__/ProofService.test.ts
@@ -1,9 +1,11 @@
-import type { Wallet } from '../../../wallet/Wallet'
+import type { AgentContext } from '../../../agent'
 import type { CredentialRepository } from '../../credentials/repository'
 import type { ProofStateChangedEvent } from '../ProofEvents'
 import type { CustomProofTags } from './../repository/ProofRecord'
 
-import { getAgentConfig, getMockConnection, mockFunction } from '../../../../tests/helpers'
+import { Subject } from 'rxjs'
+
+import { getAgentConfig, getAgentContext, getMockConnection, mockFunction } from '../../../../tests/helpers'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
 import { Attachment, AttachmentData } from '../../../decorators/attachment/Attachment'
@@ -93,13 +95,13 @@ describe('ProofService', () => {
   let proofRepository: ProofRepository
   let proofService: ProofService
   let ledgerService: IndyLedgerService
-  let wallet: Wallet
   let indyVerifierService: IndyVerifierService
   let indyHolderService: IndyHolderService
   let indyRevocationService: IndyRevocationService
   let eventEmitter: EventEmitter
   let credentialRepository: CredentialRepository
   let connectionService: ConnectionService
+  let agentContext: AgentContext
 
   beforeEach(() => {
     const agentConfig = getAgentConfig('ProofServiceTest')
@@ -108,20 +110,20 @@ describe('ProofService', () => {
     indyHolderService = new IndyHolderServiceMock()
     indyRevocationService = new IndyRevocationServiceMock()
     ledgerService = new IndyLedgerServiceMock()
-    eventEmitter = new EventEmitter(agentConfig)
+    eventEmitter = new EventEmitter(agentConfig.agentDependencies, new Subject())
     connectionService = new connectionServiceMock()
+    agentContext = getAgentContext()
 
     proofService = new ProofService(
       proofRepository,
       ledgerService,
-      wallet,
-      agentConfig,
       indyHolderService,
       indyVerifierService,
       indyRevocationService,
       connectionService,
       eventEmitter,
-      credentialRepository
+      credentialRepository,
+      agentConfig.logger
     )
 
     mockFunction(ledgerService.getCredentialDefinition).mockReturnValue(Promise.resolve(credDef))
@@ -138,6 +140,7 @@ describe('ProofService', () => {
       })
       messageContext = new InboundMessageContext(presentationRequest, {
         connection,
+        agentContext,
       })
     })
 
@@ -157,7 +160,7 @@ describe('ProofService', () => {
         connectionId: connection.id,
       }
       expect(repositorySaveSpy).toHaveBeenCalledTimes(1)
-      const [[createdProofRecord]] = repositorySaveSpy.mock.calls
+      const [[, createdProofRecord]] = repositorySaveSpy.mock.calls
       expect(createdProofRecord).toMatchObject(expectedProofRecord)
       expect(returnedProofRecord).toMatchObject(expectedProofRecord)
     })
@@ -236,6 +239,7 @@ describe('ProofService', () => {
       presentationProblemReportMessage.setThread({ threadId: 'somethreadid' })
       messageContext = new InboundMessageContext(presentationProblemReportMessage, {
         connection,
+        agentContext,
       })
     })
 
@@ -252,12 +256,12 @@ describe('ProofService', () => {
       const expectedCredentialRecord = {
         errorMessage: 'abandoned: Indy error',
       }
-      expect(proofRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, {
+      expect(proofRepository.getSingleByQuery).toHaveBeenNthCalledWith(1, agentContext, {
         threadId: 'somethreadid',
         connectionId: connection.id,
       })
       expect(repositoryUpdateSpy).toHaveBeenCalledTimes(1)
-      const [[updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
+      const [[, updatedCredentialRecord]] = repositoryUpdateSpy.mock.calls
       expect(updatedCredentialRecord).toMatchObject(expectedCredentialRecord)
       expect(returnedCredentialRecord).toMatchObject(expectedCredentialRecord)
     })

--- a/packages/core/src/modules/proofs/handlers/PresentationHandler.ts
+++ b/packages/core/src/modules/proofs/handlers/PresentationHandler.ts
@@ -1,5 +1,5 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
+import type { Logger } from '../../../logger'
 import type { ProofResponseCoordinator } from '../ProofResponseCoordinator'
 import type { ProofRecord } from '../repository'
 import type { ProofService } from '../services'
@@ -9,34 +9,30 @@ import { PresentationMessage } from '../messages'
 
 export class PresentationHandler implements Handler {
   private proofService: ProofService
-  private agentConfig: AgentConfig
   private proofResponseCoordinator: ProofResponseCoordinator
+  private logger: Logger
   public supportedMessages = [PresentationMessage]
 
-  public constructor(
-    proofService: ProofService,
-    agentConfig: AgentConfig,
-    proofResponseCoordinator: ProofResponseCoordinator
-  ) {
+  public constructor(proofService: ProofService, proofResponseCoordinator: ProofResponseCoordinator, logger: Logger) {
     this.proofService = proofService
-    this.agentConfig = agentConfig
     this.proofResponseCoordinator = proofResponseCoordinator
+    this.logger = logger
   }
 
   public async handle(messageContext: HandlerInboundMessage<PresentationHandler>) {
     const proofRecord = await this.proofService.processPresentation(messageContext)
 
-    if (this.proofResponseCoordinator.shouldAutoRespondToPresentation(proofRecord)) {
+    if (this.proofResponseCoordinator.shouldAutoRespondToPresentation(messageContext.agentContext, proofRecord)) {
       return await this.createAck(proofRecord, messageContext)
     }
   }
 
   private async createAck(record: ProofRecord, messageContext: HandlerInboundMessage<PresentationHandler>) {
-    this.agentConfig.logger.info(
-      `Automatically sending acknowledgement with autoAccept on ${this.agentConfig.autoAcceptProofs}`
+    this.logger.info(
+      `Automatically sending acknowledgement with autoAccept on ${messageContext.agentContext.config.autoAcceptProofs}`
     )
 
-    const { message, proofRecord } = await this.proofService.createAck(record)
+    const { message, proofRecord } = await this.proofService.createAck(messageContext.agentContext, record)
 
     if (messageContext.connection) {
       return createOutboundMessage(messageContext.connection, message)
@@ -51,6 +47,6 @@ export class PresentationHandler implements Handler {
       })
     }
 
-    this.agentConfig.logger.error(`Could not automatically create presentation ack`)
+    this.logger.error(`Could not automatically create presentation ack`)
   }
 }

--- a/packages/core/src/modules/proofs/handlers/ProposePresentationHandler.ts
+++ b/packages/core/src/modules/proofs/handlers/ProposePresentationHandler.ts
@@ -1,5 +1,5 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
+import type { Logger } from '../../../logger'
 import type { ProofResponseCoordinator } from '../ProofResponseCoordinator'
 import type { ProofRecord } from '../repository'
 import type { ProofService } from '../services'
@@ -9,24 +9,20 @@ import { ProposePresentationMessage } from '../messages'
 
 export class ProposePresentationHandler implements Handler {
   private proofService: ProofService
-  private agentConfig: AgentConfig
   private proofResponseCoordinator: ProofResponseCoordinator
+  private logger: Logger
   public supportedMessages = [ProposePresentationMessage]
 
-  public constructor(
-    proofService: ProofService,
-    agentConfig: AgentConfig,
-    proofResponseCoordinator: ProofResponseCoordinator
-  ) {
+  public constructor(proofService: ProofService, proofResponseCoordinator: ProofResponseCoordinator, logger: Logger) {
     this.proofService = proofService
-    this.agentConfig = agentConfig
     this.proofResponseCoordinator = proofResponseCoordinator
+    this.logger = logger
   }
 
   public async handle(messageContext: HandlerInboundMessage<ProposePresentationHandler>) {
     const proofRecord = await this.proofService.processProposal(messageContext)
 
-    if (this.proofResponseCoordinator.shouldAutoRespondToProposal(proofRecord)) {
+    if (this.proofResponseCoordinator.shouldAutoRespondToProposal(messageContext.agentContext, proofRecord)) {
       return await this.createRequest(proofRecord, messageContext)
     }
   }
@@ -35,19 +31,20 @@ export class ProposePresentationHandler implements Handler {
     proofRecord: ProofRecord,
     messageContext: HandlerInboundMessage<ProposePresentationHandler>
   ) {
-    this.agentConfig.logger.info(
-      `Automatically sending request with autoAccept on ${this.agentConfig.autoAcceptProofs}`
+    this.logger.info(
+      `Automatically sending request with autoAccept on ${messageContext.agentContext.config.autoAcceptProofs}`
     )
 
     if (!messageContext.connection) {
-      this.agentConfig.logger.error('No connection on the messageContext')
+      this.logger.error('No connection on the messageContext')
       return
     }
     if (!proofRecord.proposalMessage) {
-      this.agentConfig.logger.error(`Proof record with id ${proofRecord.id} is missing required credential proposal`)
+      this.logger.error(`Proof record with id ${proofRecord.id} is missing required credential proposal`)
       return
     }
     const proofRequest = await this.proofService.createProofRequestFromProposal(
+      messageContext.agentContext,
       proofRecord.proposalMessage.presentationProposal,
       {
         name: 'proof-request',
@@ -55,7 +52,11 @@ export class ProposePresentationHandler implements Handler {
       }
     )
 
-    const { message } = await this.proofService.createRequestAsResponse(proofRecord, proofRequest)
+    const { message } = await this.proofService.createRequestAsResponse(
+      messageContext.agentContext,
+      proofRecord,
+      proofRequest
+    )
 
     return createOutboundMessage(messageContext.connection, message)
   }

--- a/packages/core/src/modules/proofs/handlers/RequestPresentationHandler.ts
+++ b/packages/core/src/modules/proofs/handlers/RequestPresentationHandler.ts
@@ -1,5 +1,5 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
+import type { Logger } from '../../../logger'
 import type { RoutingService } from '../../routing/services/RoutingService'
 import type { ProofResponseCoordinator } from '../ProofResponseCoordinator'
 import type { ProofRecord } from '../repository'
@@ -11,27 +11,27 @@ import { RequestPresentationMessage } from '../messages'
 
 export class RequestPresentationHandler implements Handler {
   private proofService: ProofService
-  private agentConfig: AgentConfig
   private proofResponseCoordinator: ProofResponseCoordinator
   private routingService: RoutingService
+  private logger: Logger
   public supportedMessages = [RequestPresentationMessage]
 
   public constructor(
     proofService: ProofService,
-    agentConfig: AgentConfig,
     proofResponseCoordinator: ProofResponseCoordinator,
-    routingService: RoutingService
+    routingService: RoutingService,
+    logger: Logger
   ) {
     this.proofService = proofService
-    this.agentConfig = agentConfig
     this.proofResponseCoordinator = proofResponseCoordinator
     this.routingService = routingService
+    this.logger = logger
   }
 
   public async handle(messageContext: HandlerInboundMessage<RequestPresentationHandler>) {
     const proofRecord = await this.proofService.processRequest(messageContext)
 
-    if (this.proofResponseCoordinator.shouldAutoRespondToRequest(proofRecord)) {
+    if (this.proofResponseCoordinator.shouldAutoRespondToRequest(messageContext.agentContext, proofRecord)) {
       return await this.createPresentation(proofRecord, messageContext)
     }
   }
@@ -43,28 +43,36 @@ export class RequestPresentationHandler implements Handler {
     const indyProofRequest = record.requestMessage?.indyProofRequest
     const presentationProposal = record.proposalMessage?.presentationProposal
 
-    this.agentConfig.logger.info(
-      `Automatically sending presentation with autoAccept on ${this.agentConfig.autoAcceptProofs}`
+    this.logger.info(
+      `Automatically sending presentation with autoAccept on ${messageContext.agentContext.config.autoAcceptProofs}`
     )
 
     if (!indyProofRequest) {
-      this.agentConfig.logger.error('Proof request is undefined.')
+      this.logger.error('Proof request is undefined.')
       return
     }
 
-    const retrievedCredentials = await this.proofService.getRequestedCredentialsForProofRequest(indyProofRequest, {
-      presentationProposal,
-    })
+    const retrievedCredentials = await this.proofService.getRequestedCredentialsForProofRequest(
+      messageContext.agentContext,
+      indyProofRequest,
+      {
+        presentationProposal,
+      }
+    )
 
     const requestedCredentials = this.proofService.autoSelectCredentialsForProofRequest(retrievedCredentials)
 
-    const { message, proofRecord } = await this.proofService.createPresentation(record, requestedCredentials)
+    const { message, proofRecord } = await this.proofService.createPresentation(
+      messageContext.agentContext,
+      record,
+      requestedCredentials
+    )
 
     if (messageContext.connection) {
       return createOutboundMessage(messageContext.connection, message)
     } else if (proofRecord.requestMessage?.service) {
       // Create ~service decorator
-      const routing = await this.routingService.getRouting()
+      const routing = await this.routingService.getRouting(messageContext.agentContext)
       const ourService = new ServiceDecorator({
         serviceEndpoint: routing.endpoints[0],
         recipientKeys: [routing.recipientKey.publicKeyBase58],
@@ -76,7 +84,7 @@ export class RequestPresentationHandler implements Handler {
       // Set and save ~service decorator to record (to remember our verkey)
       message.service = ourService
       proofRecord.presentationMessage = message
-      await this.proofService.update(proofRecord)
+      await this.proofService.update(messageContext.agentContext, proofRecord)
 
       return createOutboundServiceMessage({
         payload: message,
@@ -85,6 +93,6 @@ export class RequestPresentationHandler implements Handler {
       })
     }
 
-    this.agentConfig.logger.error(`Could not automatically create presentation`)
+    this.logger.error(`Could not automatically create presentation`)
   }
 }

--- a/packages/core/src/modules/routing/MediatorModule.ts
+++ b/packages/core/src/modules/routing/MediatorModule.ts
@@ -2,16 +2,15 @@ import type { DependencyManager } from '../../plugins'
 import type { EncryptedMessage } from '../../types'
 import type { MediationRecord } from './repository'
 
-import { AgentConfig } from '../../agent/AgentConfig'
+import { AgentContext } from '../../agent'
 import { Dispatcher } from '../../agent/Dispatcher'
 import { EventEmitter } from '../../agent/EventEmitter'
-import { MessageReceiver } from '../../agent/MessageReceiver'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
 import { injectable, module } from '../../plugins'
 import { ConnectionService } from '../connections/services'
 
-import { KeylistUpdateHandler, ForwardHandler, BatchPickupHandler, BatchHandler } from './handlers'
+import { BatchHandler, BatchPickupHandler, ForwardHandler, KeylistUpdateHandler } from './handlers'
 import { MediationRequestHandler } from './handlers/MediationRequestHandler'
 import { MediatorService } from './services/MediatorService'
 import { MessagePickupService } from './services/MessagePickupService'
@@ -23,7 +22,7 @@ export class MediatorModule {
   private messagePickupService: MessagePickupService
   private messageSender: MessageSender
   public eventEmitter: EventEmitter
-  public agentConfig: AgentConfig
+  public agentContext: AgentContext
   public connectionService: ConnectionService
 
   public constructor(
@@ -31,28 +30,30 @@ export class MediatorModule {
     mediationService: MediatorService,
     messagePickupService: MessagePickupService,
     messageSender: MessageSender,
-    messageReceiver: MessageReceiver,
     eventEmitter: EventEmitter,
-    agentConfig: AgentConfig,
+    agentContext: AgentContext,
     connectionService: ConnectionService
   ) {
     this.mediatorService = mediationService
     this.messagePickupService = messagePickupService
     this.messageSender = messageSender
     this.eventEmitter = eventEmitter
-    this.agentConfig = agentConfig
     this.connectionService = connectionService
+    this.agentContext = agentContext
     this.registerHandlers(dispatcher)
   }
 
   public async grantRequestedMediation(mediatorId: string): Promise<MediationRecord> {
-    const record = await this.mediatorService.getById(mediatorId)
-    const connectionRecord = await this.connectionService.getById(record.connectionId)
+    const record = await this.mediatorService.getById(this.agentContext, mediatorId)
+    const connectionRecord = await this.connectionService.getById(this.agentContext, record.connectionId)
 
-    const { message, mediationRecord } = await this.mediatorService.createGrantMediationMessage(record)
+    const { message, mediationRecord } = await this.mediatorService.createGrantMediationMessage(
+      this.agentContext,
+      record
+    )
     const outboundMessage = createOutboundMessage(connectionRecord, message)
 
-    await this.messageSender.sendMessage(outboundMessage)
+    await this.messageSender.sendMessage(this.agentContext, outboundMessage)
 
     return mediationRecord
   }
@@ -66,7 +67,7 @@ export class MediatorModule {
     dispatcher.registerHandler(new ForwardHandler(this.mediatorService, this.connectionService, this.messageSender))
     dispatcher.registerHandler(new BatchPickupHandler(this.messagePickupService))
     dispatcher.registerHandler(new BatchHandler(this.eventEmitter))
-    dispatcher.registerHandler(new MediationRequestHandler(this.mediatorService, this.agentConfig))
+    dispatcher.registerHandler(new MediationRequestHandler(this.mediatorService))
   }
 
   /**

--- a/packages/core/src/modules/routing/__tests__/mediation.test.ts
+++ b/packages/core/src/modules/routing/__tests__/mediation.test.ts
@@ -7,6 +7,7 @@ import { SubjectInboundTransport } from '../../../../../../tests/transport/Subje
 import { SubjectOutboundTransport } from '../../../../../../tests/transport/SubjectOutboundTransport'
 import { getBaseConfig, waitForBasicMessage } from '../../../../tests/helpers'
 import { Agent } from '../../../agent/Agent'
+import { InjectionSymbols } from '../../../constants'
 import { sleep } from '../../../utils/sleep'
 import { ConnectionRecord, HandshakeProtocol } from '../../connections'
 import { MediatorPickupStrategy } from '../MediatorPickupStrategy'
@@ -35,7 +36,8 @@ describe('mediator establishment', () => {
     // We want to stop the mediator polling before the agent is shutdown.
     // FIXME: add a way to stop mediator polling from the public api, and make sure this is
     // being handled in the agent shutdown so we don't get any errors with wallets being closed.
-    recipientAgent.config.stop$.next(true)
+    const stop$ = recipientAgent.injectionContainer.resolve<Subject<boolean>>(InjectionSymbols.Stop$)
+    stop$.next(true)
     await sleep(1000)
 
     await recipientAgent?.shutdown()

--- a/packages/core/src/modules/routing/handlers/BatchHandler.ts
+++ b/packages/core/src/modules/routing/handlers/BatchHandler.ts
@@ -3,7 +3,6 @@ import type { AgentMessageReceivedEvent } from '../../../agent/Events'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 
 import { AgentEventTypes } from '../../../agent/Events'
-import { AriesFrameworkError } from '../../../error'
 import { BatchMessage } from '../messages'
 
 export class BatchHandler implements Handler {
@@ -15,15 +14,13 @@ export class BatchHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<BatchHandler>) {
-    const { message, connection } = messageContext
+    const { message } = messageContext
 
-    if (!connection) {
-      throw new AriesFrameworkError(`No connection associated with incoming message with id ${message.id}`)
-    }
+    messageContext.assertReadyConnection()
 
     const forwardedMessages = message.messages
     forwardedMessages.forEach((message) => {
-      this.eventEmitter.emit<AgentMessageReceivedEvent>({
+      this.eventEmitter.emit<AgentMessageReceivedEvent>(messageContext.agentContext, {
         type: AgentEventTypes.AgentMessageReceived,
         payload: {
           message: message.message,

--- a/packages/core/src/modules/routing/handlers/BatchPickupHandler.ts
+++ b/packages/core/src/modules/routing/handlers/BatchPickupHandler.ts
@@ -1,7 +1,6 @@
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { MessagePickupService } from '../services'
 
-import { AriesFrameworkError } from '../../../error'
 import { BatchPickupMessage } from '../messages'
 
 export class BatchPickupHandler implements Handler {
@@ -13,11 +12,7 @@ export class BatchPickupHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<BatchPickupHandler>) {
-    const { message, connection } = messageContext
-
-    if (!connection) {
-      throw new AriesFrameworkError(`No connection associated with incoming message with id ${message.id}`)
-    }
+    messageContext.assertReadyConnection()
 
     return this.messagePickupService.batch(messageContext)
   }

--- a/packages/core/src/modules/routing/handlers/ForwardHandler.ts
+++ b/packages/core/src/modules/routing/handlers/ForwardHandler.ts
@@ -25,10 +25,16 @@ export class ForwardHandler implements Handler {
   public async handle(messageContext: HandlerInboundMessage<ForwardHandler>) {
     const { encryptedMessage, mediationRecord } = await this.mediatorService.processForwardMessage(messageContext)
 
-    const connectionRecord = await this.connectionService.getById(mediationRecord.connectionId)
+    const connectionRecord = await this.connectionService.getById(
+      messageContext.agentContext,
+      mediationRecord.connectionId
+    )
 
     // The message inside the forward message is packed so we just send the packed
     // message to the connection associated with it
-    await this.messageSender.sendPackage({ connection: connectionRecord, encryptedMessage })
+    await this.messageSender.sendPackage(messageContext.agentContext, {
+      connection: connectionRecord,
+      encryptedMessage,
+    })
   }
 }

--- a/packages/core/src/modules/routing/handlers/KeylistUpdateHandler.ts
+++ b/packages/core/src/modules/routing/handlers/KeylistUpdateHandler.ts
@@ -2,7 +2,6 @@ import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { MediatorService } from '../services/MediatorService'
 
 import { createOutboundMessage } from '../../../agent/helpers'
-import { AriesFrameworkError } from '../../../error'
 import { KeylistUpdateMessage } from '../messages'
 
 export class KeylistUpdateHandler implements Handler {
@@ -14,11 +13,7 @@ export class KeylistUpdateHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<KeylistUpdateHandler>) {
-    const { message, connection } = messageContext
-
-    if (!connection) {
-      throw new AriesFrameworkError(`No connection associated with incoming message with id ${message.id}`)
-    }
+    const connection = messageContext.assertReadyConnection()
 
     const response = await this.mediatorService.processKeylistUpdateRequest(messageContext)
     return createOutboundMessage(connection, response)

--- a/packages/core/src/modules/routing/handlers/KeylistUpdateResponseHandler.ts
+++ b/packages/core/src/modules/routing/handlers/KeylistUpdateResponseHandler.ts
@@ -12,9 +12,8 @@ export class KeylistUpdateResponseHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<KeylistUpdateResponseHandler>) {
-    if (!messageContext.connection) {
-      throw new Error(`Connection for verkey ${messageContext.recipientKey} not found!`)
-    }
+    messageContext.assertReadyConnection()
+
     return await this.mediationRecipientService.processKeylistUpdateResults(messageContext)
   }
 }

--- a/packages/core/src/modules/routing/handlers/MediationDenyHandler.ts
+++ b/packages/core/src/modules/routing/handlers/MediationDenyHandler.ts
@@ -12,9 +12,8 @@ export class MediationDenyHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<MediationDenyHandler>) {
-    if (!messageContext.connection) {
-      throw new Error(`Connection for verkey ${messageContext.recipientKey} not found!`)
-    }
+    messageContext.assertReadyConnection()
+
     await this.mediationRecipientService.processMediationDeny(messageContext)
   }
 }

--- a/packages/core/src/modules/routing/handlers/MediationGrantHandler.ts
+++ b/packages/core/src/modules/routing/handlers/MediationGrantHandler.ts
@@ -12,9 +12,8 @@ export class MediationGrantHandler implements Handler {
   }
 
   public async handle(messageContext: HandlerInboundMessage<MediationGrantHandler>) {
-    if (!messageContext.connection) {
-      throw new Error(`Connection for key ${messageContext.recipientKey} not found!`)
-    }
+    messageContext.assertReadyConnection()
+
     await this.mediationRecipientService.processMediationGrant(messageContext)
   }
 }

--- a/packages/core/src/modules/routing/handlers/MediationRequestHandler.ts
+++ b/packages/core/src/modules/routing/handlers/MediationRequestHandler.ts
@@ -1,31 +1,28 @@
-import type { AgentConfig } from '../../../agent/AgentConfig'
 import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
 import type { MediatorService } from '../services/MediatorService'
 
 import { createOutboundMessage } from '../../../agent/helpers'
-import { AriesFrameworkError } from '../../../error'
 import { MediationRequestMessage } from '../messages/MediationRequestMessage'
 
 export class MediationRequestHandler implements Handler {
   private mediatorService: MediatorService
-  private agentConfig: AgentConfig
   public supportedMessages = [MediationRequestMessage]
 
-  public constructor(mediatorService: MediatorService, agentConfig: AgentConfig) {
+  public constructor(mediatorService: MediatorService) {
     this.mediatorService = mediatorService
-    this.agentConfig = agentConfig
   }
 
   public async handle(messageContext: HandlerInboundMessage<MediationRequestHandler>) {
-    if (!messageContext.connection) {
-      throw new AriesFrameworkError(`Connection for verkey ${messageContext.recipientKey} not found!`)
-    }
+    const connection = messageContext.assertReadyConnection()
 
     const mediationRecord = await this.mediatorService.processMediationRequest(messageContext)
 
-    if (this.agentConfig.autoAcceptMediationRequests) {
-      const { message } = await this.mediatorService.createGrantMediationMessage(mediationRecord)
-      return createOutboundMessage(messageContext.connection, message)
+    if (messageContext.agentContext.config.autoAcceptMediationRequests) {
+      const { message } = await this.mediatorService.createGrantMediationMessage(
+        messageContext.agentContext,
+        mediationRecord
+      )
+      return createOutboundMessage(connection, message)
     }
   }
 }

--- a/packages/core/src/modules/routing/repository/MediationRepository.ts
+++ b/packages/core/src/modules/routing/repository/MediationRepository.ts
@@ -1,3 +1,5 @@
+import type { AgentContext } from '../../../agent'
+
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InjectionSymbols } from '../../../constants'
 import { inject, injectable } from '../../../plugins'
@@ -15,13 +17,13 @@ export class MediationRepository extends Repository<MediationRecord> {
     super(MediationRecord, storageService, eventEmitter)
   }
 
-  public getSingleByRecipientKey(recipientKey: string) {
-    return this.getSingleByQuery({
+  public getSingleByRecipientKey(agentContext: AgentContext, recipientKey: string) {
+    return this.getSingleByQuery(agentContext, {
       recipientKeys: [recipientKey],
     })
   }
 
-  public async getByConnectionId(connectionId: string): Promise<MediationRecord> {
-    return this.getSingleByQuery({ connectionId })
+  public async getByConnectionId(agentContext: AgentContext, connectionId: string): Promise<MediationRecord> {
+    return this.getSingleByQuery(agentContext, { connectionId })
   }
 }

--- a/packages/core/src/modules/routing/services/MediationRecipientService.ts
+++ b/packages/core/src/modules/routing/services/MediationRecipientService.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../../agent'
 import type { AgentMessage } from '../../../agent/AgentMessage'
 import type { AgentMessageReceivedEvent } from '../../../agent/Events'
 import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
@@ -17,7 +18,6 @@ import type { GetRoutingOptions } from './RoutingService'
 import { firstValueFrom, ReplaySubject } from 'rxjs'
 import { filter, first, timeout } from 'rxjs/operators'
 
-import { AgentConfig } from '../../../agent/AgentConfig'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { AgentEventTypes } from '../../../agent/Events'
 import { MessageSender } from '../../../agent/MessageSender'
@@ -48,16 +48,13 @@ export class MediationRecipientService {
   private eventEmitter: EventEmitter
   private connectionService: ConnectionService
   private messageSender: MessageSender
-  private config: AgentConfig
 
   public constructor(
     connectionService: ConnectionService,
     messageSender: MessageSender,
-    config: AgentConfig,
     mediatorRepository: MediationRepository,
     eventEmitter: EventEmitter
   ) {
-    this.config = config
     this.mediationRepository = mediatorRepository
     this.eventEmitter = eventEmitter
     this.connectionService = connectionService
@@ -82,6 +79,7 @@ export class MediationRecipientService {
   }
 
   public async createRequest(
+    agentContext: AgentContext,
     connection: ConnectionRecord
   ): Promise<MediationProtocolMsgReturnType<MediationRequestMessage>> {
     const message = new MediationRequestMessage({})
@@ -92,8 +90,8 @@ export class MediationRecipientService {
       role: MediationRole.Recipient,
       connectionId: connection.id,
     })
-    await this.mediationRepository.save(mediationRecord)
-    this.emitStateChangedEvent(mediationRecord, null)
+    await this.mediationRepository.save(agentContext, mediationRecord)
+    this.emitStateChangedEvent(agentContext, mediationRecord, null)
 
     return { mediationRecord, message }
   }
@@ -103,7 +101,7 @@ export class MediationRecipientService {
     const connection = messageContext.assertReadyConnection()
 
     // Mediation record must already exists to be updated to granted status
-    const mediationRecord = await this.mediationRepository.getByConnectionId(connection.id)
+    const mediationRecord = await this.mediationRepository.getByConnectionId(messageContext.agentContext, connection.id)
 
     // Assert
     mediationRecord.assertState(MediationState.Requested)
@@ -112,14 +110,14 @@ export class MediationRecipientService {
     // Update record
     mediationRecord.endpoint = messageContext.message.endpoint
     mediationRecord.routingKeys = messageContext.message.routingKeys
-    return await this.updateState(mediationRecord, MediationState.Granted)
+    return await this.updateState(messageContext.agentContext, mediationRecord, MediationState.Granted)
   }
 
   public async processKeylistUpdateResults(messageContext: InboundMessageContext<KeylistUpdateResponseMessage>) {
     // Assert ready connection
     const connection = messageContext.assertReadyConnection()
 
-    const mediationRecord = await this.mediationRepository.getByConnectionId(connection.id)
+    const mediationRecord = await this.mediationRepository.getByConnectionId(messageContext.agentContext, connection.id)
 
     // Assert
     mediationRecord.assertReady()
@@ -136,8 +134,8 @@ export class MediationRecipientService {
       }
     }
 
-    await this.mediationRepository.update(mediationRecord)
-    this.eventEmitter.emit<KeylistUpdatedEvent>({
+    await this.mediationRepository.update(messageContext.agentContext, mediationRecord)
+    this.eventEmitter.emit<KeylistUpdatedEvent>(messageContext.agentContext, {
       type: RoutingEventTypes.RecipientKeylistUpdated,
       payload: {
         mediationRecord,
@@ -147,12 +145,13 @@ export class MediationRecipientService {
   }
 
   public async keylistUpdateAndAwait(
+    agentContext: AgentContext,
     mediationRecord: MediationRecord,
     verKey: string,
     timeoutMs = 15000 // TODO: this should be a configurable value in agent config
   ): Promise<MediationRecord> {
     const message = this.createKeylistUpdateMessage(verKey)
-    const connection = await this.connectionService.getById(mediationRecord.connectionId)
+    const connection = await this.connectionService.getById(agentContext, mediationRecord.connectionId)
 
     mediationRecord.assertReady()
     mediationRecord.assertRole(MediationRole.Recipient)
@@ -174,7 +173,7 @@ export class MediationRecipientService {
       .subscribe(subject)
 
     const outboundMessage = createOutboundMessage(connection, message)
-    await this.messageSender.sendMessage(outboundMessage)
+    await this.messageSender.sendMessage(agentContext, outboundMessage)
 
     const keylistUpdate = await firstValueFrom(subject)
     return keylistUpdate.payload.mediationRecord
@@ -193,24 +192,29 @@ export class MediationRecipientService {
   }
 
   public async addMediationRouting(
+    agentContext: AgentContext,
     routing: Routing,
     { mediatorId, useDefaultMediator = true }: GetRoutingOptions = {}
   ): Promise<Routing> {
     let mediationRecord: MediationRecord | null = null
 
     if (mediatorId) {
-      mediationRecord = await this.getById(mediatorId)
+      mediationRecord = await this.getById(agentContext, mediatorId)
     } else if (useDefaultMediator) {
       // If no mediatorId is provided, and useDefaultMediator is true (default)
       // We use the default mediator if available
-      mediationRecord = await this.findDefaultMediator()
+      mediationRecord = await this.findDefaultMediator(agentContext)
     }
 
     // Return early if no mediation record
     if (!mediationRecord) return routing
 
     // new did has been created and mediator needs to be updated with the public key.
-    mediationRecord = await this.keylistUpdateAndAwait(mediationRecord, routing.recipientKey.publicKeyBase58)
+    mediationRecord = await this.keylistUpdateAndAwait(
+      agentContext,
+      mediationRecord,
+      routing.recipientKey.publicKeyBase58
+    )
 
     return {
       ...routing,
@@ -223,7 +227,7 @@ export class MediationRecipientService {
     const connection = messageContext.assertReadyConnection()
 
     // Mediation record already exists
-    const mediationRecord = await this.findByConnectionId(connection.id)
+    const mediationRecord = await this.findByConnectionId(messageContext.agentContext, connection.id)
 
     if (!mediationRecord) {
       throw new Error(`No mediation has been requested for this connection id: ${connection.id}`)
@@ -234,7 +238,7 @@ export class MediationRecipientService {
     mediationRecord.assertState(MediationState.Requested)
 
     // Update record
-    await this.updateState(mediationRecord, MediationState.Denied)
+    await this.updateState(messageContext.agentContext, mediationRecord, MediationState.Denied)
 
     return mediationRecord
   }
@@ -244,33 +248,41 @@ export class MediationRecipientService {
     const { message: statusMessage } = messageContext
     const { messageCount, recipientKey } = statusMessage
 
-    const mediationRecord = await this.mediationRepository.getByConnectionId(connection.id)
+    const mediationRecord = await this.mediationRepository.getByConnectionId(messageContext.agentContext, connection.id)
 
     mediationRecord.assertReady()
     mediationRecord.assertRole(MediationRole.Recipient)
 
     //No messages to be sent
     if (messageCount === 0) {
-      const { message, connectionRecord } = await this.connectionService.createTrustPing(connection, {
-        responseRequested: false,
-      })
+      const { message, connectionRecord } = await this.connectionService.createTrustPing(
+        messageContext.agentContext,
+        connection,
+        {
+          responseRequested: false,
+        }
+      )
       const websocketSchemes = ['ws', 'wss']
 
-      await this.messageSender.sendMessage(createOutboundMessage(connectionRecord, message), {
-        transportPriority: {
-          schemes: websocketSchemes,
-          restrictive: true,
-          // TODO: add keepAlive: true to enforce through the public api
-          // we need to keep the socket alive. It already works this way, but would
-          // be good to make more explicit from the public facing API.
-          // This would also make it easier to change the internal API later on.
-          // keepAlive: true,
-        },
-      })
+      await this.messageSender.sendMessage(
+        messageContext.agentContext,
+        createOutboundMessage(connectionRecord, message),
+        {
+          transportPriority: {
+            schemes: websocketSchemes,
+            restrictive: true,
+            // TODO: add keepAlive: true to enforce through the public api
+            // we need to keep the socket alive. It already works this way, but would
+            // be good to make more explicit from the public facing API.
+            // This would also make it easier to change the internal API later on.
+            // keepAlive: true,
+          },
+        }
+      )
 
       return null
     }
-    const { maximumMessagePickup } = this.config
+    const { maximumMessagePickup } = messageContext.agentContext.config
     const limit = messageCount < maximumMessagePickup ? messageCount : maximumMessagePickup
 
     const deliveryRequestMessage = new DeliveryRequestMessage({
@@ -286,7 +298,7 @@ export class MediationRecipientService {
 
     const { appendedAttachments } = messageContext.message
 
-    const mediationRecord = await this.mediationRepository.getByConnectionId(connection.id)
+    const mediationRecord = await this.mediationRepository.getByConnectionId(messageContext.agentContext, connection.id)
 
     mediationRecord.assertReady()
     mediationRecord.assertRole(MediationRole.Recipient)
@@ -300,7 +312,7 @@ export class MediationRecipientService {
     for (const attachment of appendedAttachments) {
       ids.push(attachment.id)
 
-      this.eventEmitter.emit<AgentMessageReceivedEvent>({
+      this.eventEmitter.emit<AgentMessageReceivedEvent>(messageContext.agentContext, {
         type: AgentEventTypes.AgentMessageReceived,
         payload: {
           message: attachment.getDataAsJson<EncryptedMessage>(),
@@ -321,18 +333,22 @@ export class MediationRecipientService {
    * @param newState The state to update to
    *
    */
-  private async updateState(mediationRecord: MediationRecord, newState: MediationState) {
+  private async updateState(agentContext: AgentContext, mediationRecord: MediationRecord, newState: MediationState) {
     const previousState = mediationRecord.state
     mediationRecord.state = newState
-    await this.mediationRepository.update(mediationRecord)
+    await this.mediationRepository.update(agentContext, mediationRecord)
 
-    this.emitStateChangedEvent(mediationRecord, previousState)
+    this.emitStateChangedEvent(agentContext, mediationRecord, previousState)
     return mediationRecord
   }
 
-  private emitStateChangedEvent(mediationRecord: MediationRecord, previousState: MediationState | null) {
+  private emitStateChangedEvent(
+    agentContext: AgentContext,
+    mediationRecord: MediationRecord,
+    previousState: MediationState | null
+  ) {
     const clonedMediationRecord = JsonTransformer.clone(mediationRecord)
-    this.eventEmitter.emit<MediationStateChangedEvent>({
+    this.eventEmitter.emit<MediationStateChangedEvent>(agentContext, {
       type: RoutingEventTypes.MediationStateChanged,
       payload: {
         mediationRecord: clonedMediationRecord,
@@ -341,29 +357,32 @@ export class MediationRecipientService {
     })
   }
 
-  public async getById(id: string): Promise<MediationRecord> {
-    return this.mediationRepository.getById(id)
+  public async getById(agentContext: AgentContext, id: string): Promise<MediationRecord> {
+    return this.mediationRepository.getById(agentContext, id)
   }
 
-  public async findByConnectionId(connectionId: string): Promise<MediationRecord | null> {
-    return this.mediationRepository.findSingleByQuery({ connectionId })
+  public async findByConnectionId(agentContext: AgentContext, connectionId: string): Promise<MediationRecord | null> {
+    return this.mediationRepository.findSingleByQuery(agentContext, { connectionId })
   }
 
-  public async getMediators(): Promise<MediationRecord[]> {
-    return this.mediationRepository.getAll()
+  public async getMediators(agentContext: AgentContext): Promise<MediationRecord[]> {
+    return this.mediationRepository.getAll(agentContext)
   }
 
-  public async findDefaultMediator(): Promise<MediationRecord | null> {
-    return this.mediationRepository.findSingleByQuery({ default: true })
+  public async findDefaultMediator(agentContext: AgentContext): Promise<MediationRecord | null> {
+    return this.mediationRepository.findSingleByQuery(agentContext, { default: true })
   }
 
-  public async discoverMediation(mediatorId?: string): Promise<MediationRecord | undefined> {
+  public async discoverMediation(
+    agentContext: AgentContext,
+    mediatorId?: string
+  ): Promise<MediationRecord | undefined> {
     // If mediatorId is passed, always use it (and error if it is not found)
     if (mediatorId) {
-      return this.mediationRepository.getById(mediatorId)
+      return this.mediationRepository.getById(agentContext, mediatorId)
     }
 
-    const defaultMediator = await this.findDefaultMediator()
+    const defaultMediator = await this.findDefaultMediator(agentContext)
     if (defaultMediator) {
       if (defaultMediator.state !== MediationState.Granted) {
         throw new AriesFrameworkError(
@@ -375,25 +394,25 @@ export class MediationRecipientService {
     }
   }
 
-  public async setDefaultMediator(mediator: MediationRecord) {
-    const mediationRecords = await this.mediationRepository.findByQuery({ default: true })
+  public async setDefaultMediator(agentContext: AgentContext, mediator: MediationRecord) {
+    const mediationRecords = await this.mediationRepository.findByQuery(agentContext, { default: true })
 
     for (const record of mediationRecords) {
       record.setTag('default', false)
-      await this.mediationRepository.update(record)
+      await this.mediationRepository.update(agentContext, record)
     }
 
     // Set record coming in tag to true and then update.
     mediator.setTag('default', true)
-    await this.mediationRepository.update(mediator)
+    await this.mediationRepository.update(agentContext, mediator)
   }
 
-  public async clearDefaultMediator() {
-    const mediationRecord = await this.findDefaultMediator()
+  public async clearDefaultMediator(agentContext: AgentContext) {
+    const mediationRecord = await this.findDefaultMediator(agentContext)
 
     if (mediationRecord) {
       mediationRecord.setTag('default', false)
-      await this.mediationRepository.update(mediationRecord)
+      await this.mediationRepository.update(agentContext, mediationRecord)
     }
   }
 }

--- a/packages/core/src/modules/routing/services/MediatorService.ts
+++ b/packages/core/src/modules/routing/services/MediatorService.ts
@@ -1,22 +1,22 @@
+import type { AgentContext } from '../../../agent'
 import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
 import type { EncryptedMessage } from '../../../types'
 import type { MediationStateChangedEvent } from '../RoutingEvents'
 import type { ForwardMessage, KeylistUpdateMessage, MediationRequestMessage } from '../messages'
 
-import { AgentConfig } from '../../../agent/AgentConfig'
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InjectionSymbols } from '../../../constants'
 import { AriesFrameworkError } from '../../../error'
-import { inject, injectable } from '../../../plugins'
+import { Logger } from '../../../logger'
+import { injectable, inject } from '../../../plugins'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
-import { Wallet } from '../../../wallet/Wallet'
 import { RoutingEventTypes } from '../RoutingEvents'
 import {
   KeylistUpdateAction,
-  KeylistUpdateResult,
   KeylistUpdated,
-  MediationGrantMessage,
   KeylistUpdateResponseMessage,
+  KeylistUpdateResult,
+  MediationGrantMessage,
 } from '../messages'
 import { MediationRole } from '../models/MediationRole'
 import { MediationState } from '../models/MediationState'
@@ -27,54 +27,52 @@ import { MediatorRoutingRepository } from '../repository/MediatorRoutingReposito
 
 @injectable()
 export class MediatorService {
-  private agentConfig: AgentConfig
+  private logger: Logger
   private mediationRepository: MediationRepository
   private mediatorRoutingRepository: MediatorRoutingRepository
-  private wallet: Wallet
   private eventEmitter: EventEmitter
   private _mediatorRoutingRecord?: MediatorRoutingRecord
 
   public constructor(
     mediationRepository: MediationRepository,
     mediatorRoutingRepository: MediatorRoutingRepository,
-    agentConfig: AgentConfig,
-    @inject(InjectionSymbols.Wallet) wallet: Wallet,
-    eventEmitter: EventEmitter
+    eventEmitter: EventEmitter,
+    @inject(InjectionSymbols.Logger) logger: Logger
   ) {
     this.mediationRepository = mediationRepository
     this.mediatorRoutingRepository = mediatorRoutingRepository
-    this.agentConfig = agentConfig
-    this.wallet = wallet
     this.eventEmitter = eventEmitter
+    this.logger = logger
   }
 
-  private async getRoutingKeys() {
-    this.agentConfig.logger.debug('Retrieving mediator routing keys')
+  private async getRoutingKeys(agentContext: AgentContext) {
+    this.logger.debug('Retrieving mediator routing keys')
     // If the routing record is not loaded yet, retrieve it from storage
     if (!this._mediatorRoutingRecord) {
-      this.agentConfig.logger.debug('Mediator routing record not loaded yet, retrieving from storage')
+      this.logger.debug('Mediator routing record not loaded yet, retrieving from storage')
       let routingRecord = await this.mediatorRoutingRepository.findById(
+        agentContext,
         this.mediatorRoutingRepository.MEDIATOR_ROUTING_RECORD_ID
       )
 
       // If we don't have a routing record yet, create it
       if (!routingRecord) {
-        this.agentConfig.logger.debug('Mediator routing record does not exist yet, creating routing keys and record')
-        const { verkey } = await this.wallet.createDid()
+        this.logger.debug('Mediator routing record does not exist yet, creating routing keys and record')
+        const { verkey } = await agentContext.wallet.createDid()
 
         routingRecord = new MediatorRoutingRecord({
           id: this.mediatorRoutingRepository.MEDIATOR_ROUTING_RECORD_ID,
           routingKeys: [verkey],
         })
 
-        await this.mediatorRoutingRepository.save(routingRecord)
+        await this.mediatorRoutingRepository.save(agentContext, routingRecord)
       }
 
       this._mediatorRoutingRecord = routingRecord
     }
 
     // Return the routing keys
-    this.agentConfig.logger.debug(`Returning mediator routing keys ${this._mediatorRoutingRecord.routingKeys}`)
+    this.logger.debug(`Returning mediator routing keys ${this._mediatorRoutingRecord.routingKeys}`)
     return this._mediatorRoutingRecord.routingKeys
   }
 
@@ -88,7 +86,10 @@ export class MediatorService {
       throw new AriesFrameworkError('Invalid Message: Missing required attribute "to"')
     }
 
-    const mediationRecord = await this.mediationRepository.getSingleByRecipientKey(message.to)
+    const mediationRecord = await this.mediationRepository.getSingleByRecipientKey(
+      messageContext.agentContext,
+      message.to
+    )
 
     // Assert mediation record is ready to be used
     mediationRecord.assertReady()
@@ -107,7 +108,7 @@ export class MediatorService {
     const { message } = messageContext
     const keylist: KeylistUpdated[] = []
 
-    const mediationRecord = await this.mediationRepository.getByConnectionId(connection.id)
+    const mediationRecord = await this.mediationRepository.getByConnectionId(messageContext.agentContext, connection.id)
 
     mediationRecord.assertReady()
     mediationRecord.assertRole(MediationRole.Mediator)
@@ -130,21 +131,21 @@ export class MediatorService {
       }
     }
 
-    await this.mediationRepository.update(mediationRecord)
+    await this.mediationRepository.update(messageContext.agentContext, mediationRecord)
 
     return new KeylistUpdateResponseMessage({ keylist, threadId: message.threadId })
   }
 
-  public async createGrantMediationMessage(mediationRecord: MediationRecord) {
+  public async createGrantMediationMessage(agentContext: AgentContext, mediationRecord: MediationRecord) {
     // Assert
     mediationRecord.assertState(MediationState.Requested)
     mediationRecord.assertRole(MediationRole.Mediator)
 
-    await this.updateState(mediationRecord, MediationState.Granted)
+    await this.updateState(agentContext, mediationRecord, MediationState.Granted)
 
     const message = new MediationGrantMessage({
-      endpoint: this.agentConfig.endpoints[0],
-      routingKeys: await this.getRoutingKeys(),
+      endpoint: agentContext.config.endpoints[0],
+      routingKeys: await this.getRoutingKeys(agentContext),
       threadId: mediationRecord.threadId,
     })
 
@@ -162,37 +163,41 @@ export class MediatorService {
       threadId: messageContext.message.threadId,
     })
 
-    await this.mediationRepository.save(mediationRecord)
-    this.emitStateChangedEvent(mediationRecord, null)
+    await this.mediationRepository.save(messageContext.agentContext, mediationRecord)
+    this.emitStateChangedEvent(messageContext.agentContext, mediationRecord, null)
 
     return mediationRecord
   }
 
-  public async findById(mediatorRecordId: string): Promise<MediationRecord | null> {
-    return this.mediationRepository.findById(mediatorRecordId)
+  public async findById(agentContext: AgentContext, mediatorRecordId: string): Promise<MediationRecord | null> {
+    return this.mediationRepository.findById(agentContext, mediatorRecordId)
   }
 
-  public async getById(mediatorRecordId: string): Promise<MediationRecord> {
-    return this.mediationRepository.getById(mediatorRecordId)
+  public async getById(agentContext: AgentContext, mediatorRecordId: string): Promise<MediationRecord> {
+    return this.mediationRepository.getById(agentContext, mediatorRecordId)
   }
 
-  public async getAll(): Promise<MediationRecord[]> {
-    return await this.mediationRepository.getAll()
+  public async getAll(agentContext: AgentContext): Promise<MediationRecord[]> {
+    return await this.mediationRepository.getAll(agentContext)
   }
 
-  private async updateState(mediationRecord: MediationRecord, newState: MediationState) {
+  private async updateState(agentContext: AgentContext, mediationRecord: MediationRecord, newState: MediationState) {
     const previousState = mediationRecord.state
 
     mediationRecord.state = newState
 
-    await this.mediationRepository.update(mediationRecord)
+    await this.mediationRepository.update(agentContext, mediationRecord)
 
-    this.emitStateChangedEvent(mediationRecord, previousState)
+    this.emitStateChangedEvent(agentContext, mediationRecord, previousState)
   }
 
-  private emitStateChangedEvent(mediationRecord: MediationRecord, previousState: MediationState | null) {
+  private emitStateChangedEvent(
+    agentContext: AgentContext,
+    mediationRecord: MediationRecord,
+    previousState: MediationState | null
+  ) {
     const clonedMediationRecord = JsonTransformer.clone(mediationRecord)
-    this.eventEmitter.emit<MediationStateChangedEvent>({
+    this.eventEmitter.emit<MediationStateChangedEvent>(agentContext, {
       type: RoutingEventTypes.MediationStateChanged,
       payload: {
         mediationRecord: clonedMediationRecord,

--- a/packages/core/src/modules/routing/services/__tests__/MediationRecipientService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/MediationRecipientService.test.ts
@@ -1,7 +1,8 @@
+import type { AgentContext } from '../../../../agent'
 import type { Wallet } from '../../../../wallet/Wallet'
 import type { Routing } from '../../../connections/services/ConnectionService'
 
-import { getAgentConfig, getMockConnection, mockFunction } from '../../../../../tests/helpers'
+import { getAgentConfig, getAgentContext, getMockConnection, mockFunction } from '../../../../../tests/helpers'
 import { EventEmitter } from '../../../../agent/EventEmitter'
 import { AgentEventTypes } from '../../../../agent/Events'
 import { MessageSender } from '../../../../agent/MessageSender'
@@ -56,9 +57,13 @@ describe('MediationRecipientService', () => {
   let messageSender: MessageSender
   let mediationRecipientService: MediationRecipientService
   let mediationRecord: MediationRecord
+  let agentContext: AgentContext
 
   beforeAll(async () => {
-    wallet = new IndyWallet(config)
+    wallet = new IndyWallet(config.agentDependencies, config.logger)
+    agentContext = getAgentContext({
+      agentConfig: config,
+    })
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await wallet.createAndOpen(config.walletConfig!)
   })
@@ -71,7 +76,7 @@ describe('MediationRecipientService', () => {
     eventEmitter = new EventEmitterMock()
     connectionRepository = new ConnectionRepositoryMock()
     didRepository = new DidRepositoryMock()
-    connectionService = new ConnectionService(wallet, config, connectionRepository, didRepository, eventEmitter)
+    connectionService = new ConnectionService(config.logger, connectionRepository, didRepository, eventEmitter)
     mediationRepository = new MediationRepositoryMock()
     messageSender = new MessageSenderMock()
 
@@ -87,7 +92,6 @@ describe('MediationRecipientService', () => {
     mediationRecipientService = new MediationRecipientService(
       connectionService,
       messageSender,
-      config,
       mediationRepository,
       eventEmitter
     )
@@ -126,7 +130,7 @@ describe('MediationRecipientService', () => {
         messageCount: 0,
       })
 
-      const messageContext = new InboundMessageContext(status, { connection: mockConnection })
+      const messageContext = new InboundMessageContext(status, { connection: mockConnection, agentContext })
       const deliveryRequestMessage = await mediationRecipientService.processStatus(messageContext)
       expect(deliveryRequestMessage).toBeNull()
     })
@@ -135,7 +139,7 @@ describe('MediationRecipientService', () => {
       const status = new StatusMessage({
         messageCount: 1,
       })
-      const messageContext = new InboundMessageContext(status, { connection: mockConnection })
+      const messageContext = new InboundMessageContext(status, { connection: mockConnection, agentContext })
 
       const deliveryRequestMessage = await mediationRecipientService.processStatus(messageContext)
       expect(deliveryRequestMessage)
@@ -146,7 +150,7 @@ describe('MediationRecipientService', () => {
       const status = new StatusMessage({
         messageCount: 1,
       })
-      const messageContext = new InboundMessageContext(status, { connection: mockConnection })
+      const messageContext = new InboundMessageContext(status, { connection: mockConnection, agentContext })
 
       mediationRecord.role = MediationRole.Mediator
       await expect(mediationRecipientService.processStatus(messageContext)).rejects.toThrowError(
@@ -164,7 +168,10 @@ describe('MediationRecipientService', () => {
 
   describe('processDelivery', () => {
     it('if the delivery has no attachments expect an error', async () => {
-      const messageContext = new InboundMessageContext({} as MessageDeliveryMessage, { connection: mockConnection })
+      const messageContext = new InboundMessageContext({} as MessageDeliveryMessage, {
+        connection: mockConnection,
+        agentContext,
+      })
 
       await expect(mediationRecipientService.processDelivery(messageContext)).rejects.toThrowError(
         new AriesFrameworkError('Error processing attachments')
@@ -184,7 +191,10 @@ describe('MediationRecipientService', () => {
           }),
         ],
       })
-      const messageContext = new InboundMessageContext(messageDeliveryMessage, { connection: mockConnection })
+      const messageContext = new InboundMessageContext(messageDeliveryMessage, {
+        connection: mockConnection,
+        agentContext,
+      })
 
       const messagesReceivedMessage = await mediationRecipientService.processDelivery(messageContext)
 
@@ -217,18 +227,21 @@ describe('MediationRecipientService', () => {
           }),
         ],
       })
-      const messageContext = new InboundMessageContext(messageDeliveryMessage, { connection: mockConnection })
+      const messageContext = new InboundMessageContext(messageDeliveryMessage, {
+        connection: mockConnection,
+        agentContext,
+      })
 
       await mediationRecipientService.processDelivery(messageContext)
 
       expect(eventEmitter.emit).toHaveBeenCalledTimes(2)
-      expect(eventEmitter.emit).toHaveBeenNthCalledWith(1, {
+      expect(eventEmitter.emit).toHaveBeenNthCalledWith(1, agentContext, {
         type: AgentEventTypes.AgentMessageReceived,
         payload: {
           message: { first: 'value' },
         },
       })
-      expect(eventEmitter.emit).toHaveBeenNthCalledWith(2, {
+      expect(eventEmitter.emit).toHaveBeenNthCalledWith(2, agentContext, {
         type: AgentEventTypes.AgentMessageReceived,
         payload: {
           message: { second: 'value' },
@@ -249,7 +262,10 @@ describe('MediationRecipientService', () => {
           }),
         ],
       })
-      const messageContext = new InboundMessageContext(messageDeliveryMessage, { connection: mockConnection })
+      const messageContext = new InboundMessageContext(messageDeliveryMessage, {
+        connection: mockConnection,
+        agentContext,
+      })
 
       mediationRecord.role = MediationRole.Mediator
       await expect(mediationRecipientService.processDelivery(messageContext)).rejects.toThrowError(
@@ -290,7 +306,7 @@ describe('MediationRecipientService', () => {
     test('adds mediation routing id mediator id is passed', async () => {
       mockFunction(mediationRepository.getById).mockResolvedValue(mediationRecord)
 
-      const extendedRouting = await mediationRecipientService.addMediationRouting(routing, {
+      const extendedRouting = await mediationRecipientService.addMediationRouting(agentContext, routing, {
         mediatorId: 'mediator-id',
       })
 
@@ -298,14 +314,14 @@ describe('MediationRecipientService', () => {
         endpoints: ['https://a-mediator-endpoint.com'],
         routingKeys: [routingKey],
       })
-      expect(mediationRepository.getById).toHaveBeenCalledWith('mediator-id')
+      expect(mediationRepository.getById).toHaveBeenCalledWith(agentContext, 'mediator-id')
     })
 
     test('adds mediation routing if useDefaultMediator is true and default mediation is found', async () => {
       mockFunction(mediationRepository.findSingleByQuery).mockResolvedValue(mediationRecord)
 
       jest.spyOn(mediationRecipientService, 'keylistUpdateAndAwait').mockResolvedValue(mediationRecord)
-      const extendedRouting = await mediationRecipientService.addMediationRouting(routing, {
+      const extendedRouting = await mediationRecipientService.addMediationRouting(agentContext, routing, {
         useDefaultMediator: true,
       })
 
@@ -313,14 +329,14 @@ describe('MediationRecipientService', () => {
         endpoints: ['https://a-mediator-endpoint.com'],
         routingKeys: [routingKey],
       })
-      expect(mediationRepository.findSingleByQuery).toHaveBeenCalledWith({ default: true })
+      expect(mediationRepository.findSingleByQuery).toHaveBeenCalledWith(agentContext, { default: true })
     })
 
     test('does not add mediation routing if no mediation is found', async () => {
       mockFunction(mediationRepository.findSingleByQuery).mockResolvedValue(mediationRecord)
 
       jest.spyOn(mediationRecipientService, 'keylistUpdateAndAwait').mockResolvedValue(mediationRecord)
-      const extendedRouting = await mediationRecipientService.addMediationRouting(routing, {
+      const extendedRouting = await mediationRecipientService.addMediationRouting(agentContext, routing, {
         useDefaultMediator: false,
       })
 

--- a/packages/core/src/modules/routing/services/__tests__/RoutingService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/RoutingService.test.ts
@@ -1,4 +1,6 @@
-import { getAgentConfig, mockFunction } from '../../../../../tests/helpers'
+import { Subject } from 'rxjs'
+
+import { getAgentConfig, getAgentContext, mockFunction } from '../../../../../tests/helpers'
 import { EventEmitter } from '../../../../agent/EventEmitter'
 import { Key } from '../../../../crypto'
 import { IndyWallet } from '../../../../wallet/IndyWallet'
@@ -15,10 +17,14 @@ const MediationRecipientServiceMock = MediationRecipientService as jest.Mock<Med
 const agentConfig = getAgentConfig('RoutingService', {
   endpoints: ['http://endpoint.com'],
 })
-const eventEmitter = new EventEmitter(agentConfig)
+const eventEmitter = new EventEmitter(agentConfig.agentDependencies, new Subject())
 const wallet = new IndyWalletMock()
+const agentContext = getAgentContext({
+  wallet,
+  agentConfig,
+})
 const mediationRecipientService = new MediationRecipientServiceMock()
-const routingService = new RoutingService(mediationRecipientService, agentConfig, wallet, eventEmitter)
+const routingService = new RoutingService(mediationRecipientService, eventEmitter)
 
 const recipientKey = Key.fromFingerprint('z6Mkk7yqnGF3YwTrLpqrW6PGsKci7dNqh1CjnvMbzrMerSeL')
 
@@ -40,12 +46,12 @@ describe('RoutingService', () => {
 
   describe('getRouting', () => {
     test('calls mediation recipient service', async () => {
-      const routing = await routingService.getRouting({
+      const routing = await routingService.getRouting(agentContext, {
         mediatorId: 'mediator-id',
         useDefaultMediator: true,
       })
 
-      expect(mediationRecipientService.addMediationRouting).toHaveBeenCalledWith(routing, {
+      expect(mediationRecipientService.addMediationRouting).toHaveBeenCalledWith(agentContext, routing, {
         mediatorId: 'mediator-id',
         useDefaultMediator: true,
       })
@@ -55,7 +61,7 @@ describe('RoutingService', () => {
       const routingListener = jest.fn()
       eventEmitter.on(RoutingEventTypes.RoutingCreatedEvent, routingListener)
 
-      const routing = await routingService.getRouting()
+      const routing = await routingService.getRouting(agentContext)
 
       expect(routing).toEqual(routing)
       expect(routingListener).toHaveBeenCalledWith({

--- a/packages/core/src/modules/vc/W3cCredentialService.ts
+++ b/packages/core/src/modules/vc/W3cCredentialService.ts
@@ -1,5 +1,6 @@
+import type { AgentContext } from '../..'
 import type { Key } from '../../crypto/Key'
-import type { DocumentLoaderResult } from './jsonldUtil'
+import type { DocumentLoader } from './jsonldUtil'
 import type { W3cVerifyCredentialResult } from './models'
 import type {
   CreatePresentationOptions,
@@ -12,15 +13,11 @@ import type {
 } from './models/W3cCredentialServiceOptions'
 import type { VerifyPresentationResult } from './models/presentation/VerifyPresentationResult'
 
-import { inject } from 'tsyringe'
-
-import { InjectionSymbols } from '../../constants'
 import { createWalletKeyPairClass } from '../../crypto/WalletKeyPair'
 import { AriesFrameworkError } from '../../error'
 import { injectable } from '../../plugins'
 import { JsonTransformer } from '../../utils'
 import { isNodeJS, isReactNative } from '../../utils/environment'
-import { Wallet } from '../../wallet'
 import { DidResolverService, VerificationMethod } from '../dids'
 import { getKeyDidMappingByVerificationMethod } from '../dids/domain/key-type'
 
@@ -36,17 +33,11 @@ import { deriveProof } from './signature-suites/bbs'
 
 @injectable()
 export class W3cCredentialService {
-  private wallet: Wallet
   private w3cCredentialRepository: W3cCredentialRepository
   private didResolver: DidResolverService
   private suiteRegistry: SignatureSuiteRegistry
 
-  public constructor(
-    @inject(InjectionSymbols.Wallet) wallet: Wallet,
-    w3cCredentialRepository: W3cCredentialRepository,
-    didResolver: DidResolverService
-  ) {
-    this.wallet = wallet
+  public constructor(w3cCredentialRepository: W3cCredentialRepository, didResolver: DidResolverService) {
     this.w3cCredentialRepository = w3cCredentialRepository
     this.didResolver = didResolver
     this.suiteRegistry = new SignatureSuiteRegistry()
@@ -58,10 +49,13 @@ export class W3cCredentialService {
    * @param credential the credential to be signed
    * @returns the signed credential
    */
-  public async signCredential(options: SignCredentialOptions): Promise<W3cVerifiableCredential> {
-    const WalletKeyPair = createWalletKeyPairClass(this.wallet)
+  public async signCredential(
+    agentContext: AgentContext,
+    options: SignCredentialOptions
+  ): Promise<W3cVerifiableCredential> {
+    const WalletKeyPair = createWalletKeyPairClass(agentContext.wallet)
 
-    const signingKey = await this.getPublicKeyFromVerificationMethod(options.verificationMethod)
+    const signingKey = await this.getPublicKeyFromVerificationMethod(agentContext, options.verificationMethod)
     const suiteInfo = this.suiteRegistry.getByProofType(options.proofType)
 
     if (signingKey.keyType !== suiteInfo.keyType) {
@@ -72,7 +66,7 @@ export class W3cCredentialService {
       controller: options.credential.issuerId, // should we check this against the verificationMethod.controller?
       id: options.verificationMethod,
       key: signingKey,
-      wallet: this.wallet,
+      wallet: agentContext.wallet,
     })
 
     const SuiteClass = suiteInfo.suiteClass
@@ -91,7 +85,7 @@ export class W3cCredentialService {
       credential: JsonTransformer.toJSON(options.credential),
       suite: suite,
       purpose: options.proofPurpose,
-      documentLoader: this.documentLoader,
+      documentLoader: this.documentLoaderWithContext(agentContext),
     })
 
     return JsonTransformer.fromJSON(result, W3cVerifiableCredential)
@@ -103,13 +97,16 @@ export class W3cCredentialService {
    * @param credential the credential to be verified
    * @returns the verification result
    */
-  public async verifyCredential(options: VerifyCredentialOptions): Promise<W3cVerifyCredentialResult> {
-    const suites = this.getSignatureSuitesForCredential(options.credential)
+  public async verifyCredential(
+    agentContext: AgentContext,
+    options: VerifyCredentialOptions
+  ): Promise<W3cVerifyCredentialResult> {
+    const suites = this.getSignatureSuitesForCredential(agentContext, options.credential)
 
     const verifyOptions: Record<string, unknown> = {
       credential: JsonTransformer.toJSON(options.credential),
       suite: suites,
-      documentLoader: this.documentLoader,
+      documentLoader: this.documentLoaderWithContext(agentContext),
     }
 
     // this is a hack because vcjs throws if purpose is passed as undefined or null
@@ -152,9 +149,12 @@ export class W3cCredentialService {
    * @param presentation the presentation to be signed
    * @returns the signed presentation
    */
-  public async signPresentation(options: SignPresentationOptions): Promise<W3cVerifiablePresentation> {
+  public async signPresentation(
+    agentContext: AgentContext,
+    options: SignPresentationOptions
+  ): Promise<W3cVerifiablePresentation> {
     // create keyPair
-    const WalletKeyPair = createWalletKeyPairClass(this.wallet)
+    const WalletKeyPair = createWalletKeyPairClass(agentContext.wallet)
 
     const suiteInfo = this.suiteRegistry.getByProofType(options.signatureType)
 
@@ -162,13 +162,14 @@ export class W3cCredentialService {
       throw new AriesFrameworkError(`The requested proofType ${options.signatureType} is not supported`)
     }
 
-    const signingKey = await this.getPublicKeyFromVerificationMethod(options.verificationMethod)
+    const signingKey = await this.getPublicKeyFromVerificationMethod(agentContext, options.verificationMethod)
 
     if (signingKey.keyType !== suiteInfo.keyType) {
       throw new AriesFrameworkError('The key type of the verification method does not match the suite')
     }
 
-    const verificationMethodObject = (await this.documentLoader(options.verificationMethod)).document as Record<
+    const documentLoader = this.documentLoaderWithContext(agentContext)
+    const verificationMethodObject = (await documentLoader(options.verificationMethod)).document as Record<
       string,
       unknown
     >
@@ -177,7 +178,7 @@ export class W3cCredentialService {
       controller: verificationMethodObject['controller'] as string,
       id: options.verificationMethod,
       key: signingKey,
-      wallet: this.wallet,
+      wallet: agentContext.wallet,
     })
 
     const suite = new suiteInfo.suiteClass({
@@ -194,7 +195,7 @@ export class W3cCredentialService {
       presentation: JsonTransformer.toJSON(options.presentation),
       suite: suite,
       challenge: options.challenge,
-      documentLoader: this.documentLoader,
+      documentLoader: this.documentLoaderWithContext(agentContext),
     })
 
     return JsonTransformer.fromJSON(result, W3cVerifiablePresentation)
@@ -206,9 +207,12 @@ export class W3cCredentialService {
    * @param presentation the presentation to be verified
    * @returns the verification result
    */
-  public async verifyPresentation(options: VerifyPresentationOptions): Promise<VerifyPresentationResult> {
+  public async verifyPresentation(
+    agentContext: AgentContext,
+    options: VerifyPresentationOptions
+  ): Promise<VerifyPresentationResult> {
     // create keyPair
-    const WalletKeyPair = createWalletKeyPairClass(this.wallet)
+    const WalletKeyPair = createWalletKeyPairClass(agentContext.wallet)
 
     let proofs = options.presentation.proof
 
@@ -235,14 +239,16 @@ export class W3cCredentialService {
       ? options.presentation.verifiableCredential
       : [options.presentation.verifiableCredential]
 
-    const credentialSuites = credentials.map((credential) => this.getSignatureSuitesForCredential(credential))
+    const credentialSuites = credentials.map((credential) =>
+      this.getSignatureSuitesForCredential(agentContext, credential)
+    )
     const allSuites = presentationSuites.concat(...credentialSuites)
 
     const verifyOptions: Record<string, unknown> = {
       presentation: JsonTransformer.toJSON(options.presentation),
       suite: allSuites,
       challenge: options.challenge,
-      documentLoader: this.documentLoader,
+      documentLoader: this.documentLoaderWithContext(agentContext),
     }
 
     // this is a hack because vcjs throws if purpose is passed as undefined or null
@@ -255,7 +261,7 @@ export class W3cCredentialService {
     return result as unknown as VerifyPresentationResult
   }
 
-  public async deriveProof(options: DeriveProofOptions): Promise<W3cVerifiableCredential> {
+  public async deriveProof(agentContext: AgentContext, options: DeriveProofOptions): Promise<W3cVerifiableCredential> {
     const suiteInfo = this.suiteRegistry.getByProofType('BbsBlsSignatureProof2020')
     const SuiteClass = suiteInfo.suiteClass
 
@@ -263,48 +269,54 @@ export class W3cCredentialService {
 
     const proof = await deriveProof(JsonTransformer.toJSON(options.credential), options.revealDocument, {
       suite: suite,
-      documentLoader: this.documentLoader,
+      documentLoader: this.documentLoaderWithContext(agentContext),
     })
 
     return proof
   }
 
-  public documentLoader = async (url: string): Promise<DocumentLoaderResult> => {
-    if (url.startsWith('did:')) {
-      const result = await this.didResolver.resolve(url)
+  public documentLoaderWithContext = (agentContext: AgentContext): DocumentLoader => {
+    return async (url: string) => {
+      if (url.startsWith('did:')) {
+        const result = await this.didResolver.resolve(agentContext, url)
 
-      if (result.didResolutionMetadata.error || !result.didDocument) {
-        throw new AriesFrameworkError(`Unable to resolve DID: ${url}`)
+        if (result.didResolutionMetadata.error || !result.didDocument) {
+          throw new AriesFrameworkError(`Unable to resolve DID: ${url}`)
+        }
+
+        const framed = await jsonld.frame(result.didDocument.toJSON(), {
+          '@context': result.didDocument.context,
+          '@embed': '@never',
+          id: url,
+        })
+
+        return {
+          contextUrl: null,
+          documentUrl: url,
+          document: framed,
+        }
       }
 
-      const framed = await jsonld.frame(result.didDocument.toJSON(), {
-        '@context': result.didDocument.context,
-        '@embed': '@never',
-        id: url,
-      })
+      let loader
 
-      return {
-        contextUrl: null,
-        documentUrl: url,
-        document: framed,
+      if (isNodeJS()) {
+        loader = documentLoaderNode.apply(jsonld, [])
+      } else if (isReactNative()) {
+        loader = documentLoaderXhr.apply(jsonld, [])
+      } else {
+        throw new AriesFrameworkError('Unsupported environment')
       }
+
+      return await loader(url)
     }
-
-    let loader
-
-    if (isNodeJS()) {
-      loader = documentLoaderNode.apply(jsonld, [])
-    } else if (isReactNative()) {
-      loader = documentLoaderXhr.apply(jsonld, [])
-    } else {
-      throw new AriesFrameworkError('Unsupported environment')
-    }
-
-    return await loader(url)
   }
 
-  private async getPublicKeyFromVerificationMethod(verificationMethod: string): Promise<Key> {
-    const verificationMethodObject = await this.documentLoader(verificationMethod)
+  private async getPublicKeyFromVerificationMethod(
+    agentContext: AgentContext,
+    verificationMethod: string
+  ): Promise<Key> {
+    const documentLoader = this.documentLoaderWithContext(agentContext)
+    const verificationMethodObject = await documentLoader(verificationMethod)
     const verificationMethodClass = JsonTransformer.fromJSON(verificationMethodObject.document, VerificationMethod)
 
     const key = getKeyDidMappingByVerificationMethod(verificationMethodClass)
@@ -318,10 +330,15 @@ export class W3cCredentialService {
    * @param record the credential to be stored
    * @returns the credential record that was written to storage
    */
-  public async storeCredential(options: StoreCredentialOptions): Promise<W3cCredentialRecord> {
+  public async storeCredential(
+    agentContext: AgentContext,
+    options: StoreCredentialOptions
+  ): Promise<W3cCredentialRecord> {
     // Get the expanded types
     const expandedTypes = (
-      await jsonld.expand(JsonTransformer.toJSON(options.record), { documentLoader: this.documentLoader })
+      await jsonld.expand(JsonTransformer.toJSON(options.record), {
+        documentLoader: this.documentLoaderWithContext(agentContext),
+      })
     )[0]['@type']
 
     // Create an instance of the w3cCredentialRecord
@@ -331,36 +348,38 @@ export class W3cCredentialService {
     })
 
     // Store the w3c credential record
-    await this.w3cCredentialRepository.save(w3cCredentialRecord)
+    await this.w3cCredentialRepository.save(agentContext, w3cCredentialRecord)
 
     return w3cCredentialRecord
   }
 
-  public async getAllCredentials(): Promise<W3cVerifiableCredential[]> {
-    const allRecords = await this.w3cCredentialRepository.getAll()
+  public async getAllCredentials(agentContext: AgentContext): Promise<W3cVerifiableCredential[]> {
+    const allRecords = await this.w3cCredentialRepository.getAll(agentContext)
     return allRecords.map((record) => record.credential)
   }
 
-  public async getCredentialById(id: string): Promise<W3cVerifiableCredential> {
-    return (await this.w3cCredentialRepository.getById(id)).credential
+  public async getCredentialById(agentContext: AgentContext, id: string): Promise<W3cVerifiableCredential> {
+    return (await this.w3cCredentialRepository.getById(agentContext, id)).credential
   }
 
   public async findCredentialsByQuery(
-    query: Parameters<typeof W3cCredentialRepository.prototype.findByQuery>[0]
+    agentContext: AgentContext,
+    query: Parameters<typeof W3cCredentialRepository.prototype.findByQuery>[1]
   ): Promise<W3cVerifiableCredential[]> {
-    const result = await this.w3cCredentialRepository.findByQuery(query)
+    const result = await this.w3cCredentialRepository.findByQuery(agentContext, query)
     return result.map((record) => record.credential)
   }
 
   public async findSingleCredentialByQuery(
-    query: Parameters<typeof W3cCredentialRepository.prototype.findSingleByQuery>[0]
+    agentContext: AgentContext,
+    query: Parameters<typeof W3cCredentialRepository.prototype.findSingleByQuery>[1]
   ): Promise<W3cVerifiableCredential | undefined> {
-    const result = await this.w3cCredentialRepository.findSingleByQuery(query)
+    const result = await this.w3cCredentialRepository.findSingleByQuery(agentContext, query)
     return result?.credential
   }
 
-  private getSignatureSuitesForCredential(credential: W3cVerifiableCredential) {
-    const WalletKeyPair = createWalletKeyPairClass(this.wallet)
+  private getSignatureSuitesForCredential(agentContext: AgentContext, credential: W3cVerifiableCredential) {
+    const WalletKeyPair = createWalletKeyPairClass(agentContext.wallet)
 
     let proofs = credential.proof
 

--- a/packages/core/src/storage/InMemoryMessageRepository.ts
+++ b/packages/core/src/storage/InMemoryMessageRepository.ts
@@ -1,17 +1,17 @@
-import type { Logger } from '../logger'
 import type { EncryptedMessage } from '../types'
 import type { MessageRepository } from './MessageRepository'
 
-import { AgentConfig } from '../agent/AgentConfig'
-import { injectable } from '../plugins'
+import { InjectionSymbols } from '../constants'
+import { Logger } from '../logger'
+import { injectable, inject } from '../plugins'
 
 @injectable()
 export class InMemoryMessageRepository implements MessageRepository {
   private logger: Logger
   private messages: { [key: string]: EncryptedMessage[] } = {}
 
-  public constructor(agentConfig: AgentConfig) {
-    this.logger = agentConfig.logger
+  public constructor(@inject(InjectionSymbols.Logger) logger: Logger) {
+    this.logger = logger
   }
 
   public takeFromQueue(connectionId: string, limit?: number) {

--- a/packages/core/src/storage/IndyStorageService.ts
+++ b/packages/core/src/storage/IndyStorageService.ts
@@ -1,18 +1,20 @@
+import type { AgentContext } from '../agent'
+import type { IndyWallet } from '../wallet/IndyWallet'
 import type { BaseRecord, TagsBase } from './BaseRecord'
-import type { StorageService, BaseRecordConstructor, Query } from './StorageService'
+import type { BaseRecordConstructor, Query, StorageService } from './StorageService'
 import type { default as Indy, WalletQuery, WalletRecord, WalletSearchOptions } from 'indy-sdk'
 
-import { AgentConfig } from '../agent/AgentConfig'
-import { RecordNotFoundError, RecordDuplicateError, IndySdkError } from '../error'
-import { injectable } from '../plugins'
+import { AgentDependencies } from '../agent/AgentDependencies'
+import { InjectionSymbols } from '../constants'
+import { IndySdkError, RecordDuplicateError, RecordNotFoundError } from '../error'
+import { injectable, inject } from '../plugins'
 import { JsonTransformer } from '../utils/JsonTransformer'
 import { isIndyError } from '../utils/indyError'
 import { isBoolean } from '../utils/type'
-import { IndyWallet } from '../wallet/IndyWallet'
+import { assertIndyWallet } from '../wallet/util/assertIndyWallet'
 
 @injectable()
 export class IndyStorageService<T extends BaseRecord> implements StorageService<T> {
-  private wallet: IndyWallet
   private indy: typeof Indy
 
   private static DEFAULT_QUERY_OPTIONS = {
@@ -20,9 +22,8 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
     retrieveTags: true,
   }
 
-  public constructor(wallet: IndyWallet, agentConfig: AgentConfig) {
-    this.wallet = wallet
-    this.indy = agentConfig.agentDependencies.indy
+  public constructor(@inject(InjectionSymbols.AgentDependencies) agentDependencies: AgentDependencies) {
+    this.indy = agentDependencies.indy
   }
 
   private transformToRecordTagValues(tags: { [key: number]: string | undefined }): TagsBase {
@@ -133,12 +134,14 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
   }
 
   /** @inheritDoc */
-  public async save(record: T) {
+  public async save(agentContext: AgentContext, record: T) {
+    assertIndyWallet(agentContext.wallet)
+
     const value = JsonTransformer.serialize(record)
     const tags = this.transformFromRecordTagValues(record.getTags()) as Record<string, string>
 
     try {
-      await this.indy.addWalletRecord(this.wallet.handle, record.type, record.id, value, tags)
+      await this.indy.addWalletRecord(agentContext.wallet.handle, record.type, record.id, value, tags)
     } catch (error) {
       // Record already exists
       if (isIndyError(error, 'WalletItemAlreadyExists')) {
@@ -150,13 +153,15 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
   }
 
   /** @inheritDoc */
-  public async update(record: T): Promise<void> {
+  public async update(agentContext: AgentContext, record: T): Promise<void> {
+    assertIndyWallet(agentContext.wallet)
+
     const value = JsonTransformer.serialize(record)
     const tags = this.transformFromRecordTagValues(record.getTags()) as Record<string, string>
 
     try {
-      await this.indy.updateWalletRecordValue(this.wallet.handle, record.type, record.id, value)
-      await this.indy.updateWalletRecordTags(this.wallet.handle, record.type, record.id, tags)
+      await this.indy.updateWalletRecordValue(agentContext.wallet.handle, record.type, record.id, value)
+      await this.indy.updateWalletRecordTags(agentContext.wallet.handle, record.type, record.id, tags)
     } catch (error) {
       // Record does not exist
       if (isIndyError(error, 'WalletItemNotFound')) {
@@ -171,9 +176,11 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
   }
 
   /** @inheritDoc */
-  public async delete(record: T) {
+  public async delete(agentContext: AgentContext, record: T) {
+    assertIndyWallet(agentContext.wallet)
+
     try {
-      await this.indy.deleteWalletRecord(this.wallet.handle, record.type, record.id)
+      await this.indy.deleteWalletRecord(agentContext.wallet.handle, record.type, record.id)
     } catch (error) {
       // Record does not exist
       if (isIndyError(error, 'WalletItemNotFound')) {
@@ -188,10 +195,12 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
   }
 
   /** @inheritDoc */
-  public async getById(recordClass: BaseRecordConstructor<T>, id: string): Promise<T> {
+  public async getById(agentContext: AgentContext, recordClass: BaseRecordConstructor<T>, id: string): Promise<T> {
+    assertIndyWallet(agentContext.wallet)
+
     try {
       const record = await this.indy.getWalletRecord(
-        this.wallet.handle,
+        agentContext.wallet.handle,
         recordClass.type,
         id,
         IndyStorageService.DEFAULT_QUERY_OPTIONS
@@ -210,8 +219,15 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
   }
 
   /** @inheritDoc */
-  public async getAll(recordClass: BaseRecordConstructor<T>): Promise<T[]> {
-    const recordIterator = this.search(recordClass.type, {}, IndyStorageService.DEFAULT_QUERY_OPTIONS)
+  public async getAll(agentContext: AgentContext, recordClass: BaseRecordConstructor<T>): Promise<T[]> {
+    assertIndyWallet(agentContext.wallet)
+
+    const recordIterator = this.search(
+      agentContext.wallet,
+      recordClass.type,
+      {},
+      IndyStorageService.DEFAULT_QUERY_OPTIONS
+    )
     const records = []
     for await (const record of recordIterator) {
       records.push(this.recordToInstance(record, recordClass))
@@ -220,10 +236,21 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
   }
 
   /** @inheritDoc */
-  public async findByQuery(recordClass: BaseRecordConstructor<T>, query: Query<T>): Promise<T[]> {
+  public async findByQuery(
+    agentContext: AgentContext,
+    recordClass: BaseRecordConstructor<T>,
+    query: Query<T>
+  ): Promise<T[]> {
+    assertIndyWallet(agentContext.wallet)
+
     const indyQuery = this.indyQueryFromSearchQuery(query)
 
-    const recordIterator = this.search(recordClass.type, indyQuery, IndyStorageService.DEFAULT_QUERY_OPTIONS)
+    const recordIterator = this.search(
+      agentContext.wallet,
+      recordClass.type,
+      indyQuery,
+      IndyStorageService.DEFAULT_QUERY_OPTIONS
+    )
     const records = []
     for await (const record of recordIterator) {
       records.push(this.recordToInstance(record, recordClass))
@@ -232,12 +259,13 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
   }
 
   private async *search(
+    wallet: IndyWallet,
     type: string,
     query: WalletQuery,
     { limit = Infinity, ...options }: WalletSearchOptions & { limit?: number }
   ) {
     try {
-      const searchHandle = await this.indy.openWalletSearch(this.wallet.handle, type, query, options)
+      const searchHandle = await this.indy.openWalletSearch(wallet.handle, type, query, options)
 
       let records: Indy.WalletRecord[] = []
 
@@ -247,7 +275,7 @@ export class IndyStorageService<T extends BaseRecord> implements StorageService<
       // Loop while limit not reached (or no limit specified)
       while (!limit || records.length < limit) {
         // Retrieve records
-        const recordsJson = await this.indy.fetchWalletSearchNextRecords(this.wallet.handle, searchHandle, chunk)
+        const recordsJson = await this.indy.fetchWalletSearchNextRecords(wallet.handle, searchHandle, chunk)
 
         if (recordsJson.records) {
           records = [...records, ...recordsJson.records]

--- a/packages/core/src/storage/Repository.ts
+++ b/packages/core/src/storage/Repository.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../agent'
 import type { EventEmitter } from '../agent/EventEmitter'
 import type { BaseRecord } from './BaseRecord'
 import type { RecordSavedEvent, RecordUpdatedEvent, RecordDeletedEvent } from './RepositoryEvents'
@@ -24,9 +25,9 @@ export class Repository<T extends BaseRecord<any, any, any>> {
   }
 
   /** @inheritDoc {StorageService#save} */
-  public async save(record: T): Promise<void> {
-    await this.storageService.save(record)
-    this.eventEmitter.emit<RecordSavedEvent<T>>({
+  public async save(agentContext: AgentContext, record: T): Promise<void> {
+    await this.storageService.save(agentContext, record)
+    this.eventEmitter.emit<RecordSavedEvent<T>>(agentContext, {
       type: RepositoryEventTypes.RecordSaved,
       payload: {
         record,
@@ -35,9 +36,9 @@ export class Repository<T extends BaseRecord<any, any, any>> {
   }
 
   /** @inheritDoc {StorageService#update} */
-  public async update(record: T): Promise<void> {
-    await this.storageService.update(record)
-    this.eventEmitter.emit<RecordUpdatedEvent<T>>({
+  public async update(agentContext: AgentContext, record: T): Promise<void> {
+    await this.storageService.update(agentContext, record)
+    this.eventEmitter.emit<RecordUpdatedEvent<T>>(agentContext, {
       type: RepositoryEventTypes.RecordUpdated,
       payload: {
         record,
@@ -46,9 +47,9 @@ export class Repository<T extends BaseRecord<any, any, any>> {
   }
 
   /** @inheritDoc {StorageService#delete} */
-  public async delete(record: T): Promise<void> {
-    await this.storageService.delete(record)
-    this.eventEmitter.emit<RecordDeletedEvent<T>>({
+  public async delete(agentContext: AgentContext, record: T): Promise<void> {
+    await this.storageService.delete(agentContext, record)
+    this.eventEmitter.emit<RecordDeletedEvent<T>>(agentContext, {
       type: RepositoryEventTypes.RecordDeleted,
       payload: {
         record,
@@ -57,8 +58,8 @@ export class Repository<T extends BaseRecord<any, any, any>> {
   }
 
   /** @inheritDoc {StorageService#getById} */
-  public async getById(id: string): Promise<T> {
-    return this.storageService.getById(this.recordClass, id)
+  public async getById(agentContext: AgentContext, id: string): Promise<T> {
+    return this.storageService.getById(agentContext, this.recordClass, id)
   }
 
   /**
@@ -66,9 +67,9 @@ export class Repository<T extends BaseRecord<any, any, any>> {
    * @param id the id of the record to retrieve
    * @returns
    */
-  public async findById(id: string): Promise<T | null> {
+  public async findById(agentContext: AgentContext, id: string): Promise<T | null> {
     try {
-      return await this.storageService.getById(this.recordClass, id)
+      return await this.storageService.getById(agentContext, this.recordClass, id)
     } catch (error) {
       if (error instanceof RecordNotFoundError) return null
 
@@ -77,13 +78,13 @@ export class Repository<T extends BaseRecord<any, any, any>> {
   }
 
   /** @inheritDoc {StorageService#getAll} */
-  public async getAll(): Promise<T[]> {
-    return this.storageService.getAll(this.recordClass)
+  public async getAll(agentContext: AgentContext): Promise<T[]> {
+    return this.storageService.getAll(agentContext, this.recordClass)
   }
 
   /** @inheritDoc {StorageService#findByQuery} */
-  public async findByQuery(query: Query<T>): Promise<T[]> {
-    return this.storageService.findByQuery(this.recordClass, query)
+  public async findByQuery(agentContext: AgentContext, query: Query<T>): Promise<T[]> {
+    return this.storageService.findByQuery(agentContext, this.recordClass, query)
   }
 
   /**
@@ -92,8 +93,8 @@ export class Repository<T extends BaseRecord<any, any, any>> {
    * @returns the record, or null if not found
    * @throws {RecordDuplicateError} if multiple records are found for the given query
    */
-  public async findSingleByQuery(query: Query<T>): Promise<T | null> {
-    const records = await this.findByQuery(query)
+  public async findSingleByQuery(agentContext: AgentContext, query: Query<T>): Promise<T | null> {
+    const records = await this.findByQuery(agentContext, query)
 
     if (records.length > 1) {
       throw new RecordDuplicateError(`Multiple records found for given query '${JSON.stringify(query)}'`, {
@@ -115,8 +116,8 @@ export class Repository<T extends BaseRecord<any, any, any>> {
    * @throws {RecordDuplicateError} if multiple records are found for the given query
    * @throws {RecordNotFoundError} if no record is found for the given query
    */
-  public async getSingleByQuery(query: Query<T>): Promise<T> {
-    const record = await this.findSingleByQuery(query)
+  public async getSingleByQuery(agentContext: AgentContext, query: Query<T>): Promise<T> {
+    const record = await this.findSingleByQuery(agentContext, query)
 
     if (!record) {
       throw new RecordNotFoundError(`No record found for given query '${JSON.stringify(query)}'`, {

--- a/packages/core/src/storage/StorageService.ts
+++ b/packages/core/src/storage/StorageService.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../agent'
 import type { Constructor } from '../utils/mixins'
 import type { BaseRecord, TagsBase } from './BaseRecord'
 
@@ -24,7 +25,7 @@ export interface StorageService<T extends BaseRecord<any, any, any>> {
    * @param record the record to store
    * @throws {RecordDuplicateError} if a record with this id already exists
    */
-  save(record: T): Promise<void>
+  save(agentContext: AgentContext, record: T): Promise<void>
 
   /**
    * Update record in storage
@@ -32,7 +33,7 @@ export interface StorageService<T extends BaseRecord<any, any, any>> {
    * @param record the record to update
    * @throws {RecordNotFoundError} if a record with this id and type does not exist
    */
-  update(record: T): Promise<void>
+  update(agentContext: AgentContext, record: T): Promise<void>
 
   /**
    * Delete record from storage
@@ -40,7 +41,7 @@ export interface StorageService<T extends BaseRecord<any, any, any>> {
    * @param record the record to delete
    * @throws {RecordNotFoundError} if a record with this id and type does not exist
    */
-  delete(record: T): Promise<void>
+  delete(agentContext: AgentContext, record: T): Promise<void>
 
   /**
    * Get record by id.
@@ -49,14 +50,14 @@ export interface StorageService<T extends BaseRecord<any, any, any>> {
    * @param id the id of the record to retrieve from storage
    * @throws {RecordNotFoundError} if a record with this id and type does not exist
    */
-  getById(recordClass: BaseRecordConstructor<T>, id: string): Promise<T>
+  getById(agentContext: AgentContext, recordClass: BaseRecordConstructor<T>, id: string): Promise<T>
 
   /**
    * Get all records by specified record class.
    *
    * @param recordClass the record class to get records for
    */
-  getAll(recordClass: BaseRecordConstructor<T>): Promise<T[]>
+  getAll(agentContext: AgentContext, recordClass: BaseRecordConstructor<T>): Promise<T[]>
 
   /**
    * Find all records by specified record class and query.
@@ -64,5 +65,5 @@ export interface StorageService<T extends BaseRecord<any, any, any>> {
    * @param recordClass the record class to find records for
    * @param query the query to use for finding records
    */
-  findByQuery(recordClass: BaseRecordConstructor<T>, query: Query<T>): Promise<T[]>
+  findByQuery(agentContext: AgentContext, recordClass: BaseRecordConstructor<T>, query: Query<T>): Promise<T[]>
 }

--- a/packages/core/src/storage/__tests__/Repository.test.ts
+++ b/packages/core/src/storage/__tests__/Repository.test.ts
@@ -1,7 +1,10 @@
+import type { AgentContext } from '../../agent'
 import type { TagsBase } from '../BaseRecord'
 import type { RecordDeletedEvent, RecordSavedEvent, RecordUpdatedEvent } from '../RepositoryEvents'
 
-import { getAgentConfig, mockFunction } from '../../../tests/helpers'
+import { Subject } from 'rxjs'
+
+import { getAgentConfig, getAgentContext, mockFunction } from '../../../tests/helpers'
 import { EventEmitter } from '../../agent/EventEmitter'
 import { AriesFrameworkError, RecordDuplicateError, RecordNotFoundError } from '../../error'
 import { IndyStorageService } from '../IndyStorageService'
@@ -14,15 +17,19 @@ jest.mock('../IndyStorageService')
 
 const StorageMock = IndyStorageService as unknown as jest.Mock<IndyStorageService<TestRecord>>
 
+const config = getAgentConfig('Repository')
+
 describe('Repository', () => {
   let repository: Repository<TestRecord>
   let storageMock: IndyStorageService<TestRecord>
+  let agentContext: AgentContext
   let eventEmitter: EventEmitter
 
   beforeEach(async () => {
     storageMock = new StorageMock()
-    eventEmitter = new EventEmitter(getAgentConfig('RepositoryTest'))
+    eventEmitter = new EventEmitter(config.agentDependencies, new Subject())
     repository = new Repository(TestRecord, storageMock, eventEmitter)
+    agentContext = getAgentContext()
   })
 
   const getRecord = ({ id, tags }: { id?: string; tags?: TagsBase } = {}) => {
@@ -36,9 +43,9 @@ describe('Repository', () => {
   describe('save()', () => {
     it('should save the record using the storage service', async () => {
       const record = getRecord({ id: 'test-id' })
-      await repository.save(record)
+      await repository.save(agentContext, record)
 
-      expect(storageMock.save).toBeCalledWith(record)
+      expect(storageMock.save).toBeCalledWith(agentContext, record)
     })
 
     it(`should emit saved event`, async () => {
@@ -49,7 +56,7 @@ describe('Repository', () => {
       const record = getRecord({ id: 'test-id' })
 
       // when
-      await repository.save(record)
+      await repository.save(agentContext, record)
 
       // then
       expect(eventListenerMock).toHaveBeenCalledWith({
@@ -66,9 +73,9 @@ describe('Repository', () => {
   describe('update()', () => {
     it('should update the record using the storage service', async () => {
       const record = getRecord({ id: 'test-id' })
-      await repository.update(record)
+      await repository.update(agentContext, record)
 
-      expect(storageMock.update).toBeCalledWith(record)
+      expect(storageMock.update).toBeCalledWith(agentContext, record)
     })
 
     it(`should emit updated event`, async () => {
@@ -79,7 +86,7 @@ describe('Repository', () => {
       const record = getRecord({ id: 'test-id' })
 
       // when
-      await repository.update(record)
+      await repository.update(agentContext, record)
 
       // then
       expect(eventListenerMock).toHaveBeenCalledWith({
@@ -96,9 +103,9 @@ describe('Repository', () => {
   describe('delete()', () => {
     it('should delete the record using the storage service', async () => {
       const record = getRecord({ id: 'test-id' })
-      await repository.delete(record)
+      await repository.delete(agentContext, record)
 
-      expect(storageMock.delete).toBeCalledWith(record)
+      expect(storageMock.delete).toBeCalledWith(agentContext, record)
     })
 
     it(`should emit deleted event`, async () => {
@@ -109,7 +116,7 @@ describe('Repository', () => {
       const record = getRecord({ id: 'test-id' })
 
       // when
-      await repository.delete(record)
+      await repository.delete(agentContext, record)
 
       // then
       expect(eventListenerMock).toHaveBeenCalledWith({
@@ -128,9 +135,9 @@ describe('Repository', () => {
       const record = getRecord({ id: 'test-id' })
       mockFunction(storageMock.getById).mockReturnValue(Promise.resolve(record))
 
-      const returnValue = await repository.getById('test-id')
+      const returnValue = await repository.getById(agentContext, 'test-id')
 
-      expect(storageMock.getById).toBeCalledWith(TestRecord, 'test-id')
+      expect(storageMock.getById).toBeCalledWith(agentContext, TestRecord, 'test-id')
       expect(returnValue).toBe(record)
     })
   })
@@ -140,9 +147,9 @@ describe('Repository', () => {
       const record = getRecord({ id: 'test-id' })
       mockFunction(storageMock.getById).mockReturnValue(Promise.resolve(record))
 
-      const returnValue = await repository.findById('test-id')
+      const returnValue = await repository.findById(agentContext, 'test-id')
 
-      expect(storageMock.getById).toBeCalledWith(TestRecord, 'test-id')
+      expect(storageMock.getById).toBeCalledWith(agentContext, TestRecord, 'test-id')
       expect(returnValue).toBe(record)
     })
 
@@ -151,17 +158,17 @@ describe('Repository', () => {
         Promise.reject(new RecordNotFoundError('Not found', { recordType: TestRecord.type }))
       )
 
-      const returnValue = await repository.findById('test-id')
+      const returnValue = await repository.findById(agentContext, 'test-id')
 
-      expect(storageMock.getById).toBeCalledWith(TestRecord, 'test-id')
+      expect(storageMock.getById).toBeCalledWith(agentContext, TestRecord, 'test-id')
       expect(returnValue).toBeNull()
     })
 
     it('should return null if the storage service throws an error that is not RecordNotFoundError', async () => {
       mockFunction(storageMock.getById).mockReturnValue(Promise.reject(new AriesFrameworkError('Not found')))
 
-      expect(repository.findById('test-id')).rejects.toThrowError(AriesFrameworkError)
-      expect(storageMock.getById).toBeCalledWith(TestRecord, 'test-id')
+      expect(repository.findById(agentContext, 'test-id')).rejects.toThrowError(AriesFrameworkError)
+      expect(storageMock.getById).toBeCalledWith(agentContext, TestRecord, 'test-id')
     })
   })
 
@@ -171,9 +178,9 @@ describe('Repository', () => {
       const record2 = getRecord({ id: 'test-id2' })
       mockFunction(storageMock.getAll).mockReturnValue(Promise.resolve([record, record2]))
 
-      const returnValue = await repository.getAll()
+      const returnValue = await repository.getAll(agentContext)
 
-      expect(storageMock.getAll).toBeCalledWith(TestRecord)
+      expect(storageMock.getAll).toBeCalledWith(agentContext, TestRecord)
       expect(returnValue).toEqual(expect.arrayContaining([record, record2]))
     })
   })
@@ -184,9 +191,9 @@ describe('Repository', () => {
       const record2 = getRecord({ id: 'test-id2' })
       mockFunction(storageMock.findByQuery).mockReturnValue(Promise.resolve([record, record2]))
 
-      const returnValue = await repository.findByQuery({ something: 'interesting' })
+      const returnValue = await repository.findByQuery(agentContext, { something: 'interesting' })
 
-      expect(storageMock.findByQuery).toBeCalledWith(TestRecord, { something: 'interesting' })
+      expect(storageMock.findByQuery).toBeCalledWith(agentContext, TestRecord, { something: 'interesting' })
       expect(returnValue).toEqual(expect.arrayContaining([record, record2]))
     })
   })
@@ -196,18 +203,18 @@ describe('Repository', () => {
       const record = getRecord({ id: 'test-id' })
       mockFunction(storageMock.findByQuery).mockReturnValue(Promise.resolve([record]))
 
-      const returnValue = await repository.findSingleByQuery({ something: 'interesting' })
+      const returnValue = await repository.findSingleByQuery(agentContext, { something: 'interesting' })
 
-      expect(storageMock.findByQuery).toBeCalledWith(TestRecord, { something: 'interesting' })
+      expect(storageMock.findByQuery).toBeCalledWith(agentContext, TestRecord, { something: 'interesting' })
       expect(returnValue).toBe(record)
     })
 
     it('should return null if the no records are returned by the storage service', async () => {
       mockFunction(storageMock.findByQuery).mockReturnValue(Promise.resolve([]))
 
-      const returnValue = await repository.findSingleByQuery({ something: 'interesting' })
+      const returnValue = await repository.findSingleByQuery(agentContext, { something: 'interesting' })
 
-      expect(storageMock.findByQuery).toBeCalledWith(TestRecord, { something: 'interesting' })
+      expect(storageMock.findByQuery).toBeCalledWith(agentContext, TestRecord, { something: 'interesting' })
       expect(returnValue).toBeNull()
     })
 
@@ -216,8 +223,10 @@ describe('Repository', () => {
       const record2 = getRecord({ id: 'test-id2' })
       mockFunction(storageMock.findByQuery).mockReturnValue(Promise.resolve([record, record2]))
 
-      expect(repository.findSingleByQuery({ something: 'interesting' })).rejects.toThrowError(RecordDuplicateError)
-      expect(storageMock.findByQuery).toBeCalledWith(TestRecord, { something: 'interesting' })
+      expect(repository.findSingleByQuery(agentContext, { something: 'interesting' })).rejects.toThrowError(
+        RecordDuplicateError
+      )
+      expect(storageMock.findByQuery).toBeCalledWith(agentContext, TestRecord, { something: 'interesting' })
     })
   })
 
@@ -226,17 +235,19 @@ describe('Repository', () => {
       const record = getRecord({ id: 'test-id' })
       mockFunction(storageMock.findByQuery).mockReturnValue(Promise.resolve([record]))
 
-      const returnValue = await repository.getSingleByQuery({ something: 'interesting' })
+      const returnValue = await repository.getSingleByQuery(agentContext, { something: 'interesting' })
 
-      expect(storageMock.findByQuery).toBeCalledWith(TestRecord, { something: 'interesting' })
+      expect(storageMock.findByQuery).toBeCalledWith(agentContext, TestRecord, { something: 'interesting' })
       expect(returnValue).toBe(record)
     })
 
     it('should throw RecordNotFoundError if no records are returned by the storage service', async () => {
       mockFunction(storageMock.findByQuery).mockReturnValue(Promise.resolve([]))
 
-      expect(repository.getSingleByQuery({ something: 'interesting' })).rejects.toThrowError(RecordNotFoundError)
-      expect(storageMock.findByQuery).toBeCalledWith(TestRecord, { something: 'interesting' })
+      expect(repository.getSingleByQuery(agentContext, { something: 'interesting' })).rejects.toThrowError(
+        RecordNotFoundError
+      )
+      expect(storageMock.findByQuery).toBeCalledWith(agentContext, TestRecord, { something: 'interesting' })
     })
 
     it('should throw RecordDuplicateError if more than one record is returned by the storage service', async () => {
@@ -244,8 +255,10 @@ describe('Repository', () => {
       const record2 = getRecord({ id: 'test-id2' })
       mockFunction(storageMock.findByQuery).mockReturnValue(Promise.resolve([record, record2]))
 
-      expect(repository.getSingleByQuery({ something: 'interesting' })).rejects.toThrowError(RecordDuplicateError)
-      expect(storageMock.findByQuery).toBeCalledWith(TestRecord, { something: 'interesting' })
+      expect(repository.getSingleByQuery(agentContext, { something: 'interesting' })).rejects.toThrowError(
+        RecordDuplicateError
+      )
+      expect(storageMock.findByQuery).toBeCalledWith(agentContext, TestRecord, { something: 'interesting' })
     })
   })
 })

--- a/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
+++ b/packages/core/src/storage/didcomm/DidCommMessageRepository.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../../agent'
 import type { AgentMessage, ConstructableAgentMessage } from '../../agent/AgentMessage'
 import type { JsonObject } from '../../types'
 import type { DidCommMessageRole } from './DidCommMessageRole'
@@ -20,20 +21,23 @@ export class DidCommMessageRepository extends Repository<DidCommMessageRecord> {
     super(DidCommMessageRecord, storageService, eventEmitter)
   }
 
-  public async saveAgentMessage({ role, agentMessage, associatedRecordId }: SaveAgentMessageOptions) {
+  public async saveAgentMessage(
+    agentContext: AgentContext,
+    { role, agentMessage, associatedRecordId }: SaveAgentMessageOptions
+  ) {
     const didCommMessageRecord = new DidCommMessageRecord({
       message: agentMessage.toJSON() as JsonObject,
       role,
       associatedRecordId,
     })
 
-    await this.save(didCommMessageRecord)
+    await this.save(agentContext, didCommMessageRecord)
   }
 
-  public async saveOrUpdateAgentMessage(options: SaveAgentMessageOptions) {
+  public async saveOrUpdateAgentMessage(agentContext: AgentContext, options: SaveAgentMessageOptions) {
     const { messageName, protocolName, protocolMajorVersion } = parseMessageType(options.agentMessage.type)
 
-    const record = await this.findSingleByQuery({
+    const record = await this.findSingleByQuery(agentContext, {
       associatedRecordId: options.associatedRecordId,
       messageName: messageName,
       protocolName: protocolName,
@@ -43,18 +47,18 @@ export class DidCommMessageRepository extends Repository<DidCommMessageRecord> {
     if (record) {
       record.message = options.agentMessage.toJSON() as JsonObject
       record.role = options.role
-      await this.update(record)
+      await this.update(agentContext, record)
       return
     }
 
-    await this.saveAgentMessage(options)
+    await this.saveAgentMessage(agentContext, options)
   }
 
-  public async getAgentMessage<MessageClass extends ConstructableAgentMessage = ConstructableAgentMessage>({
-    associatedRecordId,
-    messageClass,
-  }: GetAgentMessageOptions<MessageClass>): Promise<InstanceType<MessageClass>> {
-    const record = await this.getSingleByQuery({
+  public async getAgentMessage<MessageClass extends ConstructableAgentMessage = ConstructableAgentMessage>(
+    agentContext: AgentContext,
+    { associatedRecordId, messageClass }: GetAgentMessageOptions<MessageClass>
+  ): Promise<InstanceType<MessageClass>> {
+    const record = await this.getSingleByQuery(agentContext, {
       associatedRecordId,
       messageName: messageClass.type.messageName,
       protocolName: messageClass.type.protocolName,
@@ -63,11 +67,11 @@ export class DidCommMessageRepository extends Repository<DidCommMessageRecord> {
 
     return record.getMessageInstance(messageClass)
   }
-  public async findAgentMessage<MessageClass extends ConstructableAgentMessage = ConstructableAgentMessage>({
-    associatedRecordId,
-    messageClass,
-  }: GetAgentMessageOptions<MessageClass>): Promise<InstanceType<MessageClass> | null> {
-    const record = await this.findSingleByQuery({
+  public async findAgentMessage<MessageClass extends ConstructableAgentMessage = ConstructableAgentMessage>(
+    agentContext: AgentContext,
+    { associatedRecordId, messageClass }: GetAgentMessageOptions<MessageClass>
+  ): Promise<InstanceType<MessageClass> | null> {
+    const record = await this.findSingleByQuery(agentContext, {
       associatedRecordId,
       messageName: messageClass.type.messageName,
       protocolName: messageClass.type.protocolName,

--- a/packages/core/src/storage/migration/StorageUpdateService.ts
+++ b/packages/core/src/storage/migration/StorageUpdateService.ts
@@ -1,8 +1,9 @@
-import type { Logger } from '../../logger'
+import type { AgentContext } from '../../agent'
 import type { VersionString } from '../../utils/version'
 
-import { AgentConfig } from '../../agent/AgentConfig'
-import { injectable } from '../../plugins'
+import { InjectionSymbols } from '../../constants'
+import { Logger } from '../../logger'
+import { injectable, inject } from '../../plugins'
 
 import { StorageVersionRecord } from './repository/StorageVersionRecord'
 import { StorageVersionRepository } from './repository/StorageVersionRepository'
@@ -15,34 +16,39 @@ export class StorageUpdateService {
   private logger: Logger
   private storageVersionRepository: StorageVersionRepository
 
-  public constructor(agentConfig: AgentConfig, storageVersionRepository: StorageVersionRepository) {
+  public constructor(
+    @inject(InjectionSymbols.Logger) logger: Logger,
+    storageVersionRepository: StorageVersionRepository
+  ) {
+    this.logger = logger
     this.storageVersionRepository = storageVersionRepository
-    this.logger = agentConfig.logger
   }
 
-  public async isUpToDate() {
-    const currentStorageVersion = await this.getCurrentStorageVersion()
+  public async isUpToDate(agentContext: AgentContext) {
+    const currentStorageVersion = await this.getCurrentStorageVersion(agentContext)
 
     const isUpToDate = CURRENT_FRAMEWORK_STORAGE_VERSION === currentStorageVersion
 
     return isUpToDate
   }
 
-  public async getCurrentStorageVersion(): Promise<VersionString> {
-    const storageVersionRecord = await this.getStorageVersionRecord()
+  public async getCurrentStorageVersion(agentContext: AgentContext): Promise<VersionString> {
+    const storageVersionRecord = await this.getStorageVersionRecord(agentContext)
 
     return storageVersionRecord.storageVersion
   }
 
-  public async setCurrentStorageVersion(storageVersion: VersionString) {
+  public async setCurrentStorageVersion(agentContext: AgentContext, storageVersion: VersionString) {
     this.logger.debug(`Setting current agent storage version to ${storageVersion}`)
     const storageVersionRecord = await this.storageVersionRepository.findById(
+      agentContext,
       StorageUpdateService.STORAGE_VERSION_RECORD_ID
     )
 
     if (!storageVersionRecord) {
       this.logger.trace('Storage upgrade record does not exist yet. Creating.')
       await this.storageVersionRepository.save(
+        agentContext,
         new StorageVersionRecord({
           id: StorageUpdateService.STORAGE_VERSION_RECORD_ID,
           storageVersion,
@@ -51,7 +57,7 @@ export class StorageUpdateService {
     } else {
       this.logger.trace('Storage upgrade record already exists. Updating.')
       storageVersionRecord.storageVersion = storageVersion
-      await this.storageVersionRepository.update(storageVersionRecord)
+      await this.storageVersionRepository.update(agentContext, storageVersionRecord)
     }
   }
 
@@ -61,8 +67,9 @@ export class StorageUpdateService {
    * The storageVersion will be set to the INITIAL_STORAGE_VERSION if it doesn't exist yet,
    * as we can assume the wallet was created before the udpate record existed
    */
-  public async getStorageVersionRecord() {
+  public async getStorageVersionRecord(agentContext: AgentContext) {
     let storageVersionRecord = await this.storageVersionRepository.findById(
+      agentContext,
       StorageUpdateService.STORAGE_VERSION_RECORD_ID
     )
 
@@ -71,7 +78,7 @@ export class StorageUpdateService {
         id: StorageUpdateService.STORAGE_VERSION_RECORD_ID,
         storageVersion: INITIAL_STORAGE_VERSION,
       })
-      await this.storageVersionRepository.save(storageVersionRecord)
+      await this.storageVersionRepository.save(agentContext, storageVersionRecord)
     }
 
     return storageVersionRecord

--- a/packages/core/src/storage/migration/__tests__/0.1.test.ts
+++ b/packages/core/src/storage/migration/__tests__/0.1.test.ts
@@ -1,3 +1,4 @@
+import type { FileSystem } from '../../../../src'
 import type { V0_1ToV0_2UpdateConfig } from '../updates/0.1-0.2'
 
 import { unlinkSync, readFileSync } from 'fs'
@@ -48,6 +49,8 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
         container
       )
 
+      const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+
       const updateAssistant = new UpdateAssistant(agent, {
         v0_1ToV0_2: {
           mediationRoleUpdateStrategy,
@@ -75,7 +78,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
       expect(storageService.records).toMatchSnapshot(mediationRoleUpdateStrategy)
 
       // Need to remove backupFiles after each run so we don't get IOErrors
-      const backupPath = `${agent.config.fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
+      const backupPath = `${fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
       unlinkSync(backupPath)
 
       await agent.shutdown()
@@ -107,6 +110,8 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
       container
     )
 
+    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+
     const updateAssistant = new UpdateAssistant(agent, {
       v0_1ToV0_2: {
         mediationRoleUpdateStrategy: 'doNotChange',
@@ -135,7 +140,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
     expect(storageService.records).toMatchSnapshot()
 
     // Need to remove backupFiles after each run so we don't get IOErrors
-    const backupPath = `${agent.config.fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
+    const backupPath = `${fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
     unlinkSync(backupPath)
 
     await agent.shutdown()
@@ -169,6 +174,8 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
       container
     )
 
+    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+
     // We need to manually initialize the wallet as we're using the in memory wallet service
     // When we call agent.initialize() it will create the wallet and store the current framework
     // version in the in memory storage service. We need to manually set the records between initializing
@@ -184,7 +191,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
     expect(storageService.records).toMatchSnapshot()
 
     // Need to remove backupFiles after each run so we don't get IOErrors
-    const backupPath = `${agent.config.fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
+    const backupPath = `${fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
     unlinkSync(backupPath)
 
     await agent.shutdown()
@@ -218,6 +225,8 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
       container
     )
 
+    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+
     // We need to manually initialize the wallet as we're using the in memory wallet service
     // When we call agent.initialize() it will create the wallet and store the current framework
     // version in the in memory storage service. We need to manually set the records between initializing
@@ -233,7 +242,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
     expect(storageService.records).toMatchSnapshot()
 
     // Need to remove backupFiles after each run so we don't get IOErrors
-    const backupPath = `${agent.config.fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
+    const backupPath = `${fileSystem.basePath}/afj/migration/backup/${backupIdentifier}`
     unlinkSync(backupPath)
 
     await agent.shutdown()

--- a/packages/core/src/storage/migration/updates/0.1-0.2/__tests__/credential.test.ts
+++ b/packages/core/src/storage/migration/updates/0.1-0.2/__tests__/credential.test.ts
@@ -1,7 +1,7 @@
 import type { CredentialRecordBinding } from '../../../../../../src/modules/credentials'
 
 import { CredentialExchangeRecord, CredentialState } from '../../../../../../src/modules/credentials'
-import { getAgentConfig, mockFunction } from '../../../../../../tests/helpers'
+import { getAgentConfig, getAgentContext, mockFunction } from '../../../../../../tests/helpers'
 import { Agent } from '../../../../../agent/Agent'
 import { CredentialRepository } from '../../../../../modules/credentials/repository/CredentialRepository'
 import { JsonTransformer } from '../../../../../utils'
@@ -10,6 +10,7 @@ import { DidCommMessageRepository } from '../../../../didcomm/DidCommMessageRepo
 import * as testModule from '../credential'
 
 const agentConfig = getAgentConfig('Migration CredentialRecord 0.1-0.2')
+const agentContext = getAgentContext()
 
 jest.mock('../../../../../modules/credentials/repository/CredentialRepository')
 const CredentialRepositoryMock = CredentialRepository as jest.Mock<CredentialRepository>
@@ -23,6 +24,7 @@ jest.mock('../../../../../agent/Agent', () => {
   return {
     Agent: jest.fn(() => ({
       config: agentConfig,
+      context: agentContext,
       dependencyManager: {
         resolve: jest.fn((token) =>
           token === CredentialRepositoryMock ? credentialRepository : didCommMessageRepository
@@ -75,7 +77,7 @@ describe('0.1-0.2 | Credential', () => {
       expect(credentialRepository.getAll).toHaveBeenCalledTimes(1)
       expect(credentialRepository.update).toHaveBeenCalledTimes(records.length)
 
-      const updatedRecord = mockFunction(credentialRepository.update).mock.calls[0][0]
+      const updatedRecord = mockFunction(credentialRepository.update).mock.calls[0][1]
 
       // Check first object is transformed correctly
       expect(updatedRecord.toJSON()).toMatchObject({
@@ -277,7 +279,7 @@ describe('0.1-0.2 | Credential', () => {
       await testModule.moveDidCommMessages(agent, credentialRecord)
 
       expect(didCommMessageRepository.save).toHaveBeenCalledTimes(4)
-      const [[proposalMessageRecord], [offerMessageRecord], [requestMessageRecord], [credentialMessageRecord]] =
+      const [[, proposalMessageRecord], [, offerMessageRecord], [, requestMessageRecord], [, credentialMessageRecord]] =
         mockFunction(didCommMessageRepository.save).mock.calls
 
       expect(proposalMessageRecord).toMatchObject({
@@ -340,7 +342,7 @@ describe('0.1-0.2 | Credential', () => {
       await testModule.moveDidCommMessages(agent, credentialRecord)
 
       expect(didCommMessageRepository.save).toHaveBeenCalledTimes(2)
-      const [[proposalMessageRecord], [offerMessageRecord]] = mockFunction(didCommMessageRepository.save).mock.calls
+      const [[, proposalMessageRecord], [, offerMessageRecord]] = mockFunction(didCommMessageRepository.save).mock.calls
 
       expect(proposalMessageRecord).toMatchObject({
         role: DidCommMessageRole.Sender,
@@ -388,7 +390,7 @@ describe('0.1-0.2 | Credential', () => {
       await testModule.moveDidCommMessages(agent, credentialRecord)
 
       expect(didCommMessageRepository.save).toHaveBeenCalledTimes(4)
-      const [[proposalMessageRecord], [offerMessageRecord], [requestMessageRecord], [credentialMessageRecord]] =
+      const [[, proposalMessageRecord], [, offerMessageRecord], [, requestMessageRecord], [, credentialMessageRecord]] =
         mockFunction(didCommMessageRepository.save).mock.calls
 
       expect(proposalMessageRecord).toMatchObject({

--- a/packages/core/src/storage/migration/updates/0.1-0.2/__tests__/mediation.test.ts
+++ b/packages/core/src/storage/migration/updates/0.1-0.2/__tests__/mediation.test.ts
@@ -1,4 +1,4 @@
-import { getAgentConfig, mockFunction } from '../../../../../../tests/helpers'
+import { getAgentConfig, getAgentContext, mockFunction } from '../../../../../../tests/helpers'
 import { Agent } from '../../../../../agent/Agent'
 import { MediationRole, MediationRecord } from '../../../../../modules/routing'
 import { MediationRepository } from '../../../../../modules/routing/repository/MediationRepository'
@@ -6,6 +6,7 @@ import { JsonTransformer } from '../../../../../utils'
 import * as testModule from '../mediation'
 
 const agentConfig = getAgentConfig('Migration MediationRecord 0.1-0.2')
+const agentContext = getAgentContext()
 
 jest.mock('../../../../../modules/routing/repository/MediationRepository')
 const MediationRepositoryMock = MediationRepository as jest.Mock<MediationRepository>
@@ -15,6 +16,7 @@ jest.mock('../../../../../agent/Agent', () => {
   return {
     Agent: jest.fn(() => ({
       config: agentConfig,
+      context: agentContext,
       dependencyManager: {
         resolve: jest.fn(() => mediationRepository),
       },
@@ -57,6 +59,7 @@ describe('0.1-0.2 | Mediation', () => {
       // Check second object is transformed correctly
       expect(mediationRepository.update).toHaveBeenNthCalledWith(
         2,
+        agentContext,
         getMediationRecord({
           role: MediationRole.Mediator,
           endpoint: 'secondEndpoint',

--- a/packages/core/src/storage/migration/updates/0.1-0.2/connection.ts
+++ b/packages/core/src/storage/migration/updates/0.1-0.2/connection.ts
@@ -36,7 +36,7 @@ export async function migrateConnectionRecordToV0_2(agent: Agent) {
   const connectionRepository = agent.dependencyManager.resolve(ConnectionRepository)
 
   agent.config.logger.debug(`Fetching all connection records from storage`)
-  const allConnections = await connectionRepository.getAll()
+  const allConnections = await connectionRepository.getAll(agent.context)
 
   agent.config.logger.debug(`Found a total of ${allConnections.length} connection records to update.`)
   for (const connectionRecord of allConnections) {
@@ -53,7 +53,7 @@ export async function migrateConnectionRecordToV0_2(agent: Agent) {
     // migrateToOobRecord will return the connection record if it has not been deleted. When using multiUseInvitation the connection record
     // will be removed after processing, in which case the update method will throw an error.
     if (_connectionRecord) {
-      await connectionRepository.update(connectionRecord)
+      await connectionRepository.update(agent.context, connectionRecord)
     }
 
     agent.config.logger.debug(
@@ -161,7 +161,7 @@ export async function extractDidDocument(agent: Agent, connectionRecord: Connect
     const newDidDocument = convertToNewDidDocument(oldDidDoc)
 
     // Maybe we already have a record for this did because the migration failed previously
-    let didRecord = await didRepository.findById(newDidDocument.id)
+    let didRecord = await didRepository.findById(agent.context, newDidDocument.id)
 
     if (!didRecord) {
       agent.config.logger.debug(`Creating did record for did ${newDidDocument.id}`)
@@ -180,7 +180,7 @@ export async function extractDidDocument(agent: Agent, connectionRecord: Connect
         didDocumentString: JsonEncoder.toString(oldDidDocJson),
       })
 
-      await didRepository.save(didRecord)
+      await didRepository.save(agent.context, didRecord)
 
       agent.config.logger.debug(`Successfully saved did record for did ${newDidDocument.id}`)
     } else {
@@ -207,7 +207,7 @@ export async function extractDidDocument(agent: Agent, connectionRecord: Connect
     const newTheirDidDocument = convertToNewDidDocument(oldTheirDidDoc)
 
     // Maybe we already have a record for this did because the migration failed previously
-    let didRecord = await didRepository.findById(newTheirDidDocument.id)
+    let didRecord = await didRepository.findById(agent.context, newTheirDidDocument.id)
 
     if (!didRecord) {
       agent.config.logger.debug(`Creating did record for theirDid ${newTheirDidDocument.id}`)
@@ -227,7 +227,7 @@ export async function extractDidDocument(agent: Agent, connectionRecord: Connect
         didDocumentString: JsonEncoder.toString(oldTheirDidDocJson),
       })
 
-      await didRepository.save(didRecord)
+      await didRepository.save(agent.context, didRecord)
 
       agent.config.logger.debug(`Successfully saved did record for theirDid ${newTheirDidDocument.id}`)
     } else {
@@ -310,7 +310,7 @@ export async function migrateToOobRecord(
     const outOfBandInvitation = convertToNewInvitation(oldInvitation)
 
     // If both the recipientKeys and the @id match we assume the connection was created using the same invitation.
-    const oobRecords = await oobRepository.findByQuery({
+    const oobRecords = await oobRepository.findByQuery(agent.context, {
       invitationId: oldInvitation.id,
       recipientKeyFingerprints: outOfBandInvitation.getRecipientKeys().map((key) => key.fingerprint),
     })
@@ -337,7 +337,7 @@ export async function migrateToOobRecord(
         createdAt: connectionRecord.createdAt,
       })
 
-      await oobRepository.save(oobRecord)
+      await oobRepository.save(agent.context, oobRecord)
       agent.config.logger.debug(`Successfully saved out of band record for invitation @id ${oldInvitation.id}`)
     } else {
       agent.config.logger.debug(
@@ -353,8 +353,8 @@ export async function migrateToOobRecord(
       oobRecord.mediatorId = connectionRecord.mediatorId
       oobRecord.autoAcceptConnection = connectionRecord.autoAcceptConnection
 
-      await oobRepository.update(oobRecord)
-      await connectionRepository.delete(connectionRecord)
+      await oobRepository.update(agent.context, oobRecord)
+      await connectionRepository.delete(agent.context, connectionRecord)
       agent.config.logger.debug(
         `Set reusable=true for out of band record with invitation @id ${oobRecord.outOfBandInvitation.id}.`
       )

--- a/packages/core/src/storage/migration/updates/0.1-0.2/credential.ts
+++ b/packages/core/src/storage/migration/updates/0.1-0.2/credential.ts
@@ -21,7 +21,7 @@ export async function migrateCredentialRecordToV0_2(agent: Agent) {
   const credentialRepository = agent.dependencyManager.resolve(CredentialRepository)
 
   agent.config.logger.debug(`Fetching all credential records from storage`)
-  const allCredentials = await credentialRepository.getAll()
+  const allCredentials = await credentialRepository.getAll(agent.context)
 
   agent.config.logger.debug(`Found a total of ${allCredentials.length} credential records to update.`)
   for (const credentialRecord of allCredentials) {
@@ -31,7 +31,7 @@ export async function migrateCredentialRecordToV0_2(agent: Agent) {
     await migrateInternalCredentialRecordProperties(agent, credentialRecord)
     await moveDidCommMessages(agent, credentialRecord)
 
-    await credentialRepository.update(credentialRecord)
+    await credentialRepository.update(agent.context, credentialRecord)
 
     agent.config.logger.debug(
       `Successfully migrated credential record with id ${credentialRecord.id} to storage version 0.2`
@@ -232,7 +232,7 @@ export async function moveDidCommMessages(agent: Agent, credentialRecord: Creden
         associatedRecordId: credentialRecord.id,
         message,
       })
-      await didCommMessageRepository.save(didCommMessageRecord)
+      await didCommMessageRepository.save(agent.context, didCommMessageRecord)
 
       agent.config.logger.debug(
         `Successfully moved ${messageKey} from credential record with id ${credentialRecord.id} to DIDCommMessageRecord`

--- a/packages/core/src/storage/migration/updates/0.1-0.2/mediation.ts
+++ b/packages/core/src/storage/migration/updates/0.1-0.2/mediation.ts
@@ -1,6 +1,6 @@
-import type { V0_1ToV0_2UpdateConfig } from '.'
 import type { Agent } from '../../../../agent/Agent'
 import type { MediationRecord } from '../../../../modules/routing'
+import type { V0_1ToV0_2UpdateConfig } from './index'
 
 import { MediationRepository, MediationRole } from '../../../../modules/routing'
 
@@ -17,7 +17,7 @@ export async function migrateMediationRecordToV0_2(agent: Agent, upgradeConfig: 
   const mediationRepository = agent.dependencyManager.resolve(MediationRepository)
 
   agent.config.logger.debug(`Fetching all mediation records from storage`)
-  const allMediationRecords = await mediationRepository.getAll()
+  const allMediationRecords = await mediationRepository.getAll(agent.context)
 
   agent.config.logger.debug(`Found a total of ${allMediationRecords.length} mediation records to update.`)
   for (const mediationRecord of allMediationRecords) {
@@ -25,7 +25,7 @@ export async function migrateMediationRecordToV0_2(agent: Agent, upgradeConfig: 
 
     await updateMediationRole(agent, mediationRecord, upgradeConfig)
 
-    await mediationRepository.update(mediationRecord)
+    await mediationRepository.update(agent.context, mediationRecord)
 
     agent.config.logger.debug(
       `Successfully migrated mediation record with id ${mediationRecord.id} to storage version 0.2`

--- a/packages/core/src/transport/HttpOutboundTransport.ts
+++ b/packages/core/src/transport/HttpOutboundTransport.ts
@@ -6,23 +6,20 @@ import type fetch from 'node-fetch'
 
 import { AbortController } from 'abort-controller'
 
-import { AgentConfig } from '../agent/AgentConfig'
 import { AriesFrameworkError } from '../error/AriesFrameworkError'
 import { isValidJweStructure, JsonEncoder } from '../utils'
 
 export class HttpOutboundTransport implements OutboundTransport {
   private agent!: Agent
   private logger!: Logger
-  private agentConfig!: AgentConfig
   private fetch!: typeof fetch
 
   public supportedSchemes = ['http', 'https']
 
   public async start(agent: Agent): Promise<void> {
     this.agent = agent
-    this.agentConfig = agent.dependencyManager.resolve(AgentConfig)
-    this.logger = this.agentConfig.logger
-    this.fetch = this.agentConfig.agentDependencies.fetch
+    this.logger = this.agent.config.logger
+    this.fetch = this.agent.config.agentDependencies.fetch
 
     this.logger.debug('Starting HTTP outbound transport')
   }
@@ -53,7 +50,7 @@ export class HttpOutboundTransport implements OutboundTransport {
         response = await this.fetch(endpoint, {
           method: 'POST',
           body: JSON.stringify(payload),
-          headers: { 'Content-Type': this.agentConfig.didCommMimeType },
+          headers: { 'Content-Type': this.agent.config.didCommMimeType },
           signal: abortController.signal,
         })
         clearTimeout(id)
@@ -96,7 +93,7 @@ export class HttpOutboundTransport implements OutboundTransport {
         error,
         message: error.message,
         body: payload,
-        didCommMimeType: this.agentConfig.didCommMimeType,
+        didCommMimeType: this.agent.config.didCommMimeType,
       })
       throw new AriesFrameworkError(`Error sending message to ${endpoint}: ${error.message}`, { cause: error })
     }

--- a/packages/core/src/wallet/IndyWallet.ts
+++ b/packages/core/src/wallet/IndyWallet.ts
@@ -1,5 +1,4 @@
 import type { BlsKeyPair } from '../crypto/BbsService'
-import type { Logger } from '../logger'
 import type {
   EncryptedMessage,
   KeyDerivationMethod,
@@ -19,12 +18,14 @@ import type {
 } from './Wallet'
 import type { default as Indy, WalletStorageConfig } from 'indy-sdk'
 
-import { AgentConfig } from '../agent/AgentConfig'
+import { AgentDependencies } from '../agent/AgentDependencies'
+import { InjectionSymbols } from '../constants'
 import { BbsService } from '../crypto/BbsService'
 import { Key } from '../crypto/Key'
 import { KeyType } from '../crypto/KeyType'
 import { AriesFrameworkError, IndySdkError, RecordDuplicateError, RecordNotFoundError } from '../error'
-import { injectable } from '../plugins'
+import { Logger } from '../logger'
+import { inject, injectable } from '../plugins'
 import { JsonEncoder, TypedArrayEncoder } from '../utils'
 import { isError } from '../utils/error'
 import { isIndyError } from '../utils/indyError'
@@ -41,9 +42,12 @@ export class IndyWallet implements Wallet {
   private publicDidInfo: DidInfo | undefined
   private indy: typeof Indy
 
-  public constructor(agentConfig: AgentConfig) {
-    this.logger = agentConfig.logger
-    this.indy = agentConfig.agentDependencies.indy
+  public constructor(
+    @inject(InjectionSymbols.AgentDependencies) agentDependencies: AgentDependencies,
+    @inject(InjectionSymbols.Logger) logger: Logger
+  ) {
+    this.logger = logger
+    this.indy = agentDependencies.indy
   }
 
   public get isProvisioned() {

--- a/packages/core/src/wallet/util/assertIndyWallet.ts
+++ b/packages/core/src/wallet/util/assertIndyWallet.ts
@@ -1,0 +1,10 @@
+import type { Wallet } from '../Wallet'
+
+import { AriesFrameworkError } from '../../error'
+import { IndyWallet } from '../IndyWallet'
+
+export function assertIndyWallet(wallet: Wallet): asserts wallet is IndyWallet {
+  if (!(wallet instanceof IndyWallet)) {
+    throw new AriesFrameworkError(`Expected wallet to be instance of IndyWallet, found ${wallet}`)
+  }
+}

--- a/packages/core/tests/connectionless-proofs.test.ts
+++ b/packages/core/tests/connectionless-proofs.test.ts
@@ -5,6 +5,7 @@ import { Subject, ReplaySubject } from 'rxjs'
 
 import { SubjectInboundTransport } from '../../../tests/transport/SubjectInboundTransport'
 import { SubjectOutboundTransport } from '../../../tests/transport/SubjectOutboundTransport'
+import { InjectionSymbols } from '../src'
 import { Agent } from '../src/agent/Agent'
 import { Attachment, AttachmentData } from '../src/decorators/attachment/Attachment'
 import { HandshakeProtocol } from '../src/modules/connections'
@@ -345,8 +346,10 @@ describe('Present Proof', () => {
     // We want to stop the mediator polling before the agent is shutdown.
     // FIXME: add a way to stop mediator polling from the public api, and make sure this is
     // being handled in the agent shutdown so we don't get any errors with wallets being closed.
-    faberAgent.config.stop$.next(true)
-    aliceAgent.config.stop$.next(true)
+    const faberStop$ = faberAgent.injectionContainer.resolve<Subject<boolean>>(InjectionSymbols.Stop$)
+    const aliceStop$ = aliceAgent.injectionContainer.resolve<Subject<boolean>>(InjectionSymbols.Stop$)
+    faberStop$.next(true)
+    aliceStop$.next(true)
     await sleep(2000)
   })
 })

--- a/packages/core/tests/helpers.ts
+++ b/packages/core/tests/helpers.ts
@@ -12,6 +12,7 @@ import type {
   ProofPredicateInfo,
   ProofStateChangedEvent,
   SchemaTemplate,
+  Wallet,
 } from '../src'
 import type { AcceptOfferOptions } from '../src/modules/credentials'
 import type { IndyOfferCredentialFormat } from '../src/modules/credentials/formats/indy/IndyCredentialFormat'
@@ -28,14 +29,17 @@ import { agentDependencies, WalletScheme } from '../../node/src'
 import {
   Agent,
   AgentConfig,
+  AgentContext,
   AriesFrameworkError,
   BasicMessageEventTypes,
   ConnectionRecord,
   CredentialEventTypes,
   CredentialState,
+  DependencyManager,
   DidExchangeRole,
   DidExchangeState,
   HandshakeProtocol,
+  InjectionSymbols,
   LogLevel,
   PredicateType,
   PresentationPreview,
@@ -132,6 +136,20 @@ export function getBasePostgresConfig(name: string, extraConfig: Partial<InitCon
 export function getAgentConfig(name: string, extraConfig: Partial<InitConfig> = {}) {
   const { config, agentDependencies } = getBaseConfig(name, extraConfig)
   return new AgentConfig(config, agentDependencies)
+}
+
+export function getAgentContext({
+  dependencyManager = new DependencyManager(),
+  wallet,
+  agentConfig,
+}: {
+  dependencyManager?: DependencyManager
+  wallet?: Wallet
+  agentConfig?: AgentConfig
+} = {}) {
+  if (wallet) dependencyManager.registerInstance(InjectionSymbols.Wallet, wallet)
+  if (agentConfig) dependencyManager.registerInstance(AgentConfig, agentConfig)
+  return new AgentContext({ dependencyManager })
 }
 
 export async function waitForProofRecord(

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -4,7 +4,6 @@ import * as indy from 'indy-sdk'
 import { Agent } from '../src/agent/Agent'
 import { DID_IDENTIFIER_REGEX, isAbbreviatedVerkey, isFullVerkey, VERKEY_REGEX } from '../src/utils/did'
 import { sleep } from '../src/utils/sleep'
-import { IndyWallet } from '../src/wallet/IndyWallet'
 
 import { genesisPath, getBaseConfig } from './helpers'
 import testLogger from './logger'
@@ -65,7 +64,7 @@ describe('ledger', () => {
       throw new Error('Agent does not have public did.')
     }
 
-    const faberWallet = faberAgent.dependencyManager.resolve(IndyWallet)
+    const faberWallet = faberAgent.context.wallet
     const didInfo = await faberWallet.createDid()
 
     const result = await faberAgent.ledger.registerPublicDid(didInfo.did, didInfo.verkey, 'alias', 'TRUST_ANCHOR')

--- a/packages/core/tests/mocks/MockWallet.ts
+++ b/packages/core/tests/mocks/MockWallet.ts
@@ -1,0 +1,74 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Wallet } from '../../src'
+import type { Key } from '../../src/crypto'
+import type { EncryptedMessage, WalletConfig, WalletExportImportConfig, WalletConfigRekey } from '../../src/types'
+import type { Buffer } from '../../src/utils/buffer'
+import type {
+  DidInfo,
+  UnpackedMessageContext,
+  DidConfig,
+  CreateKeyOptions,
+  SignOptions,
+  VerifyOptions,
+} from '../../src/wallet'
+
+export class MockWallet implements Wallet {
+  public publicDid = undefined
+  public isInitialized = true
+  public isProvisioned = true
+
+  public create(walletConfig: WalletConfig): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public createAndOpen(walletConfig: WalletConfig): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public open(walletConfig: WalletConfig): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public rotateKey(walletConfig: WalletConfigRekey): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public close(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public delete(): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public export(exportConfig: WalletExportImportConfig): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public import(walletConfig: WalletConfig, importConfig: WalletExportImportConfig): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public initPublicDid(didConfig: DidConfig): Promise<void> {
+    throw new Error('Method not implemented.')
+  }
+  public createDid(didConfig?: DidConfig): Promise<DidInfo> {
+    throw new Error('Method not implemented.')
+  }
+  public pack(
+    payload: Record<string, unknown>,
+    recipientKeys: string[],
+    senderVerkey?: string
+  ): Promise<EncryptedMessage> {
+    throw new Error('Method not implemented.')
+  }
+  public unpack(encryptedMessage: EncryptedMessage): Promise<UnpackedMessageContext> {
+    throw new Error('Method not implemented.')
+  }
+  public sign(options: SignOptions): Promise<Buffer> {
+    throw new Error('Method not implemented.')
+  }
+  public verify(options: VerifyOptions): Promise<boolean> {
+    throw new Error('Method not implemented.')
+  }
+
+  public createKey(options: CreateKeyOptions): Promise<Key> {
+    throw new Error('Method not implemented.')
+  }
+
+  public generateNonce(): Promise<string> {
+    throw new Error('Method not implemented.')
+  }
+}

--- a/packages/core/tests/mocks/index.ts
+++ b/packages/core/tests/mocks/index.ts
@@ -1,0 +1,1 @@
+export * from './MockWallet'

--- a/packages/core/tests/multi-protocol-version.test.ts
+++ b/packages/core/tests/multi-protocol-version.test.ts
@@ -84,7 +84,7 @@ describe('multi version protocols', () => {
       )
     )
 
-    await bobMessageSender.sendMessage(createOutboundMessage(bobConnection, new TestMessageV11()))
+    await bobMessageSender.sendMessage(bobAgent.context, createOutboundMessage(bobConnection, new TestMessageV11()))
 
     // Wait for the agent message processed event to be called
     await agentMessageV11ProcessedPromise
@@ -99,7 +99,7 @@ describe('multi version protocols', () => {
       )
     )
 
-    await bobMessageSender.sendMessage(createOutboundMessage(bobConnection, new TestMessageV15()))
+    await bobMessageSender.sendMessage(bobAgent.context, createOutboundMessage(bobConnection, new TestMessageV15()))
     await agentMessageV15ProcessedPromise
 
     expect(mockHandle).toHaveBeenCalledTimes(2)

--- a/packages/core/tests/oob.test.ts
+++ b/packages/core/tests/oob.test.ts
@@ -711,7 +711,7 @@ describe('out of band', () => {
         message,
       })
 
-      expect(saveOrUpdateSpy).toHaveBeenCalledWith({
+      expect(saveOrUpdateSpy).toHaveBeenCalledWith(expect.anything(), {
         agentMessage: message,
         associatedRecordId: credentialRecord.id,
         role: DidCommMessageRole.Sender,

--- a/packages/core/tests/wallet.test.ts
+++ b/packages/core/tests/wallet.test.ts
@@ -124,7 +124,7 @@ describe('wallet', () => {
     })
 
     // Save in wallet
-    await bobBasicMessageRepository.save(basicMessageRecord)
+    await bobBasicMessageRepository.save(bobAgent.context, basicMessageRecord)
 
     if (!bobAgent.config.walletConfig) {
       throw new Error('No wallet config on bobAgent')
@@ -142,7 +142,7 @@ describe('wallet', () => {
     // This should create a new wallet
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     await bobAgent.wallet.initialize(bobConfig.config.walletConfig!)
-    expect(await bobBasicMessageRepository.findById(basicMessageRecord.id)).toBeNull()
+    expect(await bobBasicMessageRepository.findById(bobAgent.context, basicMessageRecord.id)).toBeNull()
     await bobAgent.wallet.delete()
 
     // Import backup with different wallet id and initialize
@@ -150,7 +150,9 @@ describe('wallet', () => {
     await bobAgent.wallet.initialize({ id: backupWalletName, key: backupWalletName })
 
     // Expect same basic message record to exist in new wallet
-    expect(await bobBasicMessageRepository.getById(basicMessageRecord.id)).toMatchObject(basicMessageRecord)
+    expect(await bobBasicMessageRepository.getById(bobAgent.context, basicMessageRecord.id)).toMatchObject(
+      basicMessageRecord
+    )
   })
 
   test('changing wallet key', async () => {

--- a/packages/node/src/transport/HttpInboundTransport.ts
+++ b/packages/node/src/transport/HttpInboundTransport.ts
@@ -2,7 +2,7 @@ import type { InboundTransport, Agent, TransportSession, EncryptedMessage } from
 import type { Express, Request, Response } from 'express'
 import type { Server } from 'http'
 
-import { DidCommMimeType, AriesFrameworkError, AgentConfig, TransportService, utils } from '@aries-framework/core'
+import { DidCommMimeType, AriesFrameworkError, TransportService, utils } from '@aries-framework/core'
 import express, { text } from 'express'
 
 export class HttpInboundTransport implements InboundTransport {
@@ -30,9 +30,8 @@ export class HttpInboundTransport implements InboundTransport {
 
   public async start(agent: Agent) {
     const transportService = agent.dependencyManager.resolve(TransportService)
-    const config = agent.dependencyManager.resolve(AgentConfig)
 
-    config.logger.debug(`Starting HTTP inbound transport`, {
+    agent.config.logger.debug(`Starting HTTP inbound transport`, {
       port: this.port,
     })
 
@@ -48,7 +47,7 @@ export class HttpInboundTransport implements InboundTransport {
           res.status(200).end()
         }
       } catch (error) {
-        config.logger.error(`Error processing inbound message: ${error.message}`, error)
+        agent.config.logger.error(`Error processing inbound message: ${error.message}`, error)
 
         if (!res.headersSent) {
           res.status(500).send('Error processing message')

--- a/packages/node/src/transport/WsInboundTransport.ts
+++ b/packages/node/src/transport/WsInboundTransport.ts
@@ -1,6 +1,6 @@
 import type { Agent, InboundTransport, Logger, TransportSession, EncryptedMessage } from '@aries-framework/core'
 
-import { AriesFrameworkError, AgentConfig, TransportService, utils } from '@aries-framework/core'
+import { AriesFrameworkError, TransportService, utils } from '@aries-framework/core'
 import WebSocket, { Server } from 'ws'
 
 export class WsInboundTransport implements InboundTransport {
@@ -16,11 +16,10 @@ export class WsInboundTransport implements InboundTransport {
 
   public async start(agent: Agent) {
     const transportService = agent.dependencyManager.resolve(TransportService)
-    const config = agent.dependencyManager.resolve(AgentConfig)
 
-    this.logger = config.logger
+    this.logger = agent.config.logger
 
-    const wsEndpoint = config.endpoints.find((e) => e.startsWith('ws'))
+    const wsEndpoint = agent.config.endpoints.find((e) => e.startsWith('ws'))
     this.logger.debug(`Starting WS inbound transport`, {
       endpoint: wsEndpoint,
     })

--- a/samples/extension-module/dummy/services/DummyService.ts
+++ b/samples/extension-module/dummy/services/DummyService.ts
@@ -1,5 +1,5 @@
 import type { DummyStateChangedEvent } from './DummyEvents'
-import type { ConnectionRecord, InboundMessageContext } from '@aries-framework/core'
+import type { AgentContext, ConnectionRecord, InboundMessageContext } from '@aries-framework/core'
 
 import { injectable, JsonTransformer, EventEmitter } from '@aries-framework/core'
 
@@ -27,7 +27,7 @@ export class DummyService {
    * @returns Object containing dummy request message and associated dummy record
    *
    */
-  public async createRequest(connectionRecord: ConnectionRecord) {
+  public async createRequest(agentContext: AgentContext, connectionRecord: ConnectionRecord) {
     // Create message
     const message = new DummyRequestMessage({})
 
@@ -38,9 +38,9 @@ export class DummyService {
       state: DummyState.Init,
     })
 
-    await this.dummyRepository.save(record)
+    await this.dummyRepository.save(agentContext, record)
 
-    this.emitStateChangedEvent(record, null)
+    this.emitStateChangedEvent(agentContext, record, null)
 
     return { record, message }
   }
@@ -51,7 +51,7 @@ export class DummyService {
    * @param record the dummy record for which to create a dummy response
    * @returns outbound message containing dummy response
    */
-  public async createResponse(record: DummyRecord) {
+  public async createResponse(agentContext: AgentContext, record: DummyRecord) {
     const responseMessage = new DummyResponseMessage({
       threadId: record.threadId,
     })
@@ -76,9 +76,9 @@ export class DummyService {
       state: DummyState.RequestReceived,
     })
 
-    await this.dummyRepository.save(record)
+    await this.dummyRepository.save(messageContext.agentContext, record)
 
-    this.emitStateChangedEvent(record, null)
+    this.emitStateChangedEvent(messageContext.agentContext, record, null)
 
     return record
   }
@@ -96,13 +96,13 @@ export class DummyService {
     const connection = messageContext.assertReadyConnection()
 
     // Dummy record already exists
-    const record = await this.findByThreadAndConnectionId(message.threadId, connection.id)
+    const record = await this.findByThreadAndConnectionId(messageContext.agentContext, message.threadId, connection.id)
 
     if (record) {
       // Check current state
       record.assertState(DummyState.RequestSent)
 
-      await this.updateState(record, DummyState.ResponseReceived)
+      await this.updateState(messageContext.agentContext, record, DummyState.ResponseReceived)
     } else {
       throw new Error(`Dummy record not found with threadId ${message.threadId}`)
     }
@@ -115,8 +115,8 @@ export class DummyService {
    *
    * @returns List containing all dummy records
    */
-  public getAll(): Promise<DummyRecord[]> {
-    return this.dummyRepository.getAll()
+  public getAll(agentContext: AgentContext): Promise<DummyRecord[]> {
+    return this.dummyRepository.getAll(agentContext)
   }
 
   /**
@@ -127,8 +127,8 @@ export class DummyService {
    * @return The dummy record
    *
    */
-  public getById(dummyRecordId: string): Promise<DummyRecord> {
-    return this.dummyRepository.getById(dummyRecordId)
+  public getById(agentContext: AgentContext, dummyRecordId: string): Promise<DummyRecord> {
+    return this.dummyRepository.getById(agentContext, dummyRecordId)
   }
 
   /**
@@ -140,8 +140,12 @@ export class DummyService {
    * @throws {RecordDuplicateError} If multiple records are found
    * @returns The dummy record
    */
-  public async findByThreadAndConnectionId(threadId: string, connectionId?: string): Promise<DummyRecord | null> {
-    return this.dummyRepository.findSingleByQuery({ threadId, connectionId })
+  public async findByThreadAndConnectionId(
+    agentContext: AgentContext,
+    threadId: string,
+    connectionId?: string
+  ): Promise<DummyRecord | null> {
+    return this.dummyRepository.findSingleByQuery(agentContext, { threadId, connectionId })
   }
 
   /**
@@ -152,19 +156,23 @@ export class DummyService {
    * @param newState The state to update to
    *
    */
-  public async updateState(dummyRecord: DummyRecord, newState: DummyState) {
+  public async updateState(agentContext: AgentContext, dummyRecord: DummyRecord, newState: DummyState) {
     const previousState = dummyRecord.state
     dummyRecord.state = newState
-    await this.dummyRepository.update(dummyRecord)
+    await this.dummyRepository.update(agentContext, dummyRecord)
 
-    this.emitStateChangedEvent(dummyRecord, previousState)
+    this.emitStateChangedEvent(agentContext, dummyRecord, previousState)
   }
 
-  private emitStateChangedEvent(dummyRecord: DummyRecord, previousState: DummyState | null) {
+  private emitStateChangedEvent(
+    agentContext: AgentContext,
+    dummyRecord: DummyRecord,
+    previousState: DummyState | null
+  ) {
     // we need to clone the dummy record to avoid mutating records after they're emitted in an event
     const clonedDummyRecord = JsonTransformer.clone(dummyRecord)
 
-    this.eventEmitter.emit<DummyStateChangedEvent>({
+    this.eventEmitter.emit<DummyStateChangedEvent>(agentContext, {
       type: DummyEventTypes.StateChanged,
       payload: { dummyRecord: clonedDummyRecord, previousState: previousState },
     })

--- a/samples/mediator.ts
+++ b/samples/mediator.ts
@@ -25,7 +25,6 @@ import {
   Agent,
   ConnectionInvitationMessage,
   LogLevel,
-  AgentConfig,
   WsOutboundTransport,
 } from '@aries-framework/core'
 import { HttpInboundTransport, agentDependencies, WsInboundTransport } from '@aries-framework/node'
@@ -55,7 +54,7 @@ const agentConfig: InitConfig = {
 
 // Set up agent
 const agent = new Agent(agentConfig, agentDependencies)
-const config = agent.dependencyManager.resolve(AgentConfig)
+const config = agent.config
 
 // Create all transports
 const httpInboundTransport = new HttpInboundTransport({ app, port })

--- a/tests/InMemoryStorageService.ts
+++ b/tests/InMemoryStorageService.ts
@@ -1,3 +1,4 @@
+import type { AgentContext } from '../packages/core/src/agent'
 import type { BaseRecord, TagsBase } from '../packages/core/src/storage/BaseRecord'
 import type { StorageService, BaseRecordConstructor, Query } from '../packages/core/src/storage/StorageService'
 
@@ -33,7 +34,7 @@ export class InMemoryStorageService<T extends BaseRecord = BaseRecord> implement
   }
 
   /** @inheritDoc */
-  public async save(record: T) {
+  public async save(agentContext: AgentContext, record: T) {
     const value = JsonTransformer.toJSON(record)
 
     if (this.records[record.id]) {
@@ -49,7 +50,7 @@ export class InMemoryStorageService<T extends BaseRecord = BaseRecord> implement
   }
 
   /** @inheritDoc */
-  public async update(record: T): Promise<void> {
+  public async update(agentContext: AgentContext, record: T): Promise<void> {
     const value = JsonTransformer.toJSON(record)
     delete value._tags
 
@@ -68,7 +69,7 @@ export class InMemoryStorageService<T extends BaseRecord = BaseRecord> implement
   }
 
   /** @inheritDoc */
-  public async delete(record: T) {
+  public async delete(agentContext: AgentContext, record: T) {
     if (!this.records[record.id]) {
       throw new RecordNotFoundError(`record with id ${record.id} not found.`, {
         recordType: record.type,
@@ -79,7 +80,7 @@ export class InMemoryStorageService<T extends BaseRecord = BaseRecord> implement
   }
 
   /** @inheritDoc */
-  public async getById(recordClass: BaseRecordConstructor<T>, id: string): Promise<T> {
+  public async getById(agentContext: AgentContext, recordClass: BaseRecordConstructor<T>, id: string): Promise<T> {
     const record = this.records[id]
 
     if (!record) {
@@ -92,7 +93,7 @@ export class InMemoryStorageService<T extends BaseRecord = BaseRecord> implement
   }
 
   /** @inheritDoc */
-  public async getAll(recordClass: BaseRecordConstructor<T>): Promise<T[]> {
+  public async getAll(agentContext: AgentContext, recordClass: BaseRecordConstructor<T>): Promise<T[]> {
     const records = Object.values(this.records)
       .filter((record) => record.type === recordClass.type)
       .map((record) => this.recordToInstance(record, recordClass))
@@ -101,7 +102,11 @@ export class InMemoryStorageService<T extends BaseRecord = BaseRecord> implement
   }
 
   /** @inheritDoc */
-  public async findByQuery(recordClass: BaseRecordConstructor<T>, query: Query<T>): Promise<T[]> {
+  public async findByQuery(
+    agentContext: AgentContext,
+    recordClass: BaseRecordConstructor<T>,
+    query: Query<T>
+  ): Promise<T[]> {
     if (query.$and || query.$or || query.$not) {
       throw new AriesFrameworkError(
         'Advanced wallet query features $and, $or or $not not supported in in memory storage'

--- a/tests/e2e-test.ts
+++ b/tests/e2e-test.ts
@@ -1,9 +1,11 @@
 import type { Agent } from '@aries-framework/core'
+import type { Subject } from 'rxjs'
 
 import { sleep } from '../packages/core/src/utils/sleep'
 import { issueCredential, makeConnection, prepareForIssuance, presentProof } from '../packages/core/tests/helpers'
 
 import {
+  InjectionSymbols,
   V1CredentialPreview,
   AttributeFilter,
   CredentialState,
@@ -95,6 +97,7 @@ export async function e2eTest({
   // We want to stop the mediator polling before the agent is shutdown.
   // FIXME: add a way to stop mediator polling from the public api, and make sure this is
   // being handled in the agent shutdown so we don't get any errors with wallets being closed.
-  recipientAgent.config.stop$.next(true)
+  const recipientStop$ = recipientAgent.injectionContainer.resolve<Subject<boolean>>(InjectionSymbols.Stop$)
+  recipientStop$.next(true)
   await sleep(2000)
 }

--- a/tests/transport/SubjectInboundTransport.ts
+++ b/tests/transport/SubjectInboundTransport.ts
@@ -3,7 +3,6 @@ import type { TransportSession } from '../../packages/core/src/agent/TransportSe
 import type { EncryptedMessage } from '../../packages/core/src/types'
 import type { Subject, Subscription } from 'rxjs'
 
-import { AgentConfig } from '../../packages/core/src/agent/AgentConfig'
 import { TransportService } from '../../packages/core/src/agent/TransportService'
 import { uuid } from '../../packages/core/src/utils/uuid'
 
@@ -26,7 +25,7 @@ export class SubjectInboundTransport implements InboundTransport {
   }
 
   private subscribe(agent: Agent) {
-    const logger = agent.dependencyManager.resolve(AgentConfig).logger
+    const logger = agent.config.logger
     const transportService = agent.dependencyManager.resolve(TransportService)
 
     this.subscription = this.ourSubject.subscribe({

--- a/tests/transport/SubjectOutboundTransport.ts
+++ b/tests/transport/SubjectOutboundTransport.ts
@@ -9,6 +9,7 @@ export class SubjectOutboundTransport implements OutboundTransport {
   private logger!: Logger
   private subjectMap: { [key: string]: Subject<SubjectMessage> | undefined }
   private agent!: Agent
+  private stop$!: Subject<boolean>
 
   public supportedSchemes = ['rxjs']
 
@@ -20,6 +21,7 @@ export class SubjectOutboundTransport implements OutboundTransport {
     this.agent = agent
 
     this.logger = agent.dependencyManager.resolve(InjectionSymbols.Logger)
+    this.stop$ = agent.dependencyManager.resolve(InjectionSymbols.Stop$)
   }
 
   public async stop(): Promise<void> {
@@ -45,9 +47,9 @@ export class SubjectOutboundTransport implements OutboundTransport {
     // Create a replySubject just for this session. Both ends will be able to close it,
     // mimicking a transport like http or websocket. Close session automatically when agent stops
     const replySubject = new Subject<SubjectMessage>()
-    this.agent.config.stop$.pipe(take(1)).subscribe(() => !replySubject.closed && replySubject.complete())
+    this.stop$.pipe(take(1)).subscribe(() => !replySubject.closed && replySubject.complete())
 
-    replySubject.pipe(takeUntil(this.agent.config.stop$)).subscribe({
+    replySubject.pipe(takeUntil(this.stop$)).subscribe({
       next: async ({ message }: SubjectMessage) => {
         this.logger.test('Received message')
 


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

This is the same PR as #881, but based off the 0.3.0-pre branch instead of main. There's no changes compared to #881 except for making it work with this branch (making the new w3c services stateless). Due to the breaking changes we don't want to have this in main just yet. 

BREAKING CHANGE: To make AFJ multi-tenancy ready, all services and repositories have been made stateless. A new `AgentContext` is introduced that holds the current context, which is passed to each method call. The public API hasn't been affected, but due to the large impact of this change it is marked as breaking.
