### PR TITLE
fix: no return routing and wait for ping

### DIFF
--- a/packages/core/src/agent/MessageSender.ts
+++ b/packages/core/src/agent/MessageSender.ts
@@ -227,7 +227,9 @@ export class MessageSender {
     // as the `from` field in a received message will identity the did used so we don't have to store all keys in tags to be able to find the connections associated with
     // an incoming message.
     const [firstOurAuthenticationKey] = ourAuthenticationKeys
-    const shouldUseReturnRoute = !this.transportService.hasInboundEndpoint(ourDidDocument)
+    // If the returnRoute is already set we won't override it. This allows to set the returnRoute manually if this is desired.
+    const shouldAddReturnRoute =
+      payload.transport?.returnRoute === undefined && !this.transportService.hasInboundEndpoint(ourDidDocument)
 
     // Loop trough all available services and try to send the message
     for await (const service of services) {
@@ -237,7 +239,7 @@ export class MessageSender {
           message: payload,
           service,
           senderKey: firstOurAuthenticationKey,
-          returnRoute: shouldUseReturnRoute,
+          returnRoute: shouldAddReturnRoute,
           connectionId: connection.id,
         })
         return

--- a/packages/core/src/modules/connections/ConnectionsModule.ts
+++ b/packages/core/src/modules/connections/ConnectionsModule.ts
@@ -8,6 +8,7 @@ import { AgentConfig } from '../../agent/AgentConfig'
 import { Dispatcher } from '../../agent/Dispatcher'
 import { MessageSender } from '../../agent/MessageSender'
 import { createOutboundMessage } from '../../agent/helpers'
+import { ReturnRouteTypes } from '../../decorators/transport/TransportDecorator'
 import { AriesFrameworkError } from '../../error'
 import { injectable, module } from '../../plugins'
 import { DidResolverService } from '../dids'
@@ -165,11 +166,17 @@ export class ConnectionsModule {
         )
       }
       const message = await this.didExchangeProtocol.createComplete(connectionRecord, outOfBandRecord)
+      // Disable return routing as we don't want to receive a response for this message over the same channel
+      // This has led to long timeouts as not all clients actually close an http socket if there is no response message
+      message.setReturnRouting(ReturnRouteTypes.none)
       outboundMessage = createOutboundMessage(connectionRecord, message)
     } else {
       const { message } = await this.connectionService.createTrustPing(connectionRecord, {
         responseRequested: false,
       })
+      // Disable return routing as we don't want to receive a response for this message over the same channel
+      // This has led to long timeouts as not all clients actually close an http socket if there is no response message
+      message.setReturnRouting(ReturnRouteTypes.none)
       outboundMessage = createOutboundMessage(connectionRecord, message)
     }
 

--- a/packages/core/src/modules/connections/handlers/ConnectionResponseHandler.ts
+++ b/packages/core/src/modules/connections/handlers/ConnectionResponseHandler.ts
@@ -5,6 +5,7 @@ import type { OutOfBandService } from '../../oob/OutOfBandService'
 import type { ConnectionService } from '../services/ConnectionService'
 
 import { createOutboundMessage } from '../../../agent/helpers'
+import { ReturnRouteTypes } from '../../../decorators/transport/TransportDecorator'
 import { AriesFrameworkError } from '../../../error'
 import { ConnectionResponseMessage } from '../messages'
 
@@ -73,6 +74,10 @@ export class ConnectionResponseHandler implements Handler {
     // if auto accept is enable
     if (connection.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
       const { message } = await this.connectionService.createTrustPing(connection, { responseRequested: false })
+
+      // Disable return routing as we don't want to receive a response for this message over the same channel
+      // This has led to long timeouts as not all clients actually close an http socket if there is no response message
+      message.setReturnRouting(ReturnRouteTypes.none)
       return createOutboundMessage(connection, message)
     }
   }

--- a/packages/core/src/modules/connections/handlers/DidExchangeResponseHandler.ts
+++ b/packages/core/src/modules/connections/handlers/DidExchangeResponseHandler.ts
@@ -6,6 +6,7 @@ import type { DidExchangeProtocol } from '../DidExchangeProtocol'
 import type { ConnectionService } from '../services'
 
 import { createOutboundMessage } from '../../../agent/helpers'
+import { ReturnRouteTypes } from '../../../decorators/transport/TransportDecorator'
 import { AriesFrameworkError } from '../../../error'
 import { OutOfBandState } from '../../oob/domain/OutOfBandState'
 import { DidExchangeResponseMessage } from '../messages'
