### PR TITLE
fix: expose AttachmentData and DiscoverFeaturesEvents

### DIFF
--- a/packages/core/src/agent/models/OutboundMessageContext.ts
+++ b/packages/core/src/agent/models/OutboundMessageContext.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Key } from '../../crypto'
 import type { ConnectionRecord } from '../../modules/connections'
 import type { ResolvedDidCommService } from '../../modules/didcomm'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,7 @@ export { InjectionSymbols } from './constants'
 export * from './wallet'
 export type { TransportSession } from './agent/TransportService'
 export { TransportService } from './agent/TransportService'
-export { Attachment } from './decorators/attachment/Attachment'
+export { Attachment, AttachmentData } from './decorators/attachment/Attachment'
 export { ReturnRouteTypes } from './decorators/transport/TransportDecorator'
 
 export * from './plugins'

--- a/packages/core/src/modules/discover-features/index.ts
+++ b/packages/core/src/modules/discover-features/index.ts
@@ -1,3 +1,4 @@
 export * from './DiscoverFeaturesApi'
+export * from './DiscoverFeaturesEvents'
 export * from './DiscoverFeaturesModule'
 export * from './protocol'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,14 +1,8 @@
-import type { AgentMessage } from './agent/AgentMessage'
-import type { Key } from './crypto'
 import type { Logger } from './logger'
-import type { ConnectionRecord } from './modules/connections'
 import type { AutoAcceptCredential } from './modules/credentials/models/CredentialAutoAcceptType'
-import type { ResolvedDidCommService } from './modules/didcomm'
 import type { IndyPoolConfig } from './modules/ledger/IndyPool'
-import type { OutOfBandRecord } from './modules/oob/repository'
 import type { AutoAcceptProof } from './modules/proofs'
 import type { MediatorPickupStrategy } from './modules/routing'
-import type { BaseRecord } from './storage/BaseRecord'
 
 export enum KeyDerivationMethod {
   /** default value in indy-sdk. Will be used when no value is provided */


### PR DESCRIPTION
Expose AttachmentData and Discover Features events... and some minor housekeeping to remove a few lint warnings.

Signed-off-by: Ariel Gentile <gentilester@gmail.com>