### PR TITLE
feat(ledger): handle REQNACK response for write request

### DIFF
--- a/packages/core/src/modules/ledger/IndyPool.ts
+++ b/packages/core/src/modules/ledger/IndyPool.ts
@@ -138,7 +138,7 @@ export class IndyPool {
   public async submitWriteRequest(request: Indy.LedgerRequest) {
     const response = await this.submitRequest(request)
 
-    if (isLedgerRejectResponse(response)) {
+    if (isLedgerRejectResponse(response) || isLedgerReqnackResponse(response)) {
       throw new LedgerError(`Ledger '${this.id}' rejected write transaction request: ${response.reason}`)
     }
 


### PR DESCRIPTION
I'm not sure if the check for REQNACK response was omitted in the write request method on purpose, but `registerSchema` is throwing a confusing error.

Previously:
```
TypeError: Cannot read property 'txnMetadata' of undefined
```

After the update:
```
Ledger 'pool-localhost' rejected write transaction request: client request invalid: could not authenticate, verkey for 9gFCquotxSS7ctKG1GJatU cannot be found
```
