### PR TITLE
fix(routing): async message pickup on init

### DIFF
--- a/packages/core/src/modules/routing/RecipientApi.ts
+++ b/packages/core/src/modules/routing/RecipientApi.ts
@@ -101,7 +101,9 @@ export class RecipientApi {
     // Poll for messages from mediator
     const defaultMediator = await this.findDefaultMediator()
     if (defaultMediator) {
-      await this.initiateMessagePickup(defaultMediator)
+      this.initiateMessagePickup(defaultMediator).catch((error) => {
+        this.logger.warn(`Error initiating message pickup with mediator ${defaultMediator.id}`, { error })
+      })
     }
   }
 


### PR DESCRIPTION
Currently, when initializing the agent using a `MediationPickupStrategy` different from `None` (e.g. `PickupV1` or `PickupV2`), it attempts to start message pickup in a synchronous way, meaning that it might take some more time for startup depending on the . Also, if mediator is not reachable at that moment, it will throw an error and Agent's `_isInitialized` flag will not be set to true even if can connect afterwards (with the polling of PickupV1 or backoff strategy of PickupV2).

In this PR we are starting the message pickup process in an async way and catching any possible initial error, in a similar way as Agent's initialize method for connecting to ledger pools.

