### PR TITLE
fix(connections): do not log AgentContext object

### DIFF
--- a/packages/core/src/modules/connections/DidExchangeProtocol.ts
+++ b/packages/core/src/modules/connections/DidExchangeProtocol.ts
@@ -135,7 +135,9 @@ export class DidExchangeProtocol {
     messageContext: InboundMessageContext<DidExchangeRequestMessage>,
     outOfBandRecord: OutOfBandRecord
   ): Promise<ConnectionRecord> {
-    this.logger.debug(`Process message ${DidExchangeRequestMessage.type.messageTypeUri} start`, messageContext)
+    this.logger.debug(`Process message ${DidExchangeRequestMessage.type.messageTypeUri} start`, {
+      message: messageContext.message,
+    })
 
     outOfBandRecord.assertRole(OutOfBandRole.Sender)
     outOfBandRecord.assertState(OutOfBandState.AwaitResponse)
@@ -275,7 +277,10 @@ export class DidExchangeProtocol {
     messageContext: InboundMessageContext<DidExchangeResponseMessage>,
     outOfBandRecord: OutOfBandRecord
   ): Promise<ConnectionRecord> {
-    this.logger.debug(`Process message ${DidExchangeResponseMessage.type.messageTypeUri} start`, messageContext)
+    this.logger.debug(`Process message ${DidExchangeResponseMessage.type.messageTypeUri} start`, {
+      message: messageContext.message,
+    })
+
     const { connection: connectionRecord, message } = messageContext
 
     if (!connectionRecord) {
@@ -377,7 +382,10 @@ export class DidExchangeProtocol {
     messageContext: InboundMessageContext<DidExchangeCompleteMessage>,
     outOfBandRecord: OutOfBandRecord
   ): Promise<ConnectionRecord> {
-    this.logger.debug(`Process message ${DidExchangeCompleteMessage.type.messageTypeUri} start`, messageContext)
+    this.logger.debug(`Process message ${DidExchangeCompleteMessage.type.messageTypeUri} start`, {
+      message: messageContext.message,
+    })
+
     const { connection: connectionRecord, message } = messageContext
 
     if (!connectionRecord) {


### PR DESCRIPTION
In last [Aries Framework JS call](https://wiki.hyperledger.org/display/ARIES/2022-11-03+Aries+Framework+JS+Meeting+notes) @niall-shaw reported performance issues when accepting multi-use invitations. 

I've experienced the same issue after migrating to 0.3.0-alpha.x and it turns out that it was happening because some methods in `DidExchangeProtocol` were logging the whole messageContext object, which now includes agentContext and blocks the console for several seconds. This can be avoided by either logging in INFO mode or customizing the logger being in use to only output a certain depth level of objects.

This PR makes a quick-fix of this issue by logging only messageContext.message, to be consistent with other methods from `ConnectionService`. Not sure if it's really useful though, but that's another subject to discuss 😄 .