### PR TITLE
fix(routing): add connection type on mediation grant

### DIFF
--- a/packages/core/src/modules/connections/ConnectionsApi.ts
+++ b/packages/core/src/modules/connections/ConnectionsApi.ts
@@ -289,7 +289,7 @@ export class ConnectionsApi {
    * @param connectionTypes An array of connection types to query for a match for
    * @returns a promise of ab array of connection records
    */
-  public async findAllByConnectionType(connectionTypes: [ConnectionType | string]) {
+  public async findAllByConnectionType(connectionTypes: Array<ConnectionType | string>) {
     return this.connectionService.findAllByConnectionType(this.agentContext, connectionTypes)
   }
 

--- a/packages/core/src/modules/connections/ConnectionsApi.ts
+++ b/packages/core/src/modules/connections/ConnectionsApi.ts
@@ -253,10 +253,9 @@ export class ConnectionsApi {
   public async addConnectionType(connectionId: string, type: ConnectionType | string) {
     const record = await this.getById(connectionId)
 
-    const tags = (record.getTag('connectionType') as string[]) || ([] as string[])
-    record.setTag('connectionType', [type, ...tags])
-    await this.connectionService.update(this.agentContext, record)
+    await this.connectionService.addConnectionType(this.agentContext, record, type)
   }
+
   /**
    * Removes the given tag from the given record found by connectionId, if the tag exists otherwise does nothing
    * @param connectionId
@@ -266,15 +265,9 @@ export class ConnectionsApi {
   public async removeConnectionType(connectionId: string, type: ConnectionType | string) {
     const record = await this.getById(connectionId)
 
-    const tags = (record.getTag('connectionType') as string[]) || ([] as string[])
-
-    const newTags = tags.filter((value: string) => {
-      if (value != type) return value
-    })
-    record.setTag('connectionType', [...newTags])
-
-    await this.connectionService.update(this.agentContext, record)
+    await this.connectionService.removeConnectionType(this.agentContext, record, type)
   }
+
   /**
    * Gets the known connection types for the record matching the given connectionId
    * @param connectionId

--- a/packages/core/src/modules/connections/ConnectionsApi.ts
+++ b/packages/core/src/modules/connections/ConnectionsApi.ts
@@ -254,6 +254,8 @@ export class ConnectionsApi {
     const record = await this.getById(connectionId)
 
     await this.connectionService.addConnectionType(this.agentContext, record, type)
+
+    return record
   }
 
   /**
@@ -266,6 +268,8 @@ export class ConnectionsApi {
     const record = await this.getById(connectionId)
 
     await this.connectionService.removeConnectionType(this.agentContext, record, type)
+
+    return record
   }
 
   /**
@@ -276,8 +280,8 @@ export class ConnectionsApi {
    */
   public async getConnectionTypes(connectionId: string) {
     const record = await this.getById(connectionId)
-    const tags = record.getTag('connectionType') as string[]
-    return tags || null
+
+    return this.connectionService.getConnectionTypes(record)
   }
 
   /**

--- a/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -968,4 +968,55 @@ describe('ConnectionService', () => {
       expect(result).toEqual(expect.arrayContaining(expected))
     })
   })
+
+  describe('connectionType', () => {
+    it('addConnectionType', async () => {
+      const connection = getMockConnection()
+
+      await connectionService.addConnectionType(agentContext, connection, 'type-1')
+      let connectionTypes = await connectionService.getConnectionTypes(connection)
+      expect(connectionTypes).toMatchObject(['type-1'])
+
+      await connectionService.addConnectionType(agentContext, connection, 'type-2')
+      await connectionService.addConnectionType(agentContext, connection, 'type-3')
+
+      connectionTypes = await connectionService.getConnectionTypes(connection)
+      expect(connectionTypes.sort()).toMatchObject(['type-1', 'type-2', 'type-3'].sort())
+    })
+
+    it('removeConnectionType - existing type', async () => {
+      const connection = getMockConnection()
+
+      connection.setTag('connectionType', ['type-1', 'type-2', 'type-3'])
+      let connectionTypes = await connectionService.getConnectionTypes(connection)
+      expect(connectionTypes).toMatchObject(['type-1', 'type-2', 'type-3'])
+
+      await connectionService.removeConnectionType(agentContext, connection, 'type-2')
+      connectionTypes = await connectionService.getConnectionTypes(connection)
+      expect(connectionTypes.sort()).toMatchObject(['type-1', 'type-3'].sort())
+    })
+
+    it('removeConnectionType - type not existent', async () => {
+      const connection = getMockConnection()
+
+      connection.setTag('connectionType', ['type-1', 'type-2', 'type-3'])
+      let connectionTypes = await connectionService.getConnectionTypes(connection)
+      expect(connectionTypes).toMatchObject(['type-1', 'type-2', 'type-3'])
+
+      await connectionService.removeConnectionType(agentContext, connection, 'type-4')
+      connectionTypes = await connectionService.getConnectionTypes(connection)
+      expect(connectionTypes.sort()).toMatchObject(['type-1', 'type-2', 'type-3'].sort())
+    })
+
+    it('removeConnectionType - no previous types', async () => {
+      const connection = getMockConnection()
+
+      let connectionTypes = await connectionService.getConnectionTypes(connection)
+      expect(connectionTypes).toMatchObject([])
+
+      await connectionService.removeConnectionType(agentContext, connection, 'type-4')
+      connectionTypes = await connectionService.getConnectionTypes(connection)
+      expect(connectionTypes).toMatchObject([])
+    })
+  })
 })

--- a/packages/core/src/modules/connections/repository/ConnectionRecord.ts
+++ b/packages/core/src/modules/connections/repository/ConnectionRecord.ts
@@ -38,7 +38,7 @@ export type DefaultConnectionTags = {
   theirDid?: string
   outOfBandId?: string
   invitationDid?: string
-  connectionType?: [ConnectionType | string]
+  connectionType?: Array<ConnectionType | string>
 }
 
 export class ConnectionRecord
@@ -91,7 +91,7 @@ export class ConnectionRecord
     }
   }
 
-  public getTags() {
+  public getTags(): DefaultConnectionTags & CustomConnectionTags {
     return {
       ...this._tags,
       state: this.state,

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -642,21 +642,26 @@ export class ConnectionService {
     return connectionRecord
   }
 
-  public async addConnectionType(agentContext: AgentContext, record: ConnectionRecord, type: string) {
-    const tags = (record.getTag('connectionType') as string[]) || ([] as string[])
-    record.setTag('connectionType', [type, ...tags])
-    await this.update(agentContext, record)
+  public async addConnectionType(agentContext: AgentContext, connectionRecord: ConnectionRecord, type: string) {
+    const tags = (connectionRecord.getTag('connectionType') as string[]) || ([] as string[])
+    connectionRecord.setTag('connectionType', [type, ...tags])
+    await this.update(agentContext, connectionRecord)
   }
 
-  public async removeConnectionType(agentContext: AgentContext, record: ConnectionRecord, type: string) {
-    const tags = (record.getTag('connectionType') as string[]) || ([] as string[])
+  public async removeConnectionType(agentContext: AgentContext, connectionRecord: ConnectionRecord, type: string) {
+    const tags = (connectionRecord.getTag('connectionType') as string[]) || ([] as string[])
 
     const newTags = tags.filter((value: string) => {
       if (value != type) return value
     })
-    record.setTag('connectionType', [...newTags])
+    connectionRecord.setTag('connectionType', [...newTags])
 
-    await this.update(agentContext, record)
+    await this.update(agentContext, connectionRecord)
+  }
+
+  public async getConnectionTypes(connectionRecord: ConnectionRecord) {
+    const tags = connectionRecord.getTag('connectionType') as string[]
+    return tags || []
   }
 
   private async createDid(agentContext: AgentContext, { role, didDoc }: { role: DidDocumentRole; didDoc: DidDoc }) {

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -642,6 +642,23 @@ export class ConnectionService {
     return connectionRecord
   }
 
+  public async addConnectionType(agentContext: AgentContext, record: ConnectionRecord, type: string) {
+    const tags = (record.getTag('connectionType') as string[]) || ([] as string[])
+    record.setTag('connectionType', [type, ...tags])
+    await this.update(agentContext, record)
+  }
+
+  public async removeConnectionType(agentContext: AgentContext, record: ConnectionRecord, type: string) {
+    const tags = (record.getTag('connectionType') as string[]) || ([] as string[])
+
+    const newTags = tags.filter((value: string) => {
+      if (value != type) return value
+    })
+    record.setTag('connectionType', [...newTags])
+
+    await this.update(agentContext, record)
+  }
+
   private async createDid(agentContext: AgentContext, { role, didDoc }: { role: DidDocumentRole; didDoc: DidDoc }) {
     // Convert the legacy did doc to a new did document
     const didDocument = convertToNewDidDocument(didDoc)

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -601,8 +601,8 @@ export class ConnectionService {
     return this.connectionRepository.findByQuery(agentContext, { outOfBandId })
   }
 
-  public async findAllByConnectionType(agentContext: AgentContext, connectionType: [ConnectionType | string]) {
-    return this.connectionRepository.findByQuery(agentContext, { connectionType })
+  public async findAllByConnectionType(agentContext: AgentContext, connectionTypes: Array<ConnectionType | string>) {
+    return this.connectionRepository.findByQuery(agentContext, { connectionType: connectionTypes })
   }
 
   public async findByInvitationDid(agentContext: AgentContext, invitationDid: string) {

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -643,24 +643,22 @@ export class ConnectionService {
   }
 
   public async addConnectionType(agentContext: AgentContext, connectionRecord: ConnectionRecord, type: string) {
-    const tags = (connectionRecord.getTag('connectionType') as string[]) || ([] as string[])
+    const tags = connectionRecord.getTags().connectionType || []
     connectionRecord.setTag('connectionType', [type, ...tags])
     await this.update(agentContext, connectionRecord)
   }
 
   public async removeConnectionType(agentContext: AgentContext, connectionRecord: ConnectionRecord, type: string) {
-    const tags = (connectionRecord.getTag('connectionType') as string[]) || ([] as string[])
+    const tags = connectionRecord.getTags().connectionType || []
 
-    const newTags = tags.filter((value: string) => {
-      if (value != type) return value
-    })
+    const newTags = tags.filter((value: string) => value !== type)
     connectionRecord.setTag('connectionType', [...newTags])
 
     await this.update(agentContext, connectionRecord)
   }
 
   public async getConnectionTypes(connectionRecord: ConnectionRecord) {
-    const tags = connectionRecord.getTag('connectionType') as string[]
+    const tags = connectionRecord.getTags().connectionType
     return tags || []
   }
 

--- a/packages/core/src/modules/routing/services/MediationRecipientService.ts
+++ b/packages/core/src/modules/routing/services/MediationRecipientService.ts
@@ -93,8 +93,8 @@ export class MediationRecipientService {
       role: MediationRole.Recipient,
       connectionId: connection.id,
     })
-    connection.setTag('connectionType', [ConnectionType.Mediator])
-    await this.connectionService.update(agentContext, connection)
+
+    await this.connectionService.addConnectionType(agentContext, connection, ConnectionType.Mediator)
 
     await this.mediationRepository.save(agentContext, mediationRecord)
     this.emitStateChangedEvent(agentContext, mediationRecord, null)


### PR DESCRIPTION
Small update to the feature added in #994 to aggregate the connection type when a connection is related to a mediation grant. 

Previously, it was setting **only** `ConnectionType.Mediator`, so if the connection was previously tagged with another type, it would be lost.

Also fixes typing for `connectionType` in `ConnectionRecord` in order to be able to properly query for connections matching one or multiple types.