@@ -97,6 +98,10 @@ export class DidExchangeResponseHandler implements Handler {
     // if auto accept is enable
     if (connection.autoAcceptConnection ?? this.agentConfig.autoAcceptConnections) {
       const message = await this.didExchangeProtocol.createComplete(connection, outOfBandRecord)
+      // Disable return routing as we don't want to receive a response for this message over the same channel
+      // This has led to long timeouts as not all clients actually close an http socket if there is no response message
+      message.setReturnRouting(ReturnRouteTypes.none)
+
       if (!outOfBandRecord.reusable) {
         await this.outOfBandService.updateState(outOfBandRecord, OutOfBandState.Done)
       }

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -149,7 +149,7 @@ export class ConnectionService {
     messageContext: InboundMessageContext<ConnectionRequestMessage>,
     outOfBandRecord: OutOfBandRecord
   ): Promise<ConnectionRecord> {
-    this.logger.debug(`Process message ${ConnectionRequestMessage.type} start`, messageContext)
+    this.logger.debug(`Process message ${ConnectionRequestMessage.type.messageTypeUri} start`, messageContext)
     outOfBandRecord.assertRole(OutOfBandRole.Sender)
     outOfBandRecord.assertState(OutOfBandState.AwaitResponse)
 
@@ -183,7 +183,7 @@ export class ConnectionService {
     await this.connectionRepository.update(connectionRecord)
     this.emitStateChangedEvent(connectionRecord, null)
 
-    this.logger.debug(`Process message ${ConnectionRequestMessage.type} end`, connectionRecord)
+    this.logger.debug(`Process message ${ConnectionRequestMessage.type.messageTypeUri} end`, connectionRecord)
     return connectionRecord
   }
 
@@ -259,7 +259,7 @@ export class ConnectionService {
     messageContext: InboundMessageContext<ConnectionResponseMessage>,
     outOfBandRecord: OutOfBandRecord
   ): Promise<ConnectionRecord> {
-    this.logger.debug(`Process message ${ConnectionResponseMessage.type} start`, messageContext)
+    this.logger.debug(`Process message ${ConnectionResponseMessage.type.messageTypeUri} start`, messageContext)
     const { connection: connectionRecord, message, recipientKey, senderKey } = messageContext
 
     if (!recipientKey || !senderKey) {

--- a/packages/core/src/transport/HttpOutboundTransport.ts
+++ b/packages/core/src/transport/HttpOutboundTransport.ts
@@ -1,4 +1,5 @@
 import type { Agent } from '../agent/Agent'
+import type { AgentMessageReceivedEvent } from '../agent/Events'
 import type { Logger } from '../logger'
 import type { OutboundPackage } from '../types'
 import type { OutboundTransport } from './OutboundTransport'
@@ -7,6 +8,7 @@ import type fetch from 'node-fetch'
 import { AbortController } from 'abort-controller'
 
 import { AgentConfig } from '../agent/AgentConfig'
+import { AgentEventTypes } from '../agent/Events'
 import { AriesFrameworkError } from '../error/AriesFrameworkError'
 import { isValidJweStructure, JsonEncoder } from '../utils'
 
@@ -84,7 +86,13 @@ export class HttpOutboundTransport implements OutboundTransport {
             )
             return
           }
-          await this.agent.receiveMessage(encryptedMessage)
+          // Emit event with the received agent message.
+          this.agent.events.emit<AgentMessageReceivedEvent>({
+            type: AgentEventTypes.AgentMessageReceived,
+            payload: {
+              message: encryptedMessage,
+            },
+          })
         } catch (error) {
           this.logger.debug('Unable to parse response message')
         }


### PR DESCRIPTION
This PR adds some improvements to return routing. Mainly it adds two things:
1. Messages returned as a http response are now emitted using an event, meaning the sendMessage await won't wait for the returned message to be processed. This could lead to a chain of send / receive messages that would take a long time to resolve. Especially if the socket was kept open because no response was returned this could lead to unwanted behaviour. (see https://github.com/hyperledger/aries-cloudagent-python/pull/1853 for more context on socket staying open)
2. Do not include the return route decorator if not response is expected. The return route decorator is automatically added if we don't have an endpoint. This only happens with the mediator in most cases. What would happen is that the trust ping was sent to complete the connection, and we didn't receive a response. This would lead to the socket staying open for 15 seconds, before the mediation request message was sent. Now if the return route is already set (in this case to none) we won't add it in the message sender.. 

As mentioned in https://github.com/hyperledger/aries-cloudagent-python/pull/1853, this reduces the connection + request mediation flow time from ~17 seconds to around 1.5 seconds :)