### PR TITLE
fix(oob): support legacy prefix in attachments

### DIFF
--- a/packages/core/src/modules/oob/OutOfBandModule.ts
+++ b/packages/core/src/modules/oob/OutOfBandModule.ts
@@ -595,9 +595,10 @@ export class OutOfBandModule {
 
   private async emitWithConnection(connectionRecord: ConnectionRecord, messages: PlaintextMessage[]) {
     const supportedMessageTypes = this.dispatcher.supportedMessageTypes
-    const plaintextMessage = messages.find((message) =>
-      supportedMessageTypes.find((type) => supportsIncomingMessageType(parseMessageType(message['@type']), type))
-    )
+    const plaintextMessage = messages.find((message) => {
+      const parsedMessageType = parseMessageType(message['@type'])
+      return supportedMessageTypes.find((type) => supportsIncomingMessageType(parsedMessageType, type))
+    })
 
     if (!plaintextMessage) {
       throw new AriesFrameworkError('There is no message in requests~attach supported by agent.')
@@ -620,9 +621,10 @@ export class OutOfBandModule {
     }
 
     const supportedMessageTypes = this.dispatcher.supportedMessageTypes
-    const plaintextMessage = messages.find((message) =>
-      supportedMessageTypes.find((type) => supportsIncomingMessageType(parseMessageType(message['@type']), type))
-    )
+    const plaintextMessage = messages.find((message) => {
+      const parsedMessageType = parseMessageType(message['@type'])
+      return supportedMessageTypes.find((type) => supportsIncomingMessageType(parsedMessageType, type))
+    })
 
     if (!plaintextMessage) {
       throw new AriesFrameworkError('There is no message in requests~attach supported by agent.')

--- a/packages/core/src/utils/__tests__/messageType.test.ts
+++ b/packages/core/src/utils/__tests__/messageType.test.ts
@@ -128,28 +128,46 @@ describe('messageType', () => {
       const incomingMessageType = parseMessageType('https://didcomm.org/connections/1.0/request')
       const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
 
-      expect(supportsIncomingMessageType(expectedMessageType, incomingMessageType)).toBe(true)
+      expect(supportsIncomingMessageType(incomingMessageType, expectedMessageType)).toBe(true)
     })
 
     test('returns true when the document uri, protocol name, major version all match and the minor version is higher than the expected minor version', () => {
       const incomingMessageType = parseMessageType('https://didcomm.org/connections/1.8/request')
       const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
 
-      expect(supportsIncomingMessageType(expectedMessageType, incomingMessageType)).toBe(true)
+      expect(supportsIncomingMessageType(incomingMessageType, expectedMessageType)).toBe(true)
     })
 
     test('returns true when the document uri, protocol name, major version and minor version all match', () => {
       const incomingMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
       const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
 
-      expect(supportsIncomingMessageType(expectedMessageType, incomingMessageType)).toBe(true)
+      expect(supportsIncomingMessageType(incomingMessageType, expectedMessageType)).toBe(true)
+    })
+
+    test('returns true when the protocol name, major version and minor version all match and the incoming message type is using the legacy did sov prefix', () => {
+      const incomingMessageType = parseMessageType('did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.4/request')
+      const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
+
+      expect(supportsIncomingMessageType(incomingMessageType, expectedMessageType)).toBe(true)
+    })
+
+    test('returns false when the protocol name, major version and minor version all match and the incoming message type is using the legacy did sov prefix but allowLegacyDidSovPrefixMismatch is set to false', () => {
+      const incomingMessageType = parseMessageType('did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/connections/1.4/request')
+      const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
+
+      expect(
+        supportsIncomingMessageType(expectedMessageType, incomingMessageType, {
+          allowLegacyDidSovPrefixMismatch: false,
+        })
+      ).toBe(false)
     })
 
     test('returns false when the major version does not match', () => {
       const incomingMessageType = parseMessageType('https://didcomm.org/connections/2.4/request')
       const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
 
-      expect(supportsIncomingMessageType(expectedMessageType, incomingMessageType)).toBe(false)
+      expect(supportsIncomingMessageType(incomingMessageType, expectedMessageType)).toBe(false)
 
       const incomingMessageType2 = parseMessageType('https://didcomm.org/connections/2.0/request')
       const expectedMessageType2 = parseMessageType('https://didcomm.org/connections/1.4/request')
@@ -161,21 +179,21 @@ describe('messageType', () => {
       const incomingMessageType = parseMessageType('https://didcomm.org/connections/1.4/proposal')
       const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
 
-      expect(supportsIncomingMessageType(expectedMessageType, incomingMessageType)).toBe(false)
+      expect(supportsIncomingMessageType(incomingMessageType, expectedMessageType)).toBe(false)
     })
 
     test('returns false when the protocol name does not match', () => {
       const incomingMessageType = parseMessageType('https://didcomm.org/issue-credential/1.4/request')
       const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
 
-      expect(supportsIncomingMessageType(expectedMessageType, incomingMessageType)).toBe(false)
+      expect(supportsIncomingMessageType(incomingMessageType, expectedMessageType)).toBe(false)
     })
 
     test('returns false when the document uri does not match', () => {
       const incomingMessageType = parseMessageType('https://my-protocol.org/connections/1.4/request')
       const expectedMessageType = parseMessageType('https://didcomm.org/connections/1.4/request')
 
-      expect(supportsIncomingMessageType(expectedMessageType, incomingMessageType)).toBe(false)
+      expect(supportsIncomingMessageType(incomingMessageType, expectedMessageType)).toBe(false)
     })
   })
 

--- a/packages/core/tests/oob.test.ts
+++ b/packages/core/tests/oob.test.ts
@@ -362,6 +362,30 @@ describe('out of band', () => {
       expect(aliceCredentialRecord.state).toBe(CredentialState.OfferReceived)
     })
 
+    test('process credential offer requests with legacy did:sov prefix on message type based on OOB message', async () => {
+      const { message } = await faberAgent.credentials.createOffer(credentialTemplate)
+
+      // we need to override the message type to use the legacy did:sov prefix
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      message.type = message.type.replace('https://didcomm.org', 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec')
+      const { outOfBandInvitation } = await faberAgent.oob.createInvitation({
+        ...issueCredentialConfig,
+        messages: [message],
+      })
+
+      const urlMessage = outOfBandInvitation.toUrl({ domain: 'http://example.com' })
+
+      const aliceCredentialRecordPromise = waitForCredentialRecord(aliceAgent, {
+        state: CredentialState.OfferReceived,
+        threadId: message.threadId,
+      })
+      await aliceAgent.oob.receiveInvitationFromUrl(urlMessage, receiveInvitationConfig)
+
+      const aliceCredentialRecord = await aliceCredentialRecordPromise
+      expect(aliceCredentialRecord.state).toBe(CredentialState.OfferReceived)
+    })
+
     test('do not process requests when a connection is not ready', async () => {
       const eventListener = jest.fn()
       aliceAgent.events.on<AgentMessageReceivedEvent>(AgentEventTypes.AgentMessageReceived, eventListener)


### PR DESCRIPTION
Fix issue of the oob module not being able to handle the legacy did sov prefix on attachment in oob invitations.

Issue as reported on discord:

> AFJ is throwing an error when i accept an oob invitation with a present-proof/credential-offer attachment from acapy,   Error msg: There is no message in requests~attach supported by agent.  It's due to LegacyDidSovPrefix in the message type.  It fails at this step : https://github.com/hyperledger/aries-framework-javascript/blob/main/packages/core/src/modules/oob/OutOfBandModule.ts#L599 