### PR TITLE
fix(question-answer): question answer protocol state/role check

### DIFF
--- a/packages/core/src/modules/question-answer/QuestionAnswerModule.ts
+++ b/packages/core/src/modules/question-answer/QuestionAnswerModule.ts
@@ -1,5 +1,4 @@
 import type { DependencyManager } from '../../plugins'
-import type { ValidResponse } from './models'
 
 import { Dispatcher } from '../../agent/Dispatcher'
 import { MessageSender } from '../../agent/MessageSender'
@@ -8,6 +7,7 @@ import { injectable, module } from '../../plugins'
 import { ConnectionService } from '../connections'
 
 import { AnswerMessageHandler, QuestionMessageHandler } from './handlers'
+import { ValidResponse } from './models'
 import { QuestionAnswerRepository } from './repository'
 import { QuestionAnswerService } from './services'
 
@@ -51,7 +51,7 @@ export class QuestionAnswerModule {
 
     const { questionMessage, questionAnswerRecord } = await this.questionAnswerService.createQuestion(connectionId, {
       question: config.question,
-      validResponses: config.validResponses,
+      validResponses: config.validResponses.map((item) => new ValidResponse(item)),
       detail: config?.detail,
     })
     const outboundMessage = createOutboundMessage(connection, questionMessage)
@@ -90,6 +90,17 @@ export class QuestionAnswerModule {
    */
   public getAll() {
     return this.questionAnswerService.getAll()
+  }
+
+  /**
+   * Retrieve a question answer record by id
+   *
+   * @param questionAnswerId The questionAnswer record id
+   * @return The question answer record or null if not found
+   *
+   */
+  public findById(questionAnswerId: string) {
+    return this.questionAnswerService.findById(questionAnswerId)
   }
 
   private registerHandlers(dispatcher: Dispatcher) {

--- a/packages/core/src/modules/question-answer/__tests__/QuestionAnswerService.test.ts
+++ b/packages/core/src/modules/question-answer/__tests__/QuestionAnswerService.test.ts
@@ -5,10 +5,12 @@ import type { ValidResponse } from '../models'
 
 import { getAgentConfig, getMockConnection, mockFunction } from '../../../../tests/helpers'
 import { EventEmitter } from '../../../agent/EventEmitter'
+import { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
 import { IndyWallet } from '../../../wallet/IndyWallet'
+import { DidExchangeState } from '../../connections'
 import { QuestionAnswerEventTypes } from '../QuestionAnswerEvents'
 import { QuestionAnswerRole } from '../QuestionAnswerRole'
-import { QuestionMessage } from '../messages'
+import { AnswerMessage, QuestionMessage } from '../messages'
 import { QuestionAnswerState } from '../models'
 import { QuestionAnswerRecord, QuestionAnswerRepository } from '../repository'
 import { QuestionAnswerService } from '../services'
@@ -20,6 +22,7 @@ describe('QuestionAnswerService', () => {
   const mockConnectionRecord = getMockConnection({
     id: 'd3849ac3-c981-455b-a1aa-a10bea6cead8',
     did: 'did:sov:C2SsBf5QUQpqSAQfhu3sd2',
+    state: DidExchangeState.Completed,
   })
 
   let wallet: IndyWallet
@@ -129,7 +132,7 @@ describe('QuestionAnswerService', () => {
         eventListenerMock
       )
 
-      mockFunction(questionAnswerRepository.getSingleByQuery).mockReturnValue(Promise.resolve(mockRecord))
+      mockFunction(questionAnswerRepository.findSingleByQuery).mockReturnValue(Promise.resolve(mockRecord))
 
       await questionAnswerService.createAnswer(mockRecord, 'Yes')
 
@@ -146,5 +149,148 @@ describe('QuestionAnswerService', () => {
         },
       })
     })
+  })
+
+  describe('processReceiveQuestion', () => {
+    let mockRecord: QuestionAnswerRecord
+
+    beforeAll(() => {
+      mockRecord = mockQuestionAnswerRecord({
+        questionText: 'Alice, are you on the phone with Bob?',
+        connectionId: mockConnectionRecord.id,
+        role: QuestionAnswerRole.Responder,
+        signatureRequired: false,
+        state: QuestionAnswerState.QuestionReceived,
+        threadId: '123',
+        validResponses: [{ text: 'Yes' }, { text: 'No' }],
+      })
+    })
+
+    it('creates record when no previous question with that thread exists', async () => {
+      const questionMessage = new QuestionMessage({
+        questionText: 'Alice, are you on the phone with Bob?',
+        validResponses: [{ text: 'Yes' }, { text: 'No' }],
+      })
+
+      const messageContext = new InboundMessageContext(questionMessage, { connection: mockConnectionRecord })
+
+      const questionAnswerRecord = await questionAnswerService.processReceiveQuestion(messageContext)
+
+      expect(questionAnswerRecord).toMatchObject(
+        expect.objectContaining({
+          role: QuestionAnswerRole.Responder,
+          state: QuestionAnswerState.QuestionReceived,
+          threadId: questionMessage.id,
+          questionText: 'Alice, are you on the phone with Bob?',
+          validResponses: [{ text: 'Yes' }, { text: 'No' }],
+        })
+      )
+    })
+
+    it(`throws an error when question from the same thread exists `, async () => {
+      mockFunction(questionAnswerRepository.findSingleByQuery).mockReturnValue(Promise.resolve(mockRecord))
+
+      const questionMessage = new QuestionMessage({
+        id: '123',
+        questionText: 'Alice, are you on the phone with Bob?',
+        validResponses: [{ text: 'Yes' }, { text: 'No' }],
+      })
+
+      const messageContext = new InboundMessageContext(questionMessage, { connection: mockConnectionRecord })
+
+      expect(questionAnswerService.processReceiveQuestion(messageContext)).rejects.toThrowError(
+        `Question answer record with thread Id ${questionMessage.id} already exists.`
+      )
+      jest.resetAllMocks()
+    })
+  })
+
+  describe('receiveAnswer', () => {
+    let mockRecord: QuestionAnswerRecord
+
+    beforeAll(() => {
+      mockRecord = mockQuestionAnswerRecord({
+        questionText: 'Alice, are you on the phone with Bob?',
+        connectionId: mockConnectionRecord.id,
+        role: QuestionAnswerRole.Questioner,
+        signatureRequired: false,
+        state: QuestionAnswerState.QuestionReceived,
+        threadId: '123',
+        validResponses: [{ text: 'Yes' }, { text: 'No' }],
+      })
+    })
+
+    it('updates state and emits event when valid response is received', async () => {
+      mockRecord.state = QuestionAnswerState.QuestionSent
+      mockFunction(questionAnswerRepository.findSingleByQuery).mockReturnValue(Promise.resolve(mockRecord))
+
+      const answerMessage = new AnswerMessage({
+        response: 'Yes',
+        threadId: '123',
+      })
+
+      const messageContext = new InboundMessageContext(answerMessage, { connection: mockConnectionRecord })
+
+      const questionAnswerRecord = await questionAnswerService.receiveAnswer(messageContext)
+
+      expect(questionAnswerRecord).toMatchObject(
+        expect.objectContaining({
+          role: QuestionAnswerRole.Questioner,
+          state: QuestionAnswerState.AnswerReceived,
+          threadId: '123',
+          questionText: 'Alice, are you on the phone with Bob?',
+          validResponses: [{ text: 'Yes' }, { text: 'No' }],
+        })
+      )
+      jest.resetAllMocks()
+    })
+
+    it(`throws an error when no existing question is found`, async () => {
+      const answerMessage = new AnswerMessage({
+        response: 'Yes',
+        threadId: '123',
+      })
+
+      const messageContext = new InboundMessageContext(answerMessage, { connection: mockConnectionRecord })
+
+      expect(questionAnswerService.receiveAnswer(messageContext)).rejects.toThrowError(
+        `Question Answer record with thread Id ${answerMessage.threadId} not found.`
+      )
+    })
+
+    it(`throws an error when record is in invalid state`, async () => {
+      mockRecord.state = QuestionAnswerState.AnswerReceived
+      mockFunction(questionAnswerRepository.findSingleByQuery).mockReturnValue(Promise.resolve(mockRecord))
+
+      const answerMessage = new AnswerMessage({
+        response: 'Yes',
+        threadId: '123',
+      })
+
+      const messageContext = new InboundMessageContext(answerMessage, { connection: mockConnectionRecord })
+
+      expect(questionAnswerService.receiveAnswer(messageContext)).rejects.toThrowError(
+        `Question answer record is in invalid state ${mockRecord.state}. Valid states are: ${QuestionAnswerState.QuestionSent}`
+      )
+      jest.resetAllMocks()
+    })
+
+    it(`throws an error when record is in invalid role`, async () => {
+      mockRecord.state = QuestionAnswerState.QuestionSent
+      mockRecord.role = QuestionAnswerRole.Responder
+      mockFunction(questionAnswerRepository.findSingleByQuery).mockReturnValue(Promise.resolve(mockRecord))
+
+      const answerMessage = new AnswerMessage({
+        response: 'Yes',
+        threadId: '123',
+      })
+
+      const messageContext = new InboundMessageContext(answerMessage, { connection: mockConnectionRecord })
+
+      expect(questionAnswerService.receiveAnswer(messageContext)).rejects.toThrowError(
+        `Invalid question answer record role ${mockRecord.role}, expected is ${QuestionAnswerRole.Questioner}`
+      )
+    })
+    jest.resetAllMocks()
   })
 })

--- a/packages/core/src/modules/question-answer/__tests__/helpers.ts
+++ b/packages/core/src/modules/question-answer/__tests__/helpers.ts
@@ -1,0 +1,64 @@
+import type { Agent } from '../../../agent/Agent'
+import type { QuestionAnswerStateChangedEvent } from '../QuestionAnswerEvents'
+import type { QuestionAnswerRole } from '../QuestionAnswerRole'
+import type { QuestionAnswerState } from '../models'
+import type { Observable } from 'rxjs'
+
+import { catchError, filter, firstValueFrom, map, ReplaySubject, timeout } from 'rxjs'
+
+import { QuestionAnswerEventTypes } from '../QuestionAnswerEvents'
+
+export async function waitForQuestionAnswerRecord(
+  agent: Agent,
+  options: {
+    threadId?: string
+    role?: QuestionAnswerRole
+    state?: QuestionAnswerState
+    previousState?: QuestionAnswerState | null
+    timeoutMs?: number
+  }
+) {
+  const observable = agent.events.observable<QuestionAnswerStateChangedEvent>(
+    QuestionAnswerEventTypes.QuestionAnswerStateChanged
+  )
+
+  return waitForQuestionAnswerRecordSubject(observable, options)
+}
+
+export function waitForQuestionAnswerRecordSubject(
+  subject: ReplaySubject<QuestionAnswerStateChangedEvent> | Observable<QuestionAnswerStateChangedEvent>,
+  {
+    threadId,
+    role,
+    state,
+    previousState,
+    timeoutMs = 10000,
+  }: {
+    threadId?: string
+    role?: QuestionAnswerRole
+    state?: QuestionAnswerState
+    previousState?: QuestionAnswerState | null
+    timeoutMs?: number
+  }
+) {
+  const observable = subject instanceof ReplaySubject ? subject.asObservable() : subject
+  return firstValueFrom(
+    observable.pipe(
+      filter((e) => previousState === undefined || e.payload.previousState === previousState),
+      filter((e) => threadId === undefined || e.payload.questionAnswerRecord.threadId === threadId),
+      filter((e) => role === undefined || e.payload.questionAnswerRecord.role === role),
+      filter((e) => state === undefined || e.payload.questionAnswerRecord.state === state),
+      timeout(timeoutMs),
+      catchError(() => {
+        throw new Error(
+          `QuestionAnswerChangedEvent event not emitted within specified timeout: {
+    previousState: ${previousState},
+    threadId: ${threadId},
+    state: ${state}
+  }`
+        )
+      }),
+      map((e) => e.payload.questionAnswerRecord)
+    )
+  )
+}

--- a/packages/core/src/modules/question-answer/__tests__/question-answer.e2e.test.ts
+++ b/packages/core/src/modules/question-answer/__tests__/question-answer.e2e.test.ts
@@ -1,0 +1,92 @@
+import type { SubjectMessage } from '../../../../../../tests/transport/SubjectInboundTransport'
+import type { ConnectionRecord } from '../../connections/repository'
+
+import { Subject } from 'rxjs'
+
+import { SubjectInboundTransport } from '../../../../../../tests/transport/SubjectInboundTransport'
+import { SubjectOutboundTransport } from '../../../../../../tests/transport/SubjectOutboundTransport'
+import { getBaseConfig, makeConnection } from '../../../../tests/helpers'
+import testLogger from '../../../../tests/logger'
+import { Agent } from '../../../agent/Agent'
+import { QuestionAnswerRole } from '../QuestionAnswerRole'
+import { QuestionAnswerState } from '../models'
+
+import { waitForQuestionAnswerRecord } from './helpers'
+
+const bobConfig = getBaseConfig('Bob Question Answer', {
+  endpoints: ['rxjs:bob'],
+})
+
+const aliceConfig = getBaseConfig('Alice Question Answer', {
+  endpoints: ['rxjs:alice'],
+})
+
+describe('Question Answer', () => {
+  let bobAgent: Agent
+  let aliceAgent: Agent
+  let aliceConnection: ConnectionRecord
+
+  beforeEach(async () => {
+    const bobMessages = new Subject<SubjectMessage>()
+    const aliceMessages = new Subject<SubjectMessage>()
+    const subjectMap = {
+      'rxjs:bob': bobMessages,
+      'rxjs:alice': aliceMessages,
+    }
+
+    bobAgent = new Agent(bobConfig.config, bobConfig.agentDependencies)
+    bobAgent.registerInboundTransport(new SubjectInboundTransport(bobMessages))
+    bobAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    await bobAgent.initialize()
+
+    aliceAgent = new Agent(aliceConfig.config, aliceConfig.agentDependencies)
+    aliceAgent.registerInboundTransport(new SubjectInboundTransport(aliceMessages))
+    aliceAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    await aliceAgent.initialize()
+    ;[aliceConnection] = await makeConnection(aliceAgent, bobAgent)
+  })
+
+  afterEach(async () => {
+    await bobAgent.shutdown()
+    await bobAgent.wallet.delete()
+    await aliceAgent.shutdown()
+    await aliceAgent.wallet.delete()
+  })
+
+  test('Alice sends a question and Bob answers', async () => {
+    testLogger.test('Alice sends question to Bob')
+    let aliceQuestionAnswerRecord = await aliceAgent.questionAnswer.sendQuestion(aliceConnection.id, {
+      question: 'Do you want to play?',
+      validResponses: [{ text: 'Yes' }, { text: 'No' }],
+    })
+
+    testLogger.test('Bob waits for question from Alice')
+    const bobQuestionAnswerRecord = await waitForQuestionAnswerRecord(bobAgent, {
+      threadId: aliceQuestionAnswerRecord.threadId,
+      state: QuestionAnswerState.QuestionReceived,
+    })
+
+    expect(bobQuestionAnswerRecord.questionText).toEqual('Do you want to play?')
+    expect(bobQuestionAnswerRecord.validResponses).toEqual([{ text: 'Yes' }, { text: 'No' }])
+    testLogger.test('Bob sends answer to Alice')
+    await bobAgent.questionAnswer.sendAnswer(bobQuestionAnswerRecord.id, 'Yes')
+
+    testLogger.test('Alice waits until Bob answers')
+    aliceQuestionAnswerRecord = await waitForQuestionAnswerRecord(aliceAgent, {
+      threadId: aliceQuestionAnswerRecord.threadId,
+      state: QuestionAnswerState.AnswerReceived,
+    })
+
+    expect(aliceQuestionAnswerRecord.response).toEqual('Yes')
+
+    const retrievedRecord = await aliceAgent.questionAnswer.findById(aliceQuestionAnswerRecord.id)
+    expect(retrievedRecord).toMatchObject(
+      expect.objectContaining({
+        id: aliceQuestionAnswerRecord.id,
+        threadId: aliceQuestionAnswerRecord.threadId,
+        state: QuestionAnswerState.AnswerReceived,
+        role: QuestionAnswerRole.Questioner,
+      })
+    )
+  })
+})

--- a/packages/core/src/modules/question-answer/repository/QuestionAnswerRecord.ts
+++ b/packages/core/src/modules/question-answer/repository/QuestionAnswerRecord.ts
@@ -76,6 +76,12 @@ export class QuestionAnswerRecord extends BaseRecord<DefaultQuestionAnswerTags, 
     }
   }
 
+  public assertRole(expectedRole: QuestionAnswerRole) {
+    if (this.role !== expectedRole) {
+      throw new AriesFrameworkError(`Invalid question answer record role ${this.role}, expected is ${expectedRole}.`)
+    }
+  }
+
   public assertState(expectedStates: QuestionAnswerState | QuestionAnswerState[]) {
     if (!Array.isArray(expectedStates)) {
       expectedStates = [expectedStates]


### PR DESCRIPTION
Some fixes and additional checks in process methods from `QuestionAnswerService` that are preventing it to correctly accept/reject the received message.

Add some service tests as well as a simple E2E module test that allowed to find and fix a weird issue with parameter construction: `ValidResponse` takes another `ValidResponse` as input and this could make message validation to fail.

No API changes were introduced apart from adding a `findById` method.

Signed-off-by: Ariel Gentile <gentilester@gmail.com>