### PR TITLE
feat: use did:key flag

### DIFF
--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -91,6 +91,16 @@ export class AgentConfig {
     return this.initConfig.maximumMediatorReconnectionIntervalMs ?? Number.POSITIVE_INFINITY
   }
 
+  /**
+   * Encode keys in did:key format instead of 'naked' keys, as stated in Aries RFC 0360.
+   *
+   * This setting will not be taken into account if the other party has previously used naked keys
+   * in a given protocol (i.e. it does not support Aries RFC 0360).
+   */
+  public get useDidKeyInProtocols() {
+    return this.initConfig.useDidKeyInProtocols ?? false
+  }
+
   public get endpoints(): [string, ...string[]] {
     // if endpoints is not set, return queue endpoint
     // https://github.com/hyperledger/aries-rfcs/issues/405#issuecomment-582612875

--- a/packages/core/src/modules/connections/repository/ConnectionMetadataTypes.ts
+++ b/packages/core/src/modules/connections/repository/ConnectionMetadataTypes.ts
@@ -1,0 +1,9 @@
+export enum ConnectionMetadataKeys {
+  UseDidKeysForProtocol = '_internal/useDidKeysForProtocol',
+}
+
+export type ConnectionMetadata = {
+  [ConnectionMetadataKeys.UseDidKeysForProtocol]: {
+    [protocolUri: string]: boolean
+  }
+}

--- a/packages/core/src/modules/connections/repository/ConnectionRecord.ts
+++ b/packages/core/src/modules/connections/repository/ConnectionRecord.ts
@@ -1,5 +1,6 @@
 import type { TagsBase } from '../../../storage/BaseRecord'
 import type { HandshakeProtocol } from '../models'
+import type { ConnectionMetadata } from './ConnectionMetadataTypes'
 
 import { AriesFrameworkError } from '../../../error'
 import { BaseRecord } from '../../../storage/BaseRecord'
@@ -39,7 +40,7 @@ export type DefaultConnectionTags = {
 }
 
 export class ConnectionRecord
-  extends BaseRecord<DefaultConnectionTags, CustomConnectionTags>
+  extends BaseRecord<DefaultConnectionTags, CustomConnectionTags, ConnectionMetadata>
   implements ConnectionRecordProps
 {
   public state!: DidExchangeState

--- a/packages/core/src/modules/dids/helpers.ts
+++ b/packages/core/src/modules/dids/helpers.ts
@@ -3,8 +3,12 @@ import { KeyType } from '../../crypto'
 import { Key } from './domain/Key'
 import { DidKey } from './methods/key'
 
+export function isDidKey(key: string) {
+  return key.startsWith('did:key')
+}
+
 export function didKeyToVerkey(key: string) {
-  if (key.startsWith('did:key')) {
+  if (isDidKey(key)) {
     const publicKeyBase58 = DidKey.fromDid(key).key.publicKeyBase58
     return publicKeyBase58
   }
@@ -12,7 +16,7 @@ export function didKeyToVerkey(key: string) {
 }
 
 export function verkeyToDidKey(key: string) {
-  if (key.startsWith('did:key')) {
+  if (isDidKey(key)) {
     return key
   }
   const publicKeyBase58 = key

--- a/packages/core/src/modules/routing/messages/KeylistUpdateMessage.ts
+++ b/packages/core/src/modules/routing/messages/KeylistUpdateMessage.ts
@@ -1,6 +1,5 @@
 import { Expose, Type } from 'class-transformer'
 import { IsArray, ValidateNested, IsString, IsEnum, IsInstance } from 'class-validator'
-import { Verkey } from 'indy-sdk'
 
 import { AgentMessage } from '../../../agent/AgentMessage'
 import { IsValidMessageType, parseMessageType } from '../../../utils/messageType'
@@ -11,7 +10,7 @@ export enum KeylistUpdateAction {
 }
 
 export class KeylistUpdate {
-  public constructor(options: { recipientKey: Verkey; action: KeylistUpdateAction }) {
+  public constructor(options: { recipientKey: string; action: KeylistUpdateAction }) {
     if (options) {
       this.recipientKey = options.recipientKey
       this.action = options.action
@@ -20,7 +19,7 @@ export class KeylistUpdate {
 
   @IsString()
   @Expose({ name: 'recipient_key' })
-  public recipientKey!: Verkey
+  public recipientKey!: string
 
   @IsEnum(KeylistUpdateAction)
   public action!: KeylistUpdateAction

--- a/packages/core/src/modules/routing/messages/KeylistUpdateResponseMessage.ts
+++ b/packages/core/src/modules/routing/messages/KeylistUpdateResponseMessage.ts
@@ -1,6 +1,5 @@
 import { Expose, Type } from 'class-transformer'
 import { IsArray, IsEnum, IsInstance, IsString, ValidateNested } from 'class-validator'
-import { Verkey } from 'indy-sdk'
 
 import { AgentMessage } from '../../../agent/AgentMessage'
 import { IsValidMessageType, parseMessageType } from '../../../utils/messageType'
@@ -15,7 +14,7 @@ export enum KeylistUpdateResult {
 }
 
 export class KeylistUpdated {
-  public constructor(options: { recipientKey: Verkey; action: KeylistUpdateAction; result: KeylistUpdateResult }) {
+  public constructor(options: { recipientKey: string; action: KeylistUpdateAction; result: KeylistUpdateResult }) {
     if (options) {
       this.recipientKey = options.recipientKey
       this.action = options.action
@@ -25,7 +24,7 @@ export class KeylistUpdated {
 
   @IsString()
   @Expose({ name: 'recipient_key' })
-  public recipientKey!: Verkey
+  public recipientKey!: string
 
   @IsEnum(KeylistUpdateAction)
   public action!: KeylistUpdateAction

--- a/packages/core/src/modules/routing/services/MediationRecipientService.ts
+++ b/packages/core/src/modules/routing/services/MediationRecipientService.ts
@@ -134,9 +134,9 @@ export class MediationRecipientService {
     // update keylist in mediationRecord
     for (const update of keylist) {
       if (update.action === KeylistUpdateAction.add) {
-        mediationRecord.addRecipientKey(verkeyToDidKey(update.recipientKey))
+        mediationRecord.addRecipientKey(didKeyToVerkey(update.recipientKey))
       } else if (update.action === KeylistUpdateAction.remove) {
-        mediationRecord.removeRecipientKey(verkeyToDidKey(update.recipientKey))
+        mediationRecord.removeRecipientKey(didKeyToVerkey(update.recipientKey))
       }
     }
 

--- a/packages/core/src/modules/routing/services/MediatorService.ts
+++ b/packages/core/src/modules/routing/services/MediatorService.ts
@@ -1,7 +1,7 @@
 import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
 import type { EncryptedMessage } from '../../../types'
 import type { MediationStateChangedEvent } from '../RoutingEvents'
-import type { ForwardMessage, KeylistUpdateMessage, MediationRequestMessage } from '../messages'
+import type { ForwardMessage, MediationRequestMessage, KeylistUpdateMessage } from '../messages'
 
 import { AgentConfig } from '../../../agent/AgentConfig'
 import { EventEmitter } from '../../../agent/EventEmitter'
@@ -10,7 +10,7 @@ import { AriesFrameworkError } from '../../../error'
 import { inject, injectable } from '../../../plugins'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
 import { Wallet } from '../../../wallet/Wallet'
-import { didKeyToVerkey } from '../../dids/helpers'
+import { didKeyToVerkey, verkeyToDidKey } from '../../dids/helpers'
 import { RoutingEventTypes } from '../RoutingEvents'
 import {
   KeylistUpdateAction,
@@ -149,9 +149,12 @@ export class MediatorService {
 
     await this.updateState(mediationRecord, MediationState.Granted)
 
+    // Use our useDidKey configuration, as this is the first interaction for this protocol
+    const useDidKey = this.agentConfig.useDidKeyInProtocols
+
     const message = new MediationGrantMessage({
       endpoint: this.agentConfig.endpoints[0],
-      routingKeys: this.getRoutingKeys(),
+      routingKeys: useDidKey ? this.getRoutingKeys().map(verkeyToDidKey) : this.getRoutingKeys(),
       threadId: mediationRecord.threadId,
     })
 

--- a/packages/core/src/modules/routing/services/__tests__/MediationRecipientService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/MediationRecipientService.test.ts
@@ -111,11 +111,15 @@ describe('MediationRecipientService', () => {
         threadId: 'threadId',
       })
 
-      const messageContext = new InboundMessageContext(mediationGrant, { connection: mockConnection })
+      const connection = getMockConnection({
+        state: DidExchangeState.Completed,
+      })
+
+      const messageContext = new InboundMessageContext(mediationGrant, { connection })
 
       await mediationRecipientService.processMediationGrant(messageContext)
 
-      expect(mockConnection.metadata.get(ConnectionMetadataKeys.UseDidKeysForProtocol)).toEqual({
+      expect(connection.metadata.get(ConnectionMetadataKeys.UseDidKeysForProtocol)).toEqual({
         'https://didcomm.org/coordinate-mediation/1.0': false,
       })
       expect(mediationRecord.routingKeys).toEqual(['79CXkde3j8TNuMXxPdV7nLUrT2g7JAEjH5TreyVY7GEZ'])
@@ -129,11 +133,15 @@ describe('MediationRecipientService', () => {
         threadId: 'threadId',
       })
 
-      const messageContext = new InboundMessageContext(mediationGrant, { connection: mockConnection })
+      const connection = getMockConnection({
+        state: DidExchangeState.Completed,
+      })
+
+      const messageContext = new InboundMessageContext(mediationGrant, { connection })
 
       await mediationRecipientService.processMediationGrant(messageContext)
 
-      expect(mockConnection.metadata.get(ConnectionMetadataKeys.UseDidKeysForProtocol)).toEqual({
+      expect(connection.metadata.get(ConnectionMetadataKeys.UseDidKeysForProtocol)).toEqual({
         'https://didcomm.org/coordinate-mediation/1.0': true,
       })
       expect(mediationRecord.routingKeys).toEqual(['8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K'])
@@ -171,6 +179,10 @@ describe('MediationRecipientService', () => {
     it('it stores did:key-encoded keys in base58 format', async () => {
       const spyAddRecipientKey = jest.spyOn(mediationRecord, 'addRecipientKey')
 
+      const connection = getMockConnection({
+        state: DidExchangeState.Completed,
+      })
+
       const keylist = [
         {
           result: KeylistUpdateResult.Success,
@@ -184,8 +196,15 @@ describe('MediationRecipientService', () => {
         keylist,
       })
 
-      const messageContext = new InboundMessageContext(keyListUpdateResponse, { connection: mockConnection })
+      const messageContext = new InboundMessageContext(keyListUpdateResponse, { connection })
+
+      expect(connection.metadata.get(ConnectionMetadataKeys.UseDidKeysForProtocol)).toBeNull()
+
       await mediationRecipientService.processKeylistUpdateResults(messageContext)
+
+      expect(connection.metadata.get(ConnectionMetadataKeys.UseDidKeysForProtocol)).toEqual({
+        'https://didcomm.org/coordinate-mediation/1.0': true,
+      })
 
       expect(eventEmitter.emit).toHaveBeenCalledWith({
         type: RoutingEventTypes.RecipientKeylistUpdated,

--- a/packages/core/src/modules/routing/services/__tests__/MediationRecipientService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/MediationRecipientService.test.ts
@@ -11,6 +11,7 @@ import { AriesFrameworkError } from '../../../../error'
 import { uuid } from '../../../../utils/uuid'
 import { IndyWallet } from '../../../../wallet/IndyWallet'
 import { DidExchangeState } from '../../../connections'
+import { ConnectionMetadataKeys } from '../../../connections/repository/ConnectionMetadataTypes'
 import { ConnectionRepository } from '../../../connections/repository/ConnectionRepository'
 import { ConnectionService } from '../../../connections/services/ConnectionService'
 import { Key } from '../../../dids'
@@ -108,6 +109,9 @@ describe('MediationRecipientService', () => {
 
       await mediationRecipientService.processMediationGrant(messageContext)
 
+      expect(mockConnection.metadata.get(ConnectionMetadataKeys.UseDidKeysForProtocol)).toEqual({
+        'https://didcomm.org/coordinate-mediation/1.0': false,
+      })
       expect(mediationRecord.routingKeys).toEqual(['79CXkde3j8TNuMXxPdV7nLUrT2g7JAEjH5TreyVY7GEZ'])
     })
 
@@ -123,6 +127,9 @@ describe('MediationRecipientService', () => {
 
       await mediationRecipientService.processMediationGrant(messageContext)
 
+      expect(mockConnection.metadata.get(ConnectionMetadataKeys.UseDidKeysForProtocol)).toEqual({
+        'https://didcomm.org/coordinate-mediation/1.0': true,
+      })
       expect(mediationRecord.routingKeys).toEqual(['8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K'])
     })
   })

--- a/packages/core/src/modules/routing/services/__tests__/MediatorService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/MediatorService.test.ts
@@ -2,7 +2,7 @@ import { getAgentConfig, getMockConnection, mockFunction } from '../../../../../
 import { EventEmitter } from '../../../../agent/EventEmitter'
 import { InboundMessageContext } from '../../../../agent/models/InboundMessageContext'
 import { IndyWallet } from '../../../../wallet/IndyWallet'
-import { DidExchangeState } from '../../../connections'
+import { ConnectionService, DidExchangeState } from '../../../connections'
 import { isDidKey } from '../../../dids/helpers'
 import { KeylistUpdateAction, KeylistUpdateMessage, KeylistUpdateResult } from '../../messages'
 import { MediationRole, MediationState } from '../../models'
@@ -17,12 +17,15 @@ const MediationRepositoryMock = MediationRepository as jest.Mock<MediationReposi
 jest.mock('../../repository/MediatorRoutingRepository')
 const MediatorRoutingRepositoryMock = MediatorRoutingRepository as jest.Mock<MediatorRoutingRepository>
 
+jest.mock('../../../connections/services/ConnectionService')
+const ConnectionServiceMock = ConnectionService as jest.Mock<ConnectionService>
+
 jest.mock('../../../../wallet/IndyWallet')
 const WalletMock = IndyWallet as jest.Mock<IndyWallet>
 
 const mediationRepository = new MediationRepositoryMock()
 const mediatorRoutingRepository = new MediatorRoutingRepositoryMock()
-
+const connectionService = new ConnectionServiceMock()
 const wallet = new WalletMock()
 
 const mockConnection = getMockConnection({
@@ -37,7 +40,8 @@ describe('MediatorService - default config', () => {
     mediatorRoutingRepository,
     agentConfig,
     wallet,
-    new EventEmitter(agentConfig)
+    new EventEmitter(agentConfig),
+    connectionService
   )
 
   describe('createGrantMediationMessage', () => {
@@ -161,7 +165,8 @@ describe('MediatorService - useDidKeyInProtocols set to true', () => {
     mediatorRoutingRepository,
     agentConfig,
     wallet,
-    new EventEmitter(agentConfig)
+    new EventEmitter(agentConfig),
+    connectionService
   )
 
   describe('createGrantMediationMessage', () => {

--- a/packages/core/src/modules/routing/services/__tests__/MediatorService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/MediatorService.test.ts
@@ -3,14 +3,13 @@ import { EventEmitter } from '../../../../agent/EventEmitter'
 import { InboundMessageContext } from '../../../../agent/models/InboundMessageContext'
 import { IndyWallet } from '../../../../wallet/IndyWallet'
 import { DidExchangeState } from '../../../connections'
-import { KeylistUpdateAction, KeylistUpdateMessage } from '../../messages'
+import { isDidKey } from '../../../dids/helpers'
+import { KeylistUpdateAction, KeylistUpdateMessage, KeylistUpdateResult } from '../../messages'
 import { MediationRole, MediationState } from '../../models'
-import { MediationRecord } from '../../repository'
+import { MediationRecord, MediatorRoutingRecord } from '../../repository'
 import { MediationRepository } from '../../repository/MediationRepository'
 import { MediatorRoutingRepository } from '../../repository/MediatorRoutingRepository'
 import { MediatorService } from '../MediatorService'
-
-const agentConfig = getAgentConfig('MediatorService')
 
 jest.mock('../../repository/MediationRepository')
 const MediationRepositoryMock = MediationRepository as jest.Mock<MediationRepository>
@@ -26,19 +25,47 @@ const mediatorRoutingRepository = new MediatorRoutingRepositoryMock()
 
 const wallet = new WalletMock()
 
-const mediatorService = new MediatorService(
-  mediationRepository,
-  mediatorRoutingRepository,
-  agentConfig,
-  wallet,
-  new EventEmitter(agentConfig)
-)
-
 const mockConnection = getMockConnection({
   state: DidExchangeState.Completed,
 })
 
-describe('MediatorService', () => {
+describe('MediatorService - default config', () => {
+  const agentConfig = getAgentConfig('MediatorService')
+
+  const mediatorService = new MediatorService(
+    mediationRepository,
+    mediatorRoutingRepository,
+    agentConfig,
+    wallet,
+    new EventEmitter(agentConfig)
+  )
+
+  describe('createGrantMediationMessage', () => {
+    test('sends base58 encoded recipient keys by default', async () => {
+      const mediationRecord = new MediationRecord({
+        connectionId: 'connectionId',
+        role: MediationRole.Mediator,
+        state: MediationState.Requested,
+        threadId: 'threadId',
+      })
+
+      mockFunction(mediationRepository.getByConnectionId).mockResolvedValue(mediationRecord)
+
+      mockFunction(mediatorRoutingRepository.findById).mockResolvedValue(
+        new MediatorRoutingRecord({
+          routingKeys: ['8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K'],
+        })
+      )
+
+      await mediatorService.initialize()
+
+      const { message } = await mediatorService.createGrantMediationMessage(mediationRecord)
+
+      expect(message.routingKeys.length).toBe(1)
+      expect(isDidKey(message.routingKeys[0])).toBeFalsy()
+    })
+  })
+
   describe('processKeylistUpdateRequest', () => {
     test('processes base58 encoded recipient keys', async () => {
       const mediationRecord = new MediationRecord({
@@ -65,39 +92,101 @@ describe('MediatorService', () => {
       })
 
       const messageContext = new InboundMessageContext(keyListUpdate, { connection: mockConnection })
-      await mediatorService.processKeylistUpdateRequest(messageContext)
+      const response = await mediatorService.processKeylistUpdateRequest(messageContext)
 
       expect(mediationRecord.recipientKeys).toEqual(['79CXkde3j8TNuMXxPdV7nLUrT2g7JAEjH5TreyVY7GEZ'])
+      expect(response.updated).toEqual([
+        {
+          action: KeylistUpdateAction.add,
+          recipientKey: '79CXkde3j8TNuMXxPdV7nLUrT2g7JAEjH5TreyVY7GEZ',
+          result: KeylistUpdateResult.Success,
+        },
+        {
+          action: KeylistUpdateAction.remove,
+          recipientKey: '8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K',
+          result: KeylistUpdateResult.Success,
+        },
+      ])
+    })
+  })
+
+  test('processes did:key encoded recipient keys', async () => {
+    const mediationRecord = new MediationRecord({
+      connectionId: 'connectionId',
+      role: MediationRole.Mediator,
+      state: MediationState.Granted,
+      threadId: 'threadId',
+      recipientKeys: ['8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K'],
     })
 
-    test('processes did:key encoded recipient keys', async () => {
+    mockFunction(mediationRepository.getByConnectionId).mockResolvedValue(mediationRecord)
+
+    const keyListUpdate = new KeylistUpdateMessage({
+      updates: [
+        {
+          action: KeylistUpdateAction.add,
+          recipientKey: 'did:key:z6MkkbTaLstV4fwr1rNf5CSxdS2rGbwxi3V5y6NnVFTZ2V1w',
+        },
+        {
+          action: KeylistUpdateAction.remove,
+          recipientKey: 'did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th',
+        },
+      ],
+    })
+
+    const messageContext = new InboundMessageContext(keyListUpdate, { connection: mockConnection })
+    const response = await mediatorService.processKeylistUpdateRequest(messageContext)
+
+    expect(mediationRecord.recipientKeys).toEqual(['79CXkde3j8TNuMXxPdV7nLUrT2g7JAEjH5TreyVY7GEZ'])
+    expect(response.updated).toEqual([
+      {
+        action: KeylistUpdateAction.add,
+        recipientKey: 'did:key:z6MkkbTaLstV4fwr1rNf5CSxdS2rGbwxi3V5y6NnVFTZ2V1w',
+        result: KeylistUpdateResult.Success,
+      },
+      {
+        action: KeylistUpdateAction.remove,
+        recipientKey: 'did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th',
+        result: KeylistUpdateResult.Success,
+      },
+    ])
+  })
+})
+
+describe('MediatorService - useDidKeyInProtocols set to true', () => {
+  const agentConfig = getAgentConfig('MediatorService', { useDidKeyInProtocols: true })
+
+  const mediatorService = new MediatorService(
+    mediationRepository,
+    mediatorRoutingRepository,
+    agentConfig,
+    wallet,
+    new EventEmitter(agentConfig)
+  )
+
+  describe('createGrantMediationMessage', () => {
+    test('sends did:key encoded recipient keys when config is set', async () => {
       const mediationRecord = new MediationRecord({
         connectionId: 'connectionId',
         role: MediationRole.Mediator,
-        state: MediationState.Granted,
+        state: MediationState.Requested,
         threadId: 'threadId',
-        recipientKeys: ['8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K'],
       })
 
       mockFunction(mediationRepository.getByConnectionId).mockResolvedValue(mediationRecord)
 
-      const keyListUpdate = new KeylistUpdateMessage({
-        updates: [
-          {
-            action: KeylistUpdateAction.add,
-            recipientKey: 'did:key:z6MkkbTaLstV4fwr1rNf5CSxdS2rGbwxi3V5y6NnVFTZ2V1w',
-          },
-          {
-            action: KeylistUpdateAction.remove,
-            recipientKey: 'did:key:z6MkmjY8GnV5i9YTDtPETC2uUAW6ejw3nk5mXF5yci5ab7th',
-          },
-        ],
+      const routingRecord = new MediatorRoutingRecord({
+        routingKeys: ['8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K'],
       })
 
-      const messageContext = new InboundMessageContext(keyListUpdate, { connection: mockConnection })
-      await mediatorService.processKeylistUpdateRequest(messageContext)
+      mockFunction(mediatorRoutingRepository.findById).mockResolvedValue(routingRecord)
 
-      expect(mediationRecord.recipientKeys).toEqual(['79CXkde3j8TNuMXxPdV7nLUrT2g7JAEjH5TreyVY7GEZ'])
+      await mediatorService.initialize()
+
+      const { message } = await mediatorService.createGrantMediationMessage(mediationRecord)
+
+      expect(message.routingKeys.length).toBe(1)
+      expect(isDidKey(message.routingKeys[0])).toBeTruthy()
     })
   })
 })

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -77,6 +77,7 @@ export interface InitConfig {
   maximumMessagePickup?: number
   baseMediatorReconnectionIntervalMs?: number
   maximumMediatorReconnectionIntervalMs?: number
+  useDidKeyInProtocols?: boolean
 
   useLegacyDidSovPrefix?: boolean
   connectionImageUrl?: string


### PR DESCRIPTION
An initial step to support [Aries RFC 0360](https://github.com/hyperledger/aries-rfcs/tree/main/features/0360-use-did-key) by adding an optional configuration flag `useDidKeyInProtocols` that will define how agent should format keys in protocols where keys are exchanged: 'naked' (base58) or did:key encoded. 

This setting will be used unless the other party has already sent us keys (for instance, a Mediator sent us the routing key in a Mediation Grant message). In such case, their format will be used in subsequent messages for that protocol (e.g. KeyList Update). This is achieved by adding a specific metadata key `UseDidKeysForProtocol` to the related connection record, which  intended to track the other party support of did:key in different RFCs. 

Currently, only Coordinate Mediation (RFC 0211) uses this feature, but in further versions other protocols will use this metadata/settings key (such as Pickup V2 - RFC 0685). 

For key reception, the agent will always accept both formats and internally store in base58.

