### PR TITLE
refactor(credential): update repository after metadata update

### DIFF
--- a/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
+++ b/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
@@ -129,7 +129,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       schemaId: proposal.schemaId,
       credentialDefinitionId: proposal.credentialDefinitionId,
     })
-    this.credentialRepository.update(credentialRecord)
+    await this.credentialRepository.update(credentialRecord)
 
     return { format, attachment, previewAttributes }
   }
@@ -224,7 +224,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       credentialDefinitionId: credentialOffer.cred_def_id,
       schemaId: credentialOffer.schema_id,
     })
-    this.credentialRepository.update(credentialRecord)
+    await this.credentialRepository.update(credentialRecord)
   }
 
   public async acceptOffer({
@@ -250,7 +250,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       credentialDefinitionId: credentialOffer.cred_def_id,
       schemaId: credentialOffer.schema_id,
     })
-    this.credentialRepository.update(credentialRecord)
+    await this.credentialRepository.update(credentialRecord)
 
     const format = new CredentialFormatSpec({
       attachId,
@@ -484,7 +484,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       schemaId: offer.schema_id,
       credentialDefinitionId: offer.cred_def_id,
     })
-    this.credentialRepository.update(credentialRecord)
+    await this.credentialRepository.update(credentialRecord)
 
     const attachment = this.getFormatData(offer, format.attachId)
 

--- a/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
+++ b/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
@@ -129,7 +129,6 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       schemaId: proposal.schemaId,
       credentialDefinitionId: proposal.credentialDefinitionId,
     })
-    await this.credentialRepository.update(credentialRecord)
 
     return { format, attachment, previewAttributes }
   }
@@ -224,7 +223,6 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       credentialDefinitionId: credentialOffer.cred_def_id,
       schemaId: credentialOffer.schema_id,
     })
-    await this.credentialRepository.update(credentialRecord)
   }
 
   public async acceptOffer({
@@ -250,7 +248,6 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       credentialDefinitionId: credentialOffer.cred_def_id,
       schemaId: credentialOffer.schema_id,
     })
-    await this.credentialRepository.update(credentialRecord)
 
     const format = new CredentialFormatSpec({
       attachId,
@@ -484,7 +481,6 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       schemaId: offer.schema_id,
       credentialDefinitionId: offer.cred_def_id,
     })
-    await this.credentialRepository.update(credentialRecord)
 
     const attachment = this.getFormatData(offer, format.attachId)
 

--- a/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
+++ b/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
@@ -129,6 +129,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       schemaId: proposal.schemaId,
       credentialDefinitionId: proposal.credentialDefinitionId,
     })
+    this.credentialRepository.update(credentialRecord)
 
     return { format, attachment, previewAttributes }
   }
@@ -211,13 +212,19 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
   public async processOffer({ attachment, credentialRecord }: FormatProcessOptions) {
     this.logger.debug(`Processing indy credential offer for credential record ${credentialRecord.id}`)
 
-    const credOffer = attachment.getDataAsJson<Indy.CredOffer>()
+    const credentialOffer = attachment.getDataAsJson<Indy.CredOffer>()
 
-    if (!credOffer.schema_id || !credOffer.cred_def_id) {
+    if (!credentialOffer.schema_id || !credentialOffer.cred_def_id) {
       throw new CredentialProblemReportError('Invalid credential offer', {
         problemCode: CredentialProblemReportReason.IssuanceAbandoned,
       })
     }
+
+    credentialRecord.metadata.set(CredentialMetadataKeys.IndyCredential, {
+      credentialDefinitionId: credentialOffer.cred_def_id,
+      schemaId: credentialOffer.schema_id,
+    })
+    this.credentialRepository.update(credentialRecord)
   }
 
   public async acceptOffer({
@@ -243,6 +250,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       credentialDefinitionId: credentialOffer.cred_def_id,
       schemaId: credentialOffer.schema_id,
     })
+    this.credentialRepository.update(credentialRecord)
 
     const format = new CredentialFormatSpec({
       attachId,
@@ -476,6 +484,7 @@ export class IndyCredentialFormatService extends CredentialFormatService<IndyCre
       schemaId: offer.schema_id,
       credentialDefinitionId: offer.cred_def_id,
     })
+    this.credentialRepository.update(credentialRecord)
 
     const attachment = this.getFormatData(offer, format.attachId)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7652,7 +7652,7 @@ node-dir@^0.1.17:
   dependencies:
     minimatch "^3.0.2"
 
-node-fetch@2.6.7, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@2.6.7, node-fetch@^2.0, node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.7"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==


### PR DESCRIPTION
- Updates the credentialRecord in the repository after a metadata change. (This probably did not cause any issues before as we modify the object by reference).
- Processing a credential offer now also adds the schema + cred def in the metadata to show the schema as the name in a wallet before accepting the credential.