### PR TITLE
ci: use graph-type all for lerna publish

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Release Unstable
         run: |
           export NEXT_VERSION_BUMP=$(./node_modules/.bin/ts-node ./scripts/get-next-bump.ts)
-          yarn lerna publish --loglevel=verbose --canary $NEXT_VERSION_BUMP --exact --force-publish --yes --no-verify-access --dist-tag alpha
+          yarn lerna publish --loglevel=verbose --canary $NEXT_VERSION_BUMP --exact --force-publish --yes --no-verify-access --dist-tag alpha --graph-type all
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Release Unstable
         run: |
           export NEXT_VERSION_BUMP=$(./node_modules/.bin/ts-node ./scripts/get-next-bump.ts)
-          yarn lerna publish --loglevel=verbose --canary $NEXT_VERSION_BUMP --exact --force-publish --yes --no-verify-access --dist-tag alpha --graph-type all
+          yarn lerna publish --loglevel=verbose --canary $NEXT_VERSION_BUMP --exact --force-publish --yes --no-verify-access --dist-tag alpha
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/lerna.json
+++ b/lerna.json
@@ -6,6 +6,9 @@
   "command": {
     "version": {
       "allowBranch": "main"
+    },
+    "publish": {
+      "graphType": "all"
     }
   }
 }


### PR DESCRIPTION
CD is broken since #1082 has been merged, and it seems that it's because lerna is using alphabetical order when publishing packages (`lerna publish` command), so attempts to build action-menu before core (marked as peerDependency).

According to [Lerna Publish documentation](https://github.com/lerna/lerna/blob/main/commands/publish/README.md#--graph-type-alldependencies), this is because lerna uses by default a `dependencies` graph-type, which will take into account only packages listed in dependencies to determine the build order. As in this case it is listed in peerDependencies, an `all` graph-type must be used.

Another option of course would be to modify action-menu's package.json to set core as a direct dependency. However, this would be also needed for any other package that comes before to core in alphabetical order (such as `bbs-signatures`). I'm not sure if this would be conceptually correct (this was discussed recently [when extracting BBS module](https://github.com/hyperledger/aries-framework-javascript/pull/1035#discussion_r989228931)).