### PR TITLE
fix(ledger): remove poolConnected on pool close

### DIFF
--- a/packages/core/src/modules/ledger/IndyPool.ts
+++ b/packages/core/src/modules/ledger/IndyPool.ts
@@ -61,6 +61,7 @@ export class IndyPool {
     }
 
     this._poolHandle = undefined
+    this.poolConnected = undefined
 
     await this.indy.closePoolLedger(poolHandle)
   }


### PR DESCRIPTION
fixes issue where cannot reconnect to ledger after rotating wallet key

Signed-off-by: Niall Shaw <niall.shaw@absa.africa>