### PR TITLE
feat: Action Menu protocol (Aries RFC 0509) implementation

### DIFF
--- a/packages/core/src/agent/Agent.ts
+++ b/packages/core/src/agent/Agent.ts
@@ -16,6 +16,7 @@ import { CacheRepository } from '../cache'
 import { InjectionSymbols } from '../constants'
 import { JwsService } from '../crypto/JwsService'
 import { AriesFrameworkError } from '../error'
+import { ActionMenuModule } from '../modules/action-menu'
 import { BasicMessagesModule } from '../modules/basic-messages/BasicMessagesModule'
 import { ConnectionsModule } from '../modules/connections/ConnectionsModule'
 import { CredentialsModule } from '../modules/credentials/CredentialsModule'
@@ -68,6 +69,7 @@ export class Agent {
   public readonly genericRecords: GenericRecordsModule
   public readonly ledger: LedgerModule
   public readonly questionAnswer!: QuestionAnswerModule
+  public readonly actionMenu!: ActionMenuModule
   public readonly credentials: CredentialsModule
   public readonly mediationRecipient: RecipientModule
   public readonly mediator: MediatorModule
@@ -122,6 +124,7 @@ export class Agent {
     this.mediationRecipient = this.dependencyManager.resolve(RecipientModule)
     this.basicMessages = this.dependencyManager.resolve(BasicMessagesModule)
     this.questionAnswer = this.dependencyManager.resolve(QuestionAnswerModule)
+    this.actionMenu = this.dependencyManager.resolve(ActionMenuModule)
     this.genericRecords = this.dependencyManager.resolve(GenericRecordsModule)
     this.ledger = this.dependencyManager.resolve(LedgerModule)
     this.discovery = this.dependencyManager.resolve(DiscoverFeaturesModule)
@@ -342,6 +345,7 @@ export class Agent {
       RecipientModule,
       BasicMessagesModule,
       QuestionAnswerModule,
+      ActionMenuModule,
       GenericRecordsModule,
       LedgerModule,
       DiscoverFeaturesModule,

--- a/packages/core/src/modules/action-menu/ActionMenuEvents.ts
+++ b/packages/core/src/modules/action-menu/ActionMenuEvents.ts
@@ -1,0 +1,14 @@
+import type { BaseEvent } from '../../agent/Events'
+import type { ActionMenuState } from './ActionMenuState'
+import type { ActionMenuRecord } from './repository'
+
+export enum ActionMenuEventTypes {
+  ActionMenuStateChanged = 'ActionMenuStateChanged',
+}
+export interface ActionMenuStateChangedEvent extends BaseEvent {
+  type: typeof ActionMenuEventTypes.ActionMenuStateChanged
+  payload: {
+    actionMenuRecord: ActionMenuRecord
+    previousState: ActionMenuState | null
+  }
+}

--- a/packages/core/src/modules/action-menu/ActionMenuModule.ts
+++ b/packages/core/src/modules/action-menu/ActionMenuModule.ts
@@ -1,0 +1,137 @@
+import type { DependencyManager } from '../../plugins'
+import type {
+  FindActiveMenuOptions,
+  PerformActionOptions,
+  RequestMenuOptions,
+  SendMenuOptions,
+} from './ActionMenuModuleOptions'
+
+import { Dispatcher } from '../../agent/Dispatcher'
+import { MessageSender } from '../../agent/MessageSender'
+import { createOutboundMessage } from '../../agent/helpers'
+import { AriesFrameworkError } from '../../error'
+import { injectable, module } from '../../plugins'
+import { ConnectionService } from '../connections/services'
+
+import { ActionMenuRole } from './ActionMenuRole'
+import { MenuMessageHandler, MenuRequestMessageHandler, PerformMessageHandler } from './handlers'
+import { ActionMenuService } from './services'
+
+@module()
+@injectable()
+export class ActionMenuModule {
+  private connectionService: ConnectionService
+  private messageSender: MessageSender
+  private actionMenuService: ActionMenuService
+
+  public constructor(
+    dispatcher: Dispatcher,
+    connectionService: ConnectionService,
+    messageSender: MessageSender,
+    actionMenuService: ActionMenuService
+  ) {
+    this.connectionService = connectionService
+    this.messageSender = messageSender
+    this.actionMenuService = actionMenuService
+    this.registerHandlers(dispatcher)
+  }
+
+  /**
+   * Start Action Menu protocol as requester, asking for root menu. Any active menu will be closed.
+   *
+   * @param options options for requesting menu
+   * @returns Action Menu record associated to this new request
+   */
+  public async requestMenu(options: RequestMenuOptions) {
+    const connection = await this.connectionService.getById(options.connectionId)
+
+    const { message, record } = await this.actionMenuService.createRequest({
+      connection,
+    })
+
+    const outboundMessage = createOutboundMessage(connection, message)
+    await this.messageSender.sendMessage(outboundMessage)
+
+    return record
+  }
+
+  /**
+   * Send a new Action Menu as responder. This menu will be sent as response if there is an
+   * existing menu thread.
+   *
+   * @param options options for sending menu
+   * @returns Action Menu record associated to this action
+   */
+  public async sendMenu(options: SendMenuOptions) {
+    const connection = await this.connectionService.getById(options.connectionId)
+
+    const { message, record } = await this.actionMenuService.createMenu({
+      connection,
+      menu: options.menu,
+    })
+
+    const outboundMessage = createOutboundMessage(connection, message)
+    await this.messageSender.sendMessage(outboundMessage)
+
+    return record
+  }
+
+  /**
+   * Perform action in active Action Menu, as a requester. The related
+   * menu will be closed.
+   *
+   * @param options options for requesting menu
+   * @returns Action Menu record associated to this selection
+   */
+  public async performAction(options: PerformActionOptions) {
+    const connection = await this.connectionService.getById(options.connectionId)
+
+    const actionMenuRecord = await this.actionMenuService.findActive({
+      connectionId: connection.id,
+      role: ActionMenuRole.Requester,
+    })
+    if (!actionMenuRecord) {
+      throw new AriesFrameworkError(`No active menu found for connection id ${options.connectionId}`)
+    }
+
+    const { message, record } = await this.actionMenuService.createPerform({
+      actionMenuRecord,
+      performedAction: options.performedAction,
+    })
+
+    const outboundMessage = createOutboundMessage(connection, message)
+    await this.messageSender.sendMessage(outboundMessage)
+
+    return record
+  }
+
+  /**
+   * Find the current active menu for a given connection and the specified role.
+   *
+   * @param options options for requesting active menu
+   * @returns Active Action Menu record, or null if no active menu found
+   */
+  public async findActiveMenu(options: FindActiveMenuOptions) {
+    return this.actionMenuService.findActive({
+      connectionId: options.connectionId,
+      role: options.role,
+    })
+  }
+
+  private registerHandlers(dispatcher: Dispatcher) {
+    dispatcher.registerHandler(new MenuMessageHandler(this.actionMenuService))
+    dispatcher.registerHandler(new MenuRequestMessageHandler(this.actionMenuService))
+    dispatcher.registerHandler(new PerformMessageHandler(this.actionMenuService))
+  }
+
+  /**
+   * Registers the dependencies of the discover features module on the dependency manager.
+   */
+  public static register(dependencyManager: DependencyManager) {
+    // Api
+    dependencyManager.registerContextScoped(ActionMenuModule)
+
+    // Services
+    dependencyManager.registerSingleton(ActionMenuService)
+  }
+}

--- a/packages/core/src/modules/action-menu/ActionMenuModuleOptions.ts
+++ b/packages/core/src/modules/action-menu/ActionMenuModuleOptions.ts
@@ -1,0 +1,27 @@
+import type { ActionMenuRole } from './ActionMenuRole'
+import type { ActionMenu } from './models/ActionMenu'
+import type { ActionMenuSelection } from './models/ActionMenuSelection'
+
+export interface FindActiveMenuOptions {
+  connectionId: string
+  role: ActionMenuRole
+}
+
+export interface ClearActiveMenuOptions {
+  connectionId: string
+  role: ActionMenuRole
+}
+
+export interface RequestMenuOptions {
+  connectionId: string
+}
+
+export interface SendMenuOptions {
+  connectionId: string
+  menu: ActionMenu
+}
+
+export interface PerformActionOptions {
+  connectionId: string
+  performedAction: ActionMenuSelection
+}

--- a/packages/core/src/modules/action-menu/ActionMenuRole.ts
+++ b/packages/core/src/modules/action-menu/ActionMenuRole.ts
@@ -1,0 +1,9 @@
+/**
+ * Action Menu roles based on the flow defined in RFC 0509.
+ *
+ * @see https://github.com/hyperledger/aries-rfcs/tree/main/features/0509-action-menu#roles
+ */
+export enum ActionMenuRole {
+  Requester = 'requester',
+  Responder = 'responder',
+}

--- a/packages/core/src/modules/action-menu/ActionMenuState.ts
+++ b/packages/core/src/modules/action-menu/ActionMenuState.ts
@@ -1,0 +1,13 @@
+/**
+ * Action Menu states based on the flow defined in RFC 0509.
+ *
+ * @see https://github.com/hyperledger/aries-rfcs/tree/main/features/0509-action-menu#states
+ */
+export enum ActionMenuState {
+  Null = 'null',
+  AwaitingRootMenu = 'awaiting-root-menu',
+  PreparingRootMenu = 'preparing-root-menu',
+  PreparingSelection = 'preparing-selection',
+  AwaitingSelection = 'awaiting-selection',
+  Done = 'done',
+}

--- a/packages/core/src/modules/action-menu/handlers/MenuMessageHandler.ts
+++ b/packages/core/src/modules/action-menu/handlers/MenuMessageHandler.ts
@@ -1,0 +1,19 @@
+import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
+import type { ActionMenuService } from '../services'
+
+import { MenuMessage } from '../messages'
+
+export class MenuMessageHandler implements Handler {
+  private actionMenuService: ActionMenuService
+  public supportedMessages = [MenuMessage]
+
+  public constructor(actionMenuService: ActionMenuService) {
+    this.actionMenuService = actionMenuService
+  }
+
+  public async handle(inboundMessage: HandlerInboundMessage<MenuMessageHandler>) {
+    inboundMessage.assertReadyConnection()
+
+    await this.actionMenuService.processMenu(inboundMessage)
+  }
+}

--- a/packages/core/src/modules/action-menu/handlers/MenuRequestMessageHandler.ts
+++ b/packages/core/src/modules/action-menu/handlers/MenuRequestMessageHandler.ts
@@ -1,0 +1,19 @@
+import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
+import type { ActionMenuService } from '../services'
+
+import { MenuRequestMessage } from '../messages'
+
+export class MenuRequestMessageHandler implements Handler {
+  private actionMenuService: ActionMenuService
+  public supportedMessages = [MenuRequestMessage]
+
+  public constructor(actionMenuService: ActionMenuService) {
+    this.actionMenuService = actionMenuService
+  }
+
+  public async handle(inboundMessage: HandlerInboundMessage<MenuRequestMessageHandler>) {
+    inboundMessage.assertReadyConnection()
+
+    await this.actionMenuService.processRequest(inboundMessage)
+  }
+}

--- a/packages/core/src/modules/action-menu/handlers/PerformMessageHandler.ts
+++ b/packages/core/src/modules/action-menu/handlers/PerformMessageHandler.ts
@@ -1,0 +1,19 @@
+import type { Handler, HandlerInboundMessage } from '../../../agent/Handler'
+import type { ActionMenuService } from '../services'
+
+import { PerformMessage } from '../messages'
+
+export class PerformMessageHandler implements Handler {
+  private actionMenuService: ActionMenuService
+  public supportedMessages = [PerformMessage]
+
+  public constructor(actionMenuService: ActionMenuService) {
+    this.actionMenuService = actionMenuService
+  }
+
+  public async handle(inboundMessage: HandlerInboundMessage<PerformMessageHandler>) {
+    inboundMessage.assertReadyConnection()
+
+    await this.actionMenuService.processPerform(inboundMessage)
+  }
+}

--- a/packages/core/src/modules/action-menu/handlers/index.ts
+++ b/packages/core/src/modules/action-menu/handlers/index.ts
@@ -1,0 +1,3 @@
+export * from './MenuMessageHandler'
+export * from './MenuRequestMessageHandler'
+export * from './PerformMessageHandler'

--- a/packages/core/src/modules/action-menu/index.ts
+++ b/packages/core/src/modules/action-menu/index.ts
@@ -1,0 +1,4 @@
+export * from './ActionMenuModule'
+export * from './handlers'
+export * from './messages'
+export * from './services'

--- a/packages/core/src/modules/action-menu/messages/MenuMessage.ts
+++ b/packages/core/src/modules/action-menu/messages/MenuMessage.ts
@@ -1,0 +1,53 @@
+import type { ActionMenuOptionOptions } from '../models'
+
+import { Type } from 'class-transformer'
+import { IsInstance, IsOptional, IsString } from 'class-validator'
+
+import { AgentMessage } from '../../../agent/AgentMessage'
+import { IsValidMessageType, parseMessageType } from '../../../utils/messageType'
+import { ActionMenuOption } from '../models'
+
+export interface MenuMessageOptions {
+  id?: string
+  title: string
+  description: string
+  errormsg?: string
+  options: ActionMenuOptionOptions[]
+  threadId?: string
+}
+
+export class MenuMessage extends AgentMessage {
+  public constructor(options: MenuMessageOptions) {
+    super()
+
+    if (options) {
+      this.id = options.id ?? this.generateId()
+      this.title = options.title
+      this.description = options.description
+      this.options = options.options.map((p) => new ActionMenuOption(p))
+      if (options.threadId) {
+        this.setThread({
+          threadId: options.threadId,
+        })
+      }
+    }
+  }
+
+  @IsValidMessageType(MenuMessage.type)
+  public readonly type = MenuMessage.type.messageTypeUri
+  public static readonly type = parseMessageType('https://didcomm.org/action-menu/1.0/menu')
+
+  @IsString()
+  public title!: string
+
+  @IsString()
+  public description!: string
+
+  @IsString()
+  @IsOptional()
+  public errormsg?: string
+
+  @IsInstance(ActionMenuOption, { each: true })
+  @Type(() => ActionMenuOption)
+  public options!: ActionMenuOption[]
+}

--- a/packages/core/src/modules/action-menu/messages/MenuRequestMessage.ts
+++ b/packages/core/src/modules/action-menu/messages/MenuRequestMessage.ts
@@ -1,0 +1,20 @@
+import { AgentMessage } from '../../../agent/AgentMessage'
+import { IsValidMessageType, parseMessageType } from '../../../utils/messageType'
+
+export interface MenuRequestMessageOptions {
+  id?: string
+}
+
+export class MenuRequestMessage extends AgentMessage {
+  public constructor(options: MenuRequestMessageOptions) {
+    super()
+
+    if (options) {
+      this.id = options.id ?? this.generateId()
+    }
+  }
+
+  @IsValidMessageType(MenuRequestMessage.type)
+  public readonly type = MenuRequestMessage.type.messageTypeUri
+  public static readonly type = parseMessageType('https://didcomm.org/action-menu/1.0/menu-request')
+}

--- a/packages/core/src/modules/action-menu/messages/PerformMessage.ts
+++ b/packages/core/src/modules/action-menu/messages/PerformMessage.ts
@@ -1,0 +1,37 @@
+import { IsOptional, IsString } from 'class-validator'
+
+import { AgentMessage } from '../../../agent/AgentMessage'
+import { IsValidMessageType, parseMessageType } from '../../../utils/messageType'
+
+export interface PerformMessageOptions {
+  id?: string
+  name: string
+  params?: Record<string, string>
+  threadId: string
+}
+
+export class PerformMessage extends AgentMessage {
+  public constructor(options: PerformMessageOptions) {
+    super()
+
+    if (options) {
+      this.id = options.id ?? this.generateId()
+      this.name = options.name
+      this.params = options.params
+      this.setThread({
+        threadId: options.threadId,
+      })
+    }
+  }
+
+  @IsValidMessageType(PerformMessage.type)
+  public readonly type = PerformMessage.type.messageTypeUri
+  public static readonly type = parseMessageType('https://didcomm.org/action-menu/1.0/perform')
+
+  @IsString()
+  public name!: string
+
+  @IsString({ each: true })
+  @IsOptional()
+  public params?: Record<string, string>
+}

--- a/packages/core/src/modules/action-menu/messages/index.ts
+++ b/packages/core/src/modules/action-menu/messages/index.ts
@@ -1,0 +1,3 @@
+export * from './MenuMessage'
+export * from './MenuRequestMessage'
+export * from './PerformMessage'

--- a/packages/core/src/modules/action-menu/models/ActionMenu.ts
+++ b/packages/core/src/modules/action-menu/models/ActionMenu.ts
@@ -1,0 +1,32 @@
+import type { ActionMenuOptionOptions } from './ActionMenuOption'
+
+import { Type } from 'class-transformer'
+import { IsInstance, IsString } from 'class-validator'
+
+import { ActionMenuOption } from './ActionMenuOption'
+
+export interface ActionMenuOptions {
+  title: string
+  description: string
+  options: ActionMenuOptionOptions[]
+}
+
+export class ActionMenu {
+  public constructor(options: ActionMenuOptions) {
+    if (options) {
+      this.title = options.title
+      this.description = options.description
+      this.options = options.options.map((p) => new ActionMenuOption(p))
+    }
+  }
+
+  @IsString()
+  public title!: string
+
+  @IsString()
+  public description!: string
+
+  @IsInstance(ActionMenuOption, { each: true })
+  @Type(() => ActionMenuOption)
+  public options!: ActionMenuOption[]
+}

--- a/packages/core/src/modules/action-menu/models/ActionMenuOption.ts
+++ b/packages/core/src/modules/action-menu/models/ActionMenuOption.ts
@@ -1,0 +1,46 @@
+import type { ActionMenuFormOptions } from './ActionMenuOptionForm'
+
+import { Type } from 'class-transformer'
+import { IsBoolean, IsInstance, IsOptional, IsString } from 'class-validator'
+
+import { ActionMenuForm } from './ActionMenuOptionForm'
+
+export interface ActionMenuOptionOptions {
+  name: string
+  title: string
+  description: string
+  disabled?: boolean
+  form?: ActionMenuFormOptions
+}
+
+export class ActionMenuOption {
+  public constructor(options: ActionMenuOptionOptions) {
+    if (options) {
+      this.name = options.name
+      this.title = options.title
+      this.description = options.description
+      this.disabled = options.disabled
+      if (options.form) {
+        this.form = new ActionMenuForm(options.form)
+      }
+    }
+  }
+
+  @IsString()
+  public name!: string
+
+  @IsString()
+  public title!: string
+
+  @IsString()
+  public description!: string
+
+  @IsBoolean()
+  @IsOptional()
+  public disabled?: boolean
+
+  @IsInstance(ActionMenuForm)
+  @Type(() => ActionMenuForm)
+  @IsOptional()
+  public form?: ActionMenuForm
+}

--- a/packages/core/src/modules/action-menu/models/ActionMenuOptionForm.ts
+++ b/packages/core/src/modules/action-menu/models/ActionMenuOptionForm.ts
@@ -1,0 +1,33 @@
+import type { ActionMenuFormParameterOptions } from './ActionMenuOptionFormParameter'
+
+import { Expose, Type } from 'class-transformer'
+import { IsInstance, IsString } from 'class-validator'
+
+import { ActionMenuFormParameter } from './ActionMenuOptionFormParameter'
+
+export interface ActionMenuFormOptions {
+  description: string
+  params: ActionMenuFormParameterOptions[]
+  submitLabel: string
+}
+
+export class ActionMenuForm {
+  public constructor(options: ActionMenuFormOptions) {
+    if (options) {
+      this.description = options.description
+      this.params = options.params.map((p) => new ActionMenuFormParameter(p))
+      this.submitLabel = options.submitLabel
+    }
+  }
+
+  @IsString()
+  public description!: string
+
+  @Expose({ name: 'submit-label' })
+  @IsString()
+  public submitLabel!: string
+
+  @IsInstance(ActionMenuFormParameter, { each: true })
+  @Type(() => ActionMenuFormParameter)
+  public params!: ActionMenuFormParameter[]
+}

--- a/packages/core/src/modules/action-menu/models/ActionMenuOptionFormParameter.ts
+++ b/packages/core/src/modules/action-menu/models/ActionMenuOptionFormParameter.ts
@@ -1,0 +1,48 @@
+import { IsBoolean, IsEnum, IsOptional, IsString } from 'class-validator'
+
+export enum ActionMenuFormInputType {
+  Text = 'text',
+}
+
+export interface ActionMenuFormParameterOptions {
+  name: string
+  title: string
+  default?: string
+  description: string
+  required?: boolean
+  type?: ActionMenuFormInputType
+}
+
+export class ActionMenuFormParameter {
+  public constructor(options: ActionMenuFormParameterOptions) {
+    if (options) {
+      this.name = options.name
+      this.title = options.title
+      this.default = options.default
+      this.description = options.description
+      this.required = options.required
+      this.type = options.type
+    }
+  }
+
+  @IsString()
+  public name!: string
+
+  @IsString()
+  public title!: string
+
+  @IsString()
+  @IsOptional()
+  public default?: string
+
+  @IsString()
+  public description!: string
+
+  @IsBoolean()
+  @IsOptional()
+  public required?: boolean
+
+  @IsEnum(ActionMenuFormInputType)
+  @IsOptional()
+  public type?: ActionMenuFormInputType
+}

--- a/packages/core/src/modules/action-menu/models/ActionMenuSelection.ts
+++ b/packages/core/src/modules/action-menu/models/ActionMenuSelection.ts
@@ -1,0 +1,22 @@
+import { IsOptional, IsString } from 'class-validator'
+
+export interface ActionMenuSelectionOptions {
+  name: string
+  params?: Record<string, string>
+}
+
+export class ActionMenuSelection {
+  public constructor(options: ActionMenuSelectionOptions) {
+    if (options) {
+      this.name = options.name
+      this.params = options.params
+    }
+  }
+
+  @IsString()
+  public name!: string
+
+  @IsString({ each: true })
+  @IsOptional()
+  public params?: Record<string, string>
+}

--- a/packages/core/src/modules/action-menu/models/index.ts
+++ b/packages/core/src/modules/action-menu/models/index.ts
@@ -1,0 +1,5 @@
+export * from './ActionMenu'
+export * from './ActionMenuOption'
+export * from './ActionMenuOptionForm'
+export * from './ActionMenuOptionFormParameter'
+export * from './ActionMenuSelection'

--- a/packages/core/src/modules/action-menu/repository/ActionMenuRecord.ts
+++ b/packages/core/src/modules/action-menu/repository/ActionMenuRecord.ts
@@ -1,0 +1,94 @@
+import type { TagsBase } from '../../../storage/BaseRecord'
+import type { ActionMenuRole } from '../ActionMenuRole'
+import type { ActionMenuState } from '../ActionMenuState'
+
+import { Type } from 'class-transformer'
+
+import { AriesFrameworkError } from '../../../error'
+import { BaseRecord } from '../../../storage/BaseRecord'
+import { uuid } from '../../../utils/uuid'
+import { ActionMenuSelection, ActionMenu } from '../models'
+
+export interface ActionMenuRecordProps {
+  id?: string
+  state: ActionMenuState
+  role: ActionMenuRole
+  createdAt?: Date
+  connectionId: string
+  threadId: string
+  menu?: ActionMenu
+  performSelection?: ActionMenuSelection
+  tags?: CustomActionMenuTags
+}
+
+export type CustomActionMenuTags = TagsBase
+
+export type DefaultActionMenuTags = {
+  role: ActionMenuRole
+  connectionId: string
+  state: ActionMenuState
+  threadId: string
+}
+
+export class ActionMenuRecord
+  extends BaseRecord<DefaultActionMenuTags, CustomActionMenuTags>
+  implements ActionMenuRecordProps
+{
+  public state!: ActionMenuState
+  public role!: ActionMenuRole
+  public connectionId!: string
+  public threadId!: string
+
+  @Type(() => ActionMenu)
+  public menu?: ActionMenu
+
+  @Type(() => ActionMenuSelection)
+  public performedAction?: ActionMenuSelection
+
+  public static readonly type = 'ActionMenuRecord'
+  public readonly type = ActionMenuRecord.type
+
+  public constructor(props: ActionMenuRecordProps) {
+    super()
+
+    if (props) {
+      this.id = props.id ?? uuid()
+      this.createdAt = props.createdAt ?? new Date()
+      this.connectionId = props.connectionId
+      this.threadId = props.threadId
+      this.state = props.state
+      this.role = props.role
+      this.menu = props.menu
+      this.performedAction = props.performSelection
+      this._tags = props.tags ?? {}
+    }
+  }
+
+  public getTags() {
+    return {
+      ...this._tags,
+      state: this.state,
+      role: this.role,
+      connectionId: this.connectionId,
+      threadId: this.threadId,
+    }
+  }
+
+  public assertState(expectedStates: ActionMenuState | ActionMenuState[]) {
+    if (!Array.isArray(expectedStates)) {
+      expectedStates = [expectedStates]
+    }
+
+    if (!expectedStates.includes(this.state)) {
+      throw new AriesFrameworkError(
+        `Action Menu record is in invalid state ${this.state}. Valid states are: ${expectedStates.join(', ')}.`
+      )
+    }
+  }
+
+  public assertRole(expectedRole: ActionMenuRole) {
+    if (this.role !== expectedRole) {
+      throw new AriesFrameworkError(`Action Menu record has invalid role ${this.role}. Expected role ${expectedRole}.`)
+    }
+  }
+}

--- a/packages/core/src/modules/action-menu/repository/ActionMenuRepository.ts
+++ b/packages/core/src/modules/action-menu/repository/ActionMenuRepository.ts
@@ -1,0 +1,17 @@
+import { EventEmitter } from '../../../agent/EventEmitter'
+import { InjectionSymbols } from '../../../constants'
+import { inject, injectable } from '../../../plugins'
+import { Repository } from '../../../storage/Repository'
+import { StorageService } from '../../../storage/StorageService'
+
+import { ActionMenuRecord } from './ActionMenuRecord'
+
+@injectable()
+export class ActionMenuRepository extends Repository<ActionMenuRecord> {
+  public constructor(
+    @inject(InjectionSymbols.StorageService) storageService: StorageService<ActionMenuRecord>,
+    eventEmitter: EventEmitter
+  ) {
+    super(ActionMenuRecord, storageService, eventEmitter)
+  }
+}

--- a/packages/core/src/modules/action-menu/repository/index.ts
+++ b/packages/core/src/modules/action-menu/repository/index.ts
@@ -1,0 +1,2 @@
+export * from './ActionMenuRepository'
+export * from './ActionMenuRecord'

--- a/packages/core/src/modules/action-menu/services/ActionMenuService.ts
+++ b/packages/core/src/modules/action-menu/services/ActionMenuService.ts
@@ -1,0 +1,282 @@
+import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
+import type { Logger } from '../../../logger'
+import type { ActionMenuStateChangedEvent } from '../ActionMenuEvents'
+import type { FindActiveMenuOptions } from '../ActionMenuModuleOptions'
+import type { CreateMenuOptions, CreatePerformOptions, CreateRequestOptions } from './ActionMenuServiceOptions'
+
+import { AgentConfig } from '../../../agent/AgentConfig'
+import { EventEmitter } from '../../../agent/EventEmitter'
+import { AriesFrameworkError } from '../../../error'
+import { injectable } from '../../../plugins'
+import { JsonTransformer } from '../../../utils'
+import { ActionMenuEventTypes } from '../ActionMenuEvents'
+import { ActionMenuRole } from '../ActionMenuRole'
+import { ActionMenuState } from '../ActionMenuState'
+import { PerformMessage, MenuMessage, MenuRequestMessage } from '../messages'
+import { ActionMenuSelection, ActionMenu } from '../models'
+import { ActionMenuRepository, ActionMenuRecord } from '../repository'
+
+@injectable()
+export class ActionMenuService {
+  private actionMenuRepository: ActionMenuRepository
+  private eventEmitter: EventEmitter
+  private logger: Logger
+
+  public constructor(actionMenuRepository: ActionMenuRepository, agentConfig: AgentConfig, eventEmitter: EventEmitter) {
+    this.actionMenuRepository = actionMenuRepository
+    this.eventEmitter = eventEmitter
+    this.logger = agentConfig.logger
+  }
+
+  public async createRequest(options: CreateRequestOptions) {
+    // Assert
+    options.connection.assertReady()
+
+    // Create message
+    const menuRequestMessage = new MenuRequestMessage({})
+
+    // Create record if not existant for connection/role
+    let actionMenuRecord = await this.findActive({
+      connectionId: options.connection.id,
+      role: ActionMenuRole.Requester,
+    })
+
+    if (actionMenuRecord) {
+      const previousState = actionMenuRecord.state
+      actionMenuRecord.state = ActionMenuState.AwaitingRootMenu
+      actionMenuRecord.threadId = menuRequestMessage.id
+
+      await this.actionMenuRepository.update(actionMenuRecord)
+      this.emitStateChangedEvent(actionMenuRecord, previousState)
+    } else {
+      actionMenuRecord = new ActionMenuRecord({
+        connectionId: options.connection.id,
+        role: ActionMenuRole.Requester,
+        state: ActionMenuState.AwaitingRootMenu,
+        threadId: menuRequestMessage.id,
+      })
+
+      await this.actionMenuRepository.save(actionMenuRecord)
+      this.emitStateChangedEvent(actionMenuRecord, null)
+    }
+
+    return { message: menuRequestMessage, record: actionMenuRecord }
+  }
+
+  public async processRequest(messageContext: InboundMessageContext<MenuRequestMessage>) {
+    const { message: menuRequestMessage } = messageContext
+
+    this.logger.debug(`Processing menu request with id ${menuRequestMessage.id}`)
+
+    // Assert
+    const connection = messageContext.assertReadyConnection()
+
+    let actionMenuRecord = await this.findActive({
+      connectionId: connection.id,
+      role: ActionMenuRole.Responder,
+    })
+
+    if (actionMenuRecord) {
+      const previousState = actionMenuRecord.state
+      actionMenuRecord.state = ActionMenuState.PreparingRootMenu
+      actionMenuRecord.threadId = menuRequestMessage.id
+
+      await this.actionMenuRepository.update(actionMenuRecord)
+      this.emitStateChangedEvent(actionMenuRecord, previousState)
+    } else {
+      // Create record
+      actionMenuRecord = new ActionMenuRecord({
+        connectionId: connection.id,
+        role: ActionMenuRole.Responder,
+        state: ActionMenuState.PreparingRootMenu,
+        threadId: menuRequestMessage.id,
+      })
+
+      await this.actionMenuRepository.save(actionMenuRecord)
+      this.emitStateChangedEvent(actionMenuRecord, null)
+    }
+
+    return actionMenuRecord
+  }
+
+  public async createMenu(options: CreateMenuOptions) {
+    // Assert connection ready
+    options.connection.assertReady()
+
+    // Create message
+    const menuMessage = new MenuMessage({
+      title: options.menu.title,
+      description: options.menu.description,
+      options: options.menu.options,
+    })
+
+    // Check if there is an existing menu for this connection and role
+    let actionMenuRecord = await this.findActive({
+      connectionId: options.connection.id,
+      role: ActionMenuRole.Responder,
+    })
+
+    // If so, continue existing flow
+    if (actionMenuRecord) {
+      actionMenuRecord.assertState([ActionMenuState.PreparingRootMenu, ActionMenuState.Done])
+
+      const previousState = actionMenuRecord.state
+      actionMenuRecord.state = ActionMenuState.AwaitingSelection
+
+      // The new menu will be bound to the existing thread
+      menuMessage.setThread({ threadId: actionMenuRecord.threadId })
+
+      await this.actionMenuRepository.update(actionMenuRecord)
+      this.emitStateChangedEvent(actionMenuRecord, previousState)
+    } else {
+      // Create record
+      actionMenuRecord = new ActionMenuRecord({
+        connectionId: options.connection.id,
+        role: ActionMenuRole.Responder,
+        state: ActionMenuState.AwaitingSelection,
+        threadId: menuMessage.id,
+      })
+
+      await this.actionMenuRepository.save(actionMenuRecord)
+      this.emitStateChangedEvent(actionMenuRecord, null)
+    }
+
+    return { message: menuMessage, record: actionMenuRecord }
+  }
+
+  public async processMenu(messageContext: InboundMessageContext<MenuMessage>) {
+    const { message: menuMessage } = messageContext
+
+    this.logger.debug(`Processing action menu with id ${menuMessage.id}`)
+
+    // Assert
+    const connection = messageContext.assertReadyConnection()
+
+    // Check if there is an existing menu for this connection and role
+    const record = await this.findActive({
+      connectionId: connection.id,
+      role: ActionMenuRole.Requester,
+    })
+
+    if (record) {
+      // Record found: check state and update with menu details
+      record.assertState([ActionMenuState.Null, ActionMenuState.AwaitingRootMenu])
+
+      const previousState = record.state
+
+      record.state = ActionMenuState.PreparingSelection
+      record.menu = new ActionMenu({
+        title: menuMessage.title,
+        description: menuMessage.description,
+        options: menuMessage.options,
+      })
+      record.threadId = menuMessage.threadId
+
+      await this.actionMenuRepository.update(record)
+
+      this.emitStateChangedEvent(record, previousState)
+    } else {
+      // Record not found: create it
+      const actionMenuRecord = new ActionMenuRecord({
+        connectionId: connection.id,
+        role: ActionMenuRole.Requester,
+        state: ActionMenuState.PreparingSelection,
+        threadId: menuMessage.id,
+        menu: new ActionMenu({
+          title: menuMessage.title,
+          description: menuMessage.description,
+          options: menuMessage.options,
+        }),
+      })
+
+      await this.actionMenuRepository.save(actionMenuRecord)
+
+      this.emitStateChangedEvent(actionMenuRecord, null)
+    }
+  }
+
+  public async createPerform(options: CreatePerformOptions) {
+    const { actionMenuRecord: record, performedAction: performedSelection } = options
+
+    // Assert
+    record.assertRole(ActionMenuRole.Requester)
+    record.assertState([ActionMenuState.PreparingSelection])
+
+    const previousState = record.state
+
+    // Create message
+    const menuMessage = new PerformMessage({
+      name: performedSelection.name,
+      params: performedSelection.params,
+      threadId: record.threadId,
+    })
+
+    // Update record
+    record.performedAction = options.performedAction
+    record.state = ActionMenuState.Done
+
+    await this.actionMenuRepository.update(record)
+
+    this.emitStateChangedEvent(record, previousState)
+
+    return { message: menuMessage, record }
+  }
+
+  public async processPerform(messageContext: InboundMessageContext<PerformMessage>) {
+    const { message: performMessage } = messageContext
+
+    this.logger.debug(`Processing action menu perform with id ${performMessage.id}`)
+
+    const connection = messageContext.assertReadyConnection()
+
+    // Check if there is an existing menu for this connection and role
+    const record = await this.findActive({
+      connectionId: connection.id,
+      role: ActionMenuRole.Responder,
+    })
+
+    if (record) {
+      // Record found: check role and update with menu details
+      record.assertRole(ActionMenuRole.Responder)
+      record.assertState([ActionMenuState.AwaitingSelection])
+
+      const previousState = record.state
+
+      record.state = ActionMenuState.Done
+      record.performedAction = new ActionMenuSelection({ name: performMessage.name, params: performMessage.params })
+
+      await this.actionMenuRepository.update(record)
+
+      this.emitStateChangedEvent(record, previousState)
+    } else {
+      throw new AriesFrameworkError(`No Action Menu found with thread id ${messageContext.message.threadId}`)
+    }
+  }
+
+  public async findByThreadId(threadId: string) {
+    return await this.actionMenuRepository.findSingleByQuery({ threadId })
+  }
+
+  public async findById(actionMenuRecordId: string) {
+    return await this.actionMenuRepository.findById(actionMenuRecordId)
+  }
+
+  public async findActive(options: FindActiveMenuOptions) {
+    return await this.actionMenuRepository.findSingleByQuery({
+      connectionId: options.connectionId,
+      role: options.role,
+    })
+  }
+
+  private emitStateChangedEvent(actionMenuRecord: ActionMenuRecord, previousState: ActionMenuState | null) {
+    const clonedRecord = JsonTransformer.clone(actionMenuRecord)
+
+    this.eventEmitter.emit<ActionMenuStateChangedEvent>({
+      type: ActionMenuEventTypes.ActionMenuStateChanged,
+      payload: {
+        actionMenuRecord: clonedRecord,
+        previousState: previousState,
+      },
+    })
+  }
+}

--- a/packages/core/src/modules/action-menu/services/ActionMenuServiceOptions.ts
+++ b/packages/core/src/modules/action-menu/services/ActionMenuServiceOptions.ts
@@ -1,0 +1,29 @@
+import type { ConnectionRecord } from '../../connections'
+import type { ActionMenuRole } from '../ActionMenuRole'
+import type { ActionMenuSelection } from '../models'
+import type { ActionMenu } from '../models/ActionMenu'
+import type { ActionMenuRecord } from '../repository'
+
+export interface CreateRequestOptions {
+  connection: ConnectionRecord
+}
+
+export interface CreateMenuOptions {
+  connection: ConnectionRecord
+  menu: ActionMenu
+}
+
+export interface CreateMenuAsResponseOptions {
+  actionMenuRecord: ActionMenuRecord
+  menu: ActionMenu
+}
+
+export interface CreatePerformOptions {
+  actionMenuRecord: ActionMenuRecord
+  performedAction: ActionMenuSelection
+}
+
+export interface FindActiveMenuOptions {
+  connectionId: string
+  role: ActionMenuRole
+}

--- a/packages/core/src/modules/action-menu/services/index.ts
+++ b/packages/core/src/modules/action-menu/services/index.ts
@@ -1,0 +1,1 @@
+export * from './ActionMenuService'

--- a/packages/core/tests/action-menu.test.ts
+++ b/packages/core/tests/action-menu.test.ts
@@ -1,0 +1,122 @@
+import type { SubjectMessage } from '../../../tests/transport/SubjectInboundTransport'
+import type { ConnectionRecord } from '../src'
+
+import { Subject } from 'rxjs'
+
+import { SubjectInboundTransport } from '../../../tests/transport/SubjectInboundTransport'
+import { SubjectOutboundTransport } from '../../../tests/transport/SubjectOutboundTransport'
+import { Agent } from '../src'
+import { ActionMenuRole } from '../src/modules/action-menu/ActionMenuRole'
+import { ActionMenuState } from '../src/modules/action-menu/ActionMenuState'
+import { ActionMenu } from '../src/modules/action-menu/models'
+import { ActionMenuRecord } from '../src/modules/action-menu/repository'
+
+import { getBaseConfig, makeConnection, waitForActionMenuRecord } from './helpers'
+import testLogger from './logger'
+
+const faberConfig = getBaseConfig('Faber Action Menu', {
+  endpoints: ['rxjs:faber'],
+})
+
+const aliceConfig = getBaseConfig('Alice Action Menu', {
+  endpoints: ['rxjs:alice'],
+  logger: testLogger,
+})
+
+describe('Action Menu', () => {
+  let faberAgent: Agent
+  let aliceAgent: Agent
+  let faberConnection: ConnectionRecord
+  let aliceConnection: ConnectionRecord
+
+  beforeAll(async () => {
+    const faberMessages = new Subject<SubjectMessage>()
+    const aliceMessages = new Subject<SubjectMessage>()
+    const subjectMap = {
+      'rxjs:faber': faberMessages,
+      'rxjs:alice': aliceMessages,
+    }
+
+    faberAgent = new Agent(faberConfig.config, faberConfig.agentDependencies)
+    faberAgent.registerInboundTransport(new SubjectInboundTransport(faberMessages))
+    faberAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    await faberAgent.initialize()
+
+    aliceAgent = new Agent(aliceConfig.config, aliceConfig.agentDependencies)
+    aliceAgent.registerInboundTransport(new SubjectInboundTransport(aliceMessages))
+    aliceAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    await aliceAgent.initialize()
+    ;[aliceConnection, faberConnection] = await makeConnection(aliceAgent, faberAgent)
+  })
+
+  afterAll(async () => {
+    await faberAgent.shutdown()
+    await faberAgent.wallet.delete()
+    await aliceAgent.shutdown()
+    await aliceAgent.wallet.delete()
+  })
+
+  test('Alice requests menu to Faber and selects an option once received', async () => {
+    testLogger.test('Alice sends menu request to Faber')
+    let aliceActionMenuRecord = await aliceAgent.actionMenu.requestMenu({ connectionId: aliceConnection.id })
+
+    testLogger.test('Faber waits for menu request from Alice')
+    await waitForActionMenuRecord(faberAgent, {
+      state: ActionMenuState.PreparingRootMenu,
+    })
+
+    const menu = new ActionMenu({
+      title: 'Welcome',
+      description: 'This is the root menu',
+      options: [
+        {
+          name: 'option-1',
+          description: 'Option 1 description',
+          title: 'Option 1',
+        },
+        {
+          name: 'option-2',
+          description: 'Option 2 description',
+          title: 'Option 2',
+        },
+      ],
+    })
+    testLogger.test('Faber sends root menu to Alice')
+    await faberAgent.actionMenu.sendMenu({ connectionId: faberConnection.id, menu })
+
+    testLogger.test('Alice waits until she receives menu')
+    aliceActionMenuRecord = await waitForActionMenuRecord(aliceAgent, {
+      state: ActionMenuState.PreparingSelection,
+    })
+
+    expect(aliceActionMenuRecord.menu).toEqual(menu)
+    const faberActiveMenu = await faberAgent.actionMenu.findActiveMenu({
+      connectionId: faberConnection.id,
+      role: ActionMenuRole.Responder,
+    })
+    expect(faberActiveMenu).toBeInstanceOf(ActionMenuRecord)
+    expect(faberActiveMenu?.state).toBe(ActionMenuState.AwaitingSelection)
+
+    testLogger.test('Alice selects menu item')
+    await aliceAgent.actionMenu.performAction({
+      connectionId: aliceConnection.id,
+      performedAction: { name: 'option-1' },
+    })
+
+    testLogger.test('Faber waits for menu selection from Alice')
+    await waitForActionMenuRecord(faberAgent, {
+      state: ActionMenuState.Done,
+    })
+
+    // Related Alice's Action Menu Record state should be changed
+    aliceAgent.actionMenu.findActiveMenu({ connectionId: aliceConnection.id, role: ActionMenuRole.Responder })
+
+    // As Alice has responded, menu should be closed (done state)
+    const aliceActiveMenu = await faberAgent.actionMenu.findActiveMenu({
+      connectionId: faberConnection.id,
+      role: ActionMenuRole.Responder,
+    })
+    expect(aliceActiveMenu).toBeInstanceOf(ActionMenuRecord)
+    expect(aliceActiveMenu?.state).toBe(ActionMenuState.Done)
+  })
+})


### PR DESCRIPTION
Implementation of module fully supporting [Aries RFC 0509](https://github.com/hyperledger/aries-rfcs/blob/main/features/0509-action-menu/README.md) for both `requester` and `responder` roles.

Protocol states and information are stored in records of type `ActionMenuRecord`. As this protocol currently defines a single active menu per connection, there will be at most 2 records per connection (as theoretically is possible to serve as requester and responder at the same time). While this information could be stored also in Connection Metadata, specific records were created thinking in a future version/extension of this protocol where multiple menus could be deployed (e.g. a menu by thread).

Still plenty of tests to do and fixes/support for error messages, as well as check compatibility with ACA-Py implementation.

Solves #471 
Signed-off-by: Ariel Gentile <gentilester@gmail.com>