### PR TITLE
fix(oob): allow encoding in content type header

### DIFF
--- a/packages/core/src/utils/__tests__/shortenedUrl.test.ts
+++ b/packages/core/src/utils/__tests__/shortenedUrl.test.ts
@@ -7,7 +7,7 @@ import { OutOfBandInvitation } from '../../modules/oob'
 import { convertToNewInvitation } from '../../modules/oob/helpers'
 import { JsonTransformer } from '../JsonTransformer'
 import { MessageValidator } from '../MessageValidator'
-import { oobInvitationfromShortUrl } from '../parseInvitation'
+import { oobInvitationFromShortUrl } from '../parseInvitation'
 
 const mockOobInvite = {
   '@type': 'did:sov:BzCbsNYhMrjHiqZDTUASHg;spec/out-of-band/1.0/invitation',
@@ -89,21 +89,32 @@ beforeAll(async () => {
 
 describe('shortened urls resolving to oob invitations', () => {
   test('Resolve a mocked response in the form of a oob invitation as a json object', async () => {
-    const short = await oobInvitationfromShortUrl(mockedResponseOobJson)
+    const short = await oobInvitationFromShortUrl(mockedResponseOobJson)
     expect(short).toEqual(outOfBandInvitationMock)
   })
   test('Resolve a mocked response in the form of a oob invitation encoded in an url', async () => {
-    const short = await oobInvitationfromShortUrl(mockedResponseOobUrl)
+    const short = await oobInvitationFromShortUrl(mockedResponseOobUrl)
+    expect(short).toEqual(outOfBandInvitationMock)
+  })
+
+  test("Resolve a mocked response in the form of a oob invitation as a json object with header 'application/json; charset=utf-8'", async () => {
+    const short = await oobInvitationFromShortUrl({
+      ...mockedResponseOobJson,
+      headers: new Headers({
+        'content-type': 'application/json; charset=utf-8',
+      }),
+    } as Response)
     expect(short).toEqual(outOfBandInvitationMock)
   })
 })
+
 describe('shortened urls resolving to connection invitations', () => {
   test('Resolve a mocked response in the form of a connection invitation as a json object', async () => {
-    const short = await oobInvitationfromShortUrl(mockedResponseConnectionJson)
+    const short = await oobInvitationFromShortUrl(mockedResponseConnectionJson)
     expect(short).toEqual(connectionInvitationToNew)
   })
   test('Resolve a mocked Response in the form of a connection invitation encoded in an url', async () => {
-    const short = await oobInvitationfromShortUrl(mockedResponseConnectionUrl)
+    const short = await oobInvitationFromShortUrl(mockedResponseConnectionUrl)
     expect(short).toEqual(connectionInvitationToNew)
   })
 })

--- a/packages/core/src/utils/parseInvitation.ts
+++ b/packages/core/src/utils/parseInvitation.ts
@@ -54,9 +54,9 @@ export const parseInvitationUrl = (invitationUrl: string): OutOfBandInvitation =
 }
 
 //This currently does not follow the RFC because of issues with fetch, currently uses a janky work around
-export const oobInvitationfromShortUrl = async (response: Response): Promise<OutOfBandInvitation> => {
+export const oobInvitationFromShortUrl = async (response: Response): Promise<OutOfBandInvitation> => {
   if (response) {
-    if (response.headers.get('Content-Type') === 'application/json' && response.ok) {
+    if (response.headers.get('Content-Type')?.startsWith('application/json') && response.ok) {
       const invitationJson = await response.json()
       const parsedMessageType = parseMessageType(invitationJson['@type'])
       if (supportsIncomingMessageType(parsedMessageType, OutOfBandInvitation.type)) {
@@ -107,7 +107,7 @@ export const parseInvitationShortUrl = async (
     return convertToNewInvitation(invitation)
   } else {
     try {
-      return oobInvitationfromShortUrl(await fetchShortUrl(invitationUrl, dependencies))
+      return oobInvitationFromShortUrl(await fetchShortUrl(invitationUrl, dependencies))
     } catch (error) {
       throw new AriesFrameworkError(
         'InvitationUrl is invalid. It needs to contain one, and only one, of the following parameters: `oob`, `c_i` or `d_m`, or be valid shortened URL'


### PR DESCRIPTION
Allows content type header to have encoding in the value. To not break implementations that only use `application/json` it just checks wether the header value starts with `application/json`

The oob RFC describes the content type header with encoding in it: 

> The sender MAY include a Content-Type header specifying application/json; charset=utf-8, and in the case where the agent included an Accept header for the application/json MIME type, the sender MUST include the header. If so, the sender MUST return the invitation in JSON format in the response body with a status_code of 200.