### PR TITLE
chore: add @janrtvld to maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,3 +10,4 @@
 | Karim Stekelenburg | [@karimStekelenburg](https://github.com/karimStekelenburg) | ssi_karim#3505   |
 | Timo Glastra       | [@TimoGlastra](https://github.com/TimoGlastra)             | TimoGlastra#2988 |
 | Ariel Gentile      | [@genaris](https://github.com/genaris)                     | GenAris#4962     |
+| Jan Rietveld       | [@janrtvld](https://github.com/janrtvld)                   | janrtvld#3868    |


### PR DESCRIPTION
Add @janrtvld to maintainers as discussed in [Discord](https://discord.com/channels/905194001349627914/941708033434738768/1016248809589850132).

Signed-off-by: Timo Glastra <timo@animo.id>