### PR TITLE
refactor(proofs)!: createRequest for connectionless proof request

### DIFF
--- a/packages/core/src/modules/proofs/ProofsApiOptions.ts
+++ b/packages/core/src/modules/proofs/ProofsApiOptions.ts
@@ -63,12 +63,13 @@ export interface RequestProofOptions<
   parentThreadId?: string
 }
 
-export interface OutOfBandRequestOptions<
+export interface CreateProofRequestOptions<
   PFs extends ProofFormat[] = ProofFormat[],
   PSs extends ProofService[] = ProofService[]
 > {
   protocolVersion: ProtocolVersionType<PSs>
-  proofFormats: ProofFormatPayload<PFs, 'createOutOfBandRequest'>
+  proofFormats: ProofFormatPayload<PFs, 'createRequest'>
   comment?: string
   autoAcceptProof?: AutoAcceptProof
+  parentThreadId?: string
 }

--- a/packages/core/src/modules/proofs/models/ProofServiceOptions.ts
+++ b/packages/core/src/modules/proofs/models/ProofServiceOptions.ts
@@ -28,11 +28,6 @@ export interface CreateRequestAsResponseOptions<PFs extends ProofFormat[]> exten
   proofFormats: ProofFormatPayload<PFs, 'createRequestAsResponse'>
 }
 
-// ----- Out Of Band Proof ----- //
-export interface CreateOutOfBandRequestOptions<PFs extends ProofFormat[]> extends BaseOptions {
-  proofFormats: ProofFormatPayload<PFs, 'createOutOfBandRequest'>
-}
-
 export interface CreateRequestOptions<PFs extends ProofFormat[]> extends BaseOptions {
   connectionRecord?: ConnectionRecord
   proofFormats: ProofFormatPayload<PFs, 'createRequest'>

--- a/packages/core/tests/v1-connectionless-proofs.test.ts
+++ b/packages/core/tests/v1-connectionless-proofs.test.ts
@@ -1,6 +1,6 @@
 import type { SubjectMessage } from '../../../tests/transport/SubjectInboundTransport'
 import type { ProofStateChangedEvent } from '../src/modules/proofs'
-import type { OutOfBandRequestOptions } from '../src/modules/proofs/ProofsApiOptions'
+import type { CreateProofRequestOptions } from '../src/modules/proofs/ProofsApiOptions'
 import type { IndyProofFormat } from '../src/modules/proofs/formats/indy/IndyProofFormat'
 import type { V1ProofService } from '../src/modules/proofs/protocol/v1'
 
@@ -81,7 +81,7 @@ describe('Present Proof', () => {
       }),
     }
 
-    const outOfBandRequestOptions: OutOfBandRequestOptions<[IndyProofFormat], [V1ProofService]> = {
+    const outOfBandRequestOptions: CreateProofRequestOptions<[IndyProofFormat], [V1ProofService]> = {
       protocolVersion: ProofProtocolVersion.V1,
       proofFormats: {
         indy: {
@@ -99,11 +99,14 @@ describe('Present Proof', () => {
     })
 
     // eslint-disable-next-line prefer-const
-    let { proofRecord: faberProofRecord, message } = await faberAgent.proofs.createOutOfBandRequest(
-      outOfBandRequestOptions
-    )
+    let { proofRecord: faberProofRecord, message } = await faberAgent.proofs.createRequest(outOfBandRequestOptions)
 
-    await aliceAgent.receiveMessage(message.toJSON())
+    const { message: requestMessage } = await faberAgent.oob.createLegacyConnectionlessInvitation({
+      recordId: faberProofRecord.id,
+      message,
+      domain: 'https://a-domain.com',
+    })
+    await aliceAgent.receiveMessage(requestMessage.toJSON())
 
     testLogger.test('Alice waits for presentation request from Faber')
     let aliceProofRecord = await aliceProofRecordPromise
@@ -179,7 +182,7 @@ describe('Present Proof', () => {
       }),
     }
 
-    const outOfBandRequestOptions: OutOfBandRequestOptions<[IndyProofFormat], [V1ProofService]> = {
+    const outOfBandRequestOptions: CreateProofRequestOptions<[IndyProofFormat], [V1ProofService]> = {
       protocolVersion: ProofProtocolVersion.V1,
       proofFormats: {
         indy: {
@@ -202,9 +205,15 @@ describe('Present Proof', () => {
     })
 
     // eslint-disable-next-line prefer-const
-    let { message } = await faberAgent.proofs.createOutOfBandRequest(outOfBandRequestOptions)
+    let { message, proofRecord: faberProofRecord } = await faberAgent.proofs.createRequest(outOfBandRequestOptions)
 
-    await aliceAgent.receiveMessage(message.toJSON())
+    const { message: requestMessage } = await faberAgent.oob.createLegacyConnectionlessInvitation({
+      recordId: faberProofRecord.id,
+      message,
+      domain: 'https://a-domain.com',
+    })
+
+    await aliceAgent.receiveMessage(requestMessage.toJSON())
 
     await aliceProofRecordPromise
 
@@ -339,7 +348,7 @@ describe('Present Proof', () => {
       }),
     }
 
-    const outOfBandRequestOptions: OutOfBandRequestOptions<[IndyProofFormat], [V1ProofService]> = {
+    const outOfBandRequestOptions: CreateProofRequestOptions<[IndyProofFormat], [V1ProofService]> = {
       protocolVersion: ProofProtocolVersion.V1,
       proofFormats: {
         indy: {
@@ -362,14 +371,20 @@ describe('Present Proof', () => {
     })
 
     // eslint-disable-next-line prefer-const
-    let { message } = await faberAgent.proofs.createOutOfBandRequest(outOfBandRequestOptions)
+    let { message, proofRecord: faberProofRecord } = await faberAgent.proofs.createRequest(outOfBandRequestOptions)
+
+    const { message: requestMessage } = await faberAgent.oob.createLegacyConnectionlessInvitation({
+      recordId: faberProofRecord.id,
+      message,
+      domain: 'https://a-domain.com',
+    })
 
     const mediationRecord = await faberAgent.mediationRecipient.findDefaultMediator()
     if (!mediationRecord) {
       throw new Error('Faber agent has no default mediator')
     }
 
-    expect(message).toMatchObject({
+    expect(requestMessage).toMatchObject({
       service: {
         recipientKeys: [expect.any(String)],
         routingKeys: mediationRecord.routingKeys,
@@ -377,7 +392,7 @@ describe('Present Proof', () => {
       },
     })
 
-    await aliceAgent.receiveMessage(message.toJSON())
+    await aliceAgent.receiveMessage(requestMessage.toJSON())
 
     await aliceProofRecordPromise
 


### PR DESCRIPTION
Similar approach as #772, to be able to create a legacy Out-of-Band invitation containing a Request Proof message.

Resolves #997 

