### PR TITLE
feat!: use did:key in protocols by default

### DIFF
--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -125,7 +125,7 @@ export class AgentConfig {
    * in a given protocol (i.e. it does not support Aries RFC 0360).
    */
   public get useDidKeyInProtocols() {
-    return this.initConfig.useDidKeyInProtocols ?? false
+    return this.initConfig.useDidKeyInProtocols ?? true
   }
 
   public get endpoints(): [string, ...string[]] {

--- a/packages/core/src/modules/routing/__tests__/mediation.test.ts
+++ b/packages/core/src/modules/routing/__tests__/mediation.test.ts
@@ -158,17 +158,17 @@ describe('mediator establishment', () => {
     })
   })
 
-  test('Mediation end-to-end flow (use did:key in both sides)', async () => {
+  test('Mediation end-to-end flow (not using did:key)', async () => {
     await e2eMediationTest(
       {
-        config: { ...mediatorAgentOptions.config, useDidKeyInProtocols: true },
+        config: { ...mediatorAgentOptions.config, useDidKeyInProtocols: false },
         dependencies: mediatorAgentOptions.dependencies,
       },
       {
         config: {
           ...recipientAgentOptions.config,
           mediatorPickupStrategy: MediatorPickupStrategy.PickUpV1,
-          useDidKeyInProtocols: true,
+          useDidKeyInProtocols: false,
         },
         dependencies: recipientAgentOptions.dependencies,
       }

--- a/packages/core/src/modules/routing/services/__tests__/MediatorService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/MediatorService.test.ts
@@ -45,7 +45,7 @@ describe('MediatorService - default config', () => {
   )
 
   describe('createGrantMediationMessage', () => {
-    test('sends base58 encoded recipient keys by default', async () => {
+    test('sends did:key encoded recipient keys by default', async () => {
       const mediationRecord = new MediationRecord({
         connectionId: 'connectionId',
         role: MediationRole.Mediator,
@@ -64,7 +64,7 @@ describe('MediatorService - default config', () => {
       const { message } = await mediatorService.createGrantMediationMessage(agentContext, mediationRecord)
 
       expect(message.routingKeys.length).toBe(1)
-      expect(isDidKey(message.routingKeys[0])).toBeFalsy()
+      expect(isDidKey(message.routingKeys[0])).toBeTruthy()
     })
   })
 
@@ -155,8 +155,8 @@ describe('MediatorService - default config', () => {
   })
 })
 
-describe('MediatorService - useDidKeyInProtocols set to true', () => {
-  const agentConfig = getAgentConfig('MediatorService', { useDidKeyInProtocols: true })
+describe('MediatorService - useDidKeyInProtocols set to false', () => {
+  const agentConfig = getAgentConfig('MediatorService', { useDidKeyInProtocols: false })
 
   const agentContext = getAgentContext({
     agentConfig,
@@ -171,7 +171,7 @@ describe('MediatorService - useDidKeyInProtocols set to true', () => {
   )
 
   describe('createGrantMediationMessage', () => {
-    test('sends did:key encoded recipient keys when config is set', async () => {
+    test('sends base58 encoded recipient keys when config is set', async () => {
       const mediationRecord = new MediationRecord({
         connectionId: 'connectionId',
         role: MediationRole.Mediator,
@@ -190,7 +190,7 @@ describe('MediatorService - useDidKeyInProtocols set to true', () => {
       const { message } = await mediatorService.createGrantMediationMessage(agentContext, mediationRecord)
 
       expect(message.routingKeys.length).toBe(1)
-      expect(isDidKey(message.routingKeys[0])).toBeTruthy()
+      expect(isDidKey(message.routingKeys[0])).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
As discussed some time ago in #497, now we are having a new major release, we use did:key in protocols by default. We'll of course still accept base58-encoded keys if the other party is not yet using did:key.

BREAKING CHANGE:
`useDidKeyInProtocols` configuration parameter is now enabled by default. If your agent only interacts with modern agents (e.g. AFJ 0.2.5 and newer) this will not represent any issue. Otherwise it is safer to explicitly set it to `false`. However, keep in mind that we expect this setting to be deprecated in the future, so we encourage you to update all your agents to use did:key.
