### PR TITLE
fix: credential values encoding

### DIFF
--- a/packages/core/src/modules/credentials/formats/indy/IndyCredentialUtils.ts
+++ b/packages/core/src/modules/credentials/formats/indy/IndyCredentialUtils.ts
@@ -156,7 +156,13 @@ export class IndyCredentialUtils {
     }
 
     // If value is an int32 number string return as number string
-    if (isString(value) && !isEmpty(value) && !isNaN(Number(value)) && this.isInt32(Number(value))) {
+    if (
+      isString(value) &&
+      !isEmpty(value) &&
+      !isNaN(Number(value)) &&
+      this.isNumeric(value) &&
+      this.isInt32(Number(value))
+    ) {
       return Number(value).toString()
     }
 
@@ -193,5 +199,9 @@ export class IndyCredentialUtils {
 
     // Check if number is integer and in range of int32
     return Number.isInteger(number) && number >= minI32 && number <= maxI32
+  }
+
+  private static isNumeric(value: string) {
+    return /^-?\d+$/.test(value)
   }
 }

--- a/packages/core/src/modules/credentials/formats/indy/__tests__/IndyCredentialUtils.test.ts
+++ b/packages/core/src/modules/credentials/formats/indy/__tests__/IndyCredentialUtils.test.ts
@@ -74,6 +74,14 @@ const testEncodings: { [key: string]: { raw: string | number | boolean | null; e
     raw: '0.1',
     encoded: '9382477430624249591204401974786823110077201914483282671737639310288175260432',
   },
+  'str 1.0': {
+    raw: '1.0',
+    encoded: '94532235908853478633102631881008651863941875830027892478278578250784387892726',
+  },
+  'str 1': {
+    raw: '1',
+    encoded: '1',
+  },
   'leading zero number string': {
     raw: '012345',
     encoded: '12345',


### PR DESCRIPTION
Signed-off-by: Łukasz Przytuła <lprzytula@gmail.com>

String values containing round decimal numbers (for example `1.0`, `6.0`) were encoded as a number (into `1` and `6` respectively) instead of properly hashing the string value, which causes issues with accepting credentials containing such values, issued by aca-py.