### PR TITLE
refactor: do not log websocket data

### DIFF
--- a/packages/core/src/transport/WsOutboundTransport.ts
+++ b/packages/core/src/transport/WsOutboundTransport.ts
@@ -103,7 +103,7 @@ export class WsOutboundTransport implements OutboundTransport {
   // so 'this' is scoped to the 'WsOutboundTransport' class instance
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private handleMessageEvent = (event: any) => {
-    this.logger.trace('WebSocket message event received.', { url: event.target.url, data: event.data })
+    this.logger.trace('WebSocket message event received.', { url: event.target.url })
     const payload = JsonEncoder.fromBuffer(event.data)
     if (!isValidJweStructure(payload)) {
       throw new Error(

--- a/packages/node/src/transport/WsInboundTransport.ts
+++ b/packages/node/src/transport/WsInboundTransport.ts
@@ -61,7 +61,7 @@ export class WsInboundTransport implements InboundTransport {
   private listenOnWebSocketMessages(agent: Agent, socket: WebSocket, session: TransportSession) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     socket.addEventListener('message', async (event: any) => {
-      this.logger.debug('WebSocket message event received.', { url: event.target.url, data: event.data })
+      this.logger.debug('WebSocket message event received.', { url: event.target.url })
       try {
         await agent.receiveMessage(JSON.parse(event.data), session)
       } catch (error) {


### PR DESCRIPTION
It logs the following to the console, which is really unhelpful and bloats your logs:

```
2022-07-24 09:57:06.677  DEBUG [DIDComm Chat  WebSocket.<anonymous>] WebSocket message event received. 
{
  data: {
    type: 'Buffer',
    data: [
      123,
      34,
      112,
      114,
      111,
      116,
      101,
      99,
      116,
      101,
      100,
      34,
      58,
      34,
      101,
      121,
      74,
      108,
      98,
      109,
      77,
      105,
      79,
      105,
      74,
      52,
      89,
      50,
      104,
      104,
      89,
      50,
      104,
      104,
      77,
      106,
      66,
      119,
      98,
      50,
      120,
      53,
      77,
      84,
      77,
      119,
      78,
      86,
      57,
      112,
      90,
      88,
      82,
      109,
      73,
      105,
      119,
      105,
      100,
      72,
      108,
      119,
      73,
      106,
      111,
      105,
      83,
      108,
      100,
      78,
      76,
      122,
      69,
      117,
      77,
      67,
      73,
      115,
      73,
      109,
      70,
      115,
      90,
      121,
      73,
      54,
      73,
      107,
      70,
      49,
      100,
      71,
      104,
      106,
      99,
      110,
      108,
      119,
      100,
      67,
      ... 745 more items
    ]
  }
}
```