### PR TITLE
fix: avoid crash when an unexpected message arrives

### DIFF
--- a/packages/core/src/agent/Agent.ts
+++ b/packages/core/src/agent/Agent.ts
@@ -137,7 +137,13 @@ export class Agent {
       .observable<AgentMessageReceivedEvent>(AgentEventTypes.AgentMessageReceived)
       .pipe(
         takeUntil(this.agentConfig.stop$),
-        concatMap((e) => this.messageReceiver.receiveMessage(e.payload.message, { connection: e.payload.connection }))
+        concatMap((e) =>
+          this.messageReceiver
+            .receiveMessage(e.payload.message, { connection: e.payload.connection })
+            .catch((error) => {
+              this.logger.error('Failed to process message', { error })
+            })
+        )
       )
       .subscribe()
   }


### PR DESCRIPTION
Signed-off-by: Pavel Zarecky <zarecky@procivis.ch>

This catch block is added to avoid potential crash, when an unexpected message arrives from a connection.

See #1018
