### PR TITLE
refactor(dids): use class instances in module config

### DIFF
--- a/packages/core/src/modules/dids/DidsModule.ts
+++ b/packages/core/src/modules/dids/DidsModule.ts
@@ -3,7 +3,6 @@ import type { DidsModuleConfigOptions } from './DidsModuleConfig'
 
 import { DidsApi } from './DidsApi'
 import { DidsModuleConfig } from './DidsModuleConfig'
-import { DidResolverToken, DidRegistrarToken } from './domain'
 import { DidRepository } from './repository'
 import { DidResolverService, DidRegistrarService } from './services'
 
@@ -30,15 +29,5 @@ export class DidsModule implements Module {
     dependencyManager.registerSingleton(DidResolverService)
     dependencyManager.registerSingleton(DidRegistrarService)
     dependencyManager.registerSingleton(DidRepository)
-
-    // Register all did resolvers
-    for (const Resolver of this.config.resolvers) {
-      dependencyManager.registerSingleton(DidResolverToken, Resolver)
-    }
-
-    // Register all did registrars
-    for (const Registrar of this.config.registrars) {
-      dependencyManager.registerSingleton(DidRegistrarToken, Registrar)
-    }
   }
 }

--- a/packages/core/src/modules/dids/DidsModuleConfig.ts
+++ b/packages/core/src/modules/dids/DidsModuleConfig.ts
@@ -70,6 +70,10 @@ export class DidsModuleConfig {
     return registrars
   }
 
+  public addRegistrar(registrar: DidRegistrar) {
+    this.registrars.push(registrar)
+  }
+
   /** See {@link DidsModuleConfigOptions.resolvers} */
   public get resolvers() {
     // This prevents creating new instances every time this property is accessed
@@ -90,5 +94,9 @@ export class DidsModuleConfig {
 
     this._resolvers = resolvers
     return resolvers
+  }
+
+  public addResolver(resolver: DidResolver) {
+    this.resolvers.push(resolver)
   }
 }

--- a/packages/core/src/modules/dids/DidsModuleConfig.ts
+++ b/packages/core/src/modules/dids/DidsModuleConfig.ts
@@ -1,4 +1,3 @@
-import type { Constructor } from '../../utils/mixins'
 import type { DidRegistrar, DidResolver } from './domain'
 
 import {
@@ -17,9 +16,8 @@ import {
  */
 export interface DidsModuleConfigOptions {
   /**
-   * List of did registrars that should be registered on the dids module. The registrar must
-   * follow the {@link DidRegistrar} interface, and must be constructable. The registrar will be injected
-   * into the `DidRegistrarService` and should be decorated with the `@injectable` decorator.
+   * List of did registrars that should be used by the dids module. The registrar must
+   * be an instance of the {@link DidRegistrar} interface.
    *
    * If no registrars are provided, the default registrars will be used. The `PeerDidRegistrar` will ALWAYS be
    * registered, as it is needed for the connections and out of band module to function. Other did methods can be
@@ -27,12 +25,11 @@ export interface DidsModuleConfigOptions {
    *
    * @default [KeyDidRegistrar, IndySdkSovDidRegistrar, PeerDidRegistrar]
    */
-  registrars?: Constructor<DidRegistrar>[]
+  registrars?: DidRegistrar[]
 
   /**
-   * List of did resolvers that should be registered on the dids module. The resolver must
-   * follow the {@link DidResolver} interface, and must be constructable. The resolver will be injected
-   * into the `DidResolverService` and should be decorated with the `@injectable` decorator.
+   * List of did resolvers that should be used by the dids module. The resolver must
+   * be an instance of the {@link DidResolver} interface.
    *
    * If no resolvers are provided, the default resolvers will be used. The `PeerDidResolver` will ALWAYS be
    * registered, as it is needed for the connections and out of band module to function. Other did methods can be
@@ -40,11 +37,13 @@ export interface DidsModuleConfigOptions {
    *
    * @default [IndySdkSovDidResolver, WebDidResolver, KeyDidResolver, PeerDidResolver]
    */
-  resolvers?: Constructor<DidResolver>[]
+  resolvers?: DidResolver[]
 }
 
 export class DidsModuleConfig {
   private options: DidsModuleConfigOptions
+  private _registrars: DidRegistrar[] | undefined
+  private _resolvers: DidResolver[] | undefined
 
   public constructor(options?: DidsModuleConfigOptions) {
     this.options = options ?? {}
@@ -52,17 +51,44 @@ export class DidsModuleConfig {
 
   /** See {@link DidsModuleConfigOptions.registrars} */
   public get registrars() {
-    const registrars = this.options.registrars ?? [KeyDidRegistrar, IndySdkSovDidRegistrar, PeerDidRegistrar]
+    // This prevents creating new instances every time this property is accessed
+    if (this._registrars) return this._registrars
 
-    // If the peer did registrar is not included yet, add it
-    return registrars.includes(PeerDidRegistrar) ? registrars : [...registrars, PeerDidRegistrar]
+    let registrars = this.options.registrars ?? [
+      new KeyDidRegistrar(),
+      new IndySdkSovDidRegistrar(),
+      new PeerDidRegistrar(),
+    ]
+
+    // Add peer did registrar if it is not included yet
+    if (!registrars.find((registrar) => registrar instanceof PeerDidRegistrar)) {
+      // Do not modify original options array
+      registrars = [...registrars, new PeerDidRegistrar()]
+    }
+
+    this._registrars = registrars
+    return registrars
   }
 
   /** See {@link DidsModuleConfigOptions.resolvers} */
   public get resolvers() {
-    const resolvers = this.options.resolvers ?? [IndySdkSovDidResolver, WebDidResolver, KeyDidResolver, PeerDidResolver]
+    // This prevents creating new instances every time this property is accessed
+    if (this._resolvers) return this._resolvers
 
-    // If the peer did resolver is not included yet, add it
-    return resolvers.includes(PeerDidResolver) ? resolvers : [...resolvers, PeerDidResolver]
+    let resolvers = this.options.resolvers ?? [
+      new IndySdkSovDidResolver(),
+      new WebDidResolver(),
+      new KeyDidResolver(),
+      new PeerDidResolver(),
+    ]
+
+    // Add peer did resolver if it is not included yet
+    if (!resolvers.find((resolver) => resolver instanceof PeerDidResolver)) {
+      // Do not modify original options array
+      resolvers = [...resolvers, new PeerDidResolver()]
+    }
+
+    this._resolvers = resolvers
+    return resolvers
   }
 }

--- a/packages/core/src/modules/dids/__tests__/DidsModule.test.ts
+++ b/packages/core/src/modules/dids/__tests__/DidsModule.test.ts
@@ -1,20 +1,7 @@
-import type { Constructor } from '../../../utils/mixins'
-import type { DidRegistrar, DidResolver } from '../domain'
-
 import { DependencyManager } from '../../../plugins/DependencyManager'
 import { DidsApi } from '../DidsApi'
 import { DidsModule } from '../DidsModule'
 import { DidsModuleConfig } from '../DidsModuleConfig'
-import { DidRegistrarToken, DidResolverToken } from '../domain'
-import {
-  KeyDidRegistrar,
-  KeyDidResolver,
-  PeerDidRegistrar,
-  PeerDidResolver,
-  IndySdkSovDidRegistrar,
-  IndySdkSovDidResolver,
-  WebDidResolver,
-} from '../methods'
 import { DidRepository } from '../repository'
 import { DidRegistrarService, DidResolverService } from '../services'
 
@@ -34,31 +21,9 @@ describe('DidsModule', () => {
     expect(dependencyManager.registerInstance).toHaveBeenCalledTimes(1)
     expect(dependencyManager.registerInstance).toHaveBeenCalledWith(DidsModuleConfig, didsModule.config)
 
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledTimes(10)
+    expect(dependencyManager.registerSingleton).toHaveBeenCalledTimes(3)
     expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidResolverService)
     expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidRegistrarService)
     expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidRepository)
-
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidResolverToken, IndySdkSovDidResolver)
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidResolverToken, WebDidResolver)
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidResolverToken, KeyDidResolver)
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidResolverToken, PeerDidResolver)
-
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidRegistrarToken, KeyDidRegistrar)
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidRegistrarToken, IndySdkSovDidRegistrar)
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidRegistrarToken, PeerDidRegistrar)
-  })
-
-  test('takes the values from the dids config', () => {
-    const registrar = {} as Constructor<DidRegistrar>
-    const resolver = {} as Constructor<DidResolver>
-
-    new DidsModule({
-      registrars: [registrar],
-      resolvers: [resolver],
-    }).register(dependencyManager)
-
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidResolverToken, resolver)
-    expect(dependencyManager.registerSingleton).toHaveBeenCalledWith(DidRegistrarToken, registrar)
   })
 })

--- a/packages/core/src/modules/dids/__tests__/DidsModuleConfig.test.ts
+++ b/packages/core/src/modules/dids/__tests__/DidsModuleConfig.test.ts
@@ -51,4 +51,22 @@ describe('DidsModuleConfig', () => {
     expect(config.registrars).toEqual([registrar, expect.any(PeerDidRegistrar)])
     expect(config.resolvers).toEqual([resolver, expect.any(PeerDidResolver)])
   })
+
+  test('add resolver and registrar after creation', () => {
+    const registrar = {} as DidRegistrar
+    const resolver = {} as DidResolver
+    const config = new DidsModuleConfig({
+      resolvers: [],
+      registrars: [],
+    })
+
+    expect(config.registrars).not.toContain(registrar)
+    expect(config.resolvers).not.toContain(resolver)
+
+    config.addRegistrar(registrar)
+    config.addResolver(resolver)
+
+    expect(config.registrars).toContain(registrar)
+    expect(config.resolvers).toContain(resolver)
+  })
 })

--- a/packages/core/src/modules/dids/__tests__/DidsModuleConfig.test.ts
+++ b/packages/core/src/modules/dids/__tests__/DidsModuleConfig.test.ts
@@ -1,4 +1,3 @@
-import type { Constructor } from '../../../utils/mixins'
 import type { DidRegistrar, DidResolver } from '../domain'
 
 import {
@@ -16,13 +15,22 @@ describe('DidsModuleConfig', () => {
   test('sets default values', () => {
     const config = new DidsModuleConfig()
 
-    expect(config.registrars).toEqual([KeyDidRegistrar, IndySdkSovDidRegistrar, PeerDidRegistrar])
-    expect(config.resolvers).toEqual([IndySdkSovDidResolver, WebDidResolver, KeyDidResolver, PeerDidResolver])
+    expect(config.registrars).toEqual([
+      expect.any(KeyDidRegistrar),
+      expect.any(IndySdkSovDidRegistrar),
+      expect.any(PeerDidRegistrar),
+    ])
+    expect(config.resolvers).toEqual([
+      expect.any(IndySdkSovDidResolver),
+      expect.any(WebDidResolver),
+      expect.any(KeyDidResolver),
+      expect.any(PeerDidResolver),
+    ])
   })
 
   test('sets values', () => {
-    const registrars = [PeerDidRegistrar, {} as Constructor<DidRegistrar>]
-    const resolvers = [PeerDidResolver, {} as Constructor<DidResolver>]
+    const registrars = [new PeerDidRegistrar(), {} as DidRegistrar]
+    const resolvers = [new PeerDidResolver(), {} as DidResolver]
     const config = new DidsModuleConfig({
       registrars,
       resolvers,
@@ -33,14 +41,14 @@ describe('DidsModuleConfig', () => {
   })
 
   test('adds peer did resolver and registrar if not provided in config', () => {
-    const registrar = {} as Constructor<DidRegistrar>
-    const resolver = {} as Constructor<DidResolver>
+    const registrar = {} as DidRegistrar
+    const resolver = {} as DidResolver
     const config = new DidsModuleConfig({
       registrars: [registrar],
       resolvers: [resolver],
     })
 
-    expect(config.registrars).toEqual([registrar, PeerDidRegistrar])
-    expect(config.resolvers).toEqual([resolver, PeerDidResolver])
+    expect(config.registrars).toEqual([registrar, expect.any(PeerDidRegistrar)])
+    expect(config.resolvers).toEqual([resolver, expect.any(PeerDidResolver)])
   })
 })

--- a/packages/core/src/modules/dids/__tests__/peer-did.test.ts
+++ b/packages/core/src/modules/dids/__tests__/peer-did.test.ts
@@ -4,11 +4,13 @@ import { Subject } from 'rxjs'
 
 import { getAgentConfig, getAgentContext } from '../../../../tests/helpers'
 import { EventEmitter } from '../../../agent/EventEmitter'
+import { InjectionSymbols } from '../../../constants'
 import { Key, KeyType } from '../../../crypto'
 import { SigningProviderRegistry } from '../../../crypto/signing-provider'
 import { IndyStorageService } from '../../../storage/IndyStorageService'
 import { JsonTransformer } from '../../../utils'
 import { IndyWallet } from '../../../wallet/IndyWallet'
+import { DidsModuleConfig } from '../DidsModuleConfig'
 import { DidCommV1Service, DidDocument, DidDocumentBuilder } from '../domain'
 import { DidDocumentRole } from '../domain/DidDocumentRole'
 import { convertPublicKeyToX25519, getEd25519VerificationMethod } from '../domain/key-type/ed25519'
@@ -33,16 +35,24 @@ describe('peer dids', () => {
 
   beforeEach(async () => {
     wallet = new IndyWallet(config.agentDependencies, config.logger, new SigningProviderRegistry([]))
-    agentContext = getAgentContext({ wallet })
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    await wallet.createAndOpen(config.walletConfig!)
-
     const storageService = new IndyStorageService<DidRecord>(config.agentDependencies)
     eventEmitter = new EventEmitter(config.agentDependencies, new Subject())
     didRepository = new DidRepository(storageService, eventEmitter)
 
-    // Mocking IndyLedgerService as we're only interested in the did:peer resolver
-    didResolverService = new DidResolverService(config.logger, [new PeerDidResolver(didRepository)])
+    agentContext = getAgentContext({
+      wallet,
+      registerInstances: [
+        [DidRepository, didRepository],
+        [InjectionSymbols.StorageService, storageService],
+      ],
+    })
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await wallet.createAndOpen(config.walletConfig!)
+
+    didResolverService = new DidResolverService(
+      config.logger,
+      new DidsModuleConfig({ resolvers: [new PeerDidResolver()] })
+    )
   })
 
   afterEach(async () => {

--- a/packages/core/src/modules/dids/domain/DidRegistrar.ts
+++ b/packages/core/src/modules/dids/domain/DidRegistrar.ts
@@ -8,8 +8,6 @@ import type {
   DidDeactivateResult,
 } from '../types'
 
-export const DidRegistrarToken = Symbol('DidRegistrar')
-
 export interface DidRegistrar {
   readonly supportedMethods: string[]
 

--- a/packages/core/src/modules/dids/domain/DidResolver.ts
+++ b/packages/core/src/modules/dids/domain/DidResolver.ts
@@ -1,8 +1,6 @@
 import type { AgentContext } from '../../../agent'
 import type { ParsedDid, DidResolutionResult, DidResolutionOptions } from '../types'
 
-export const DidResolverToken = Symbol('DidResolver')
-
 export interface DidResolver {
   readonly supportedMethods: string[]
   resolve(

--- a/packages/core/src/modules/dids/methods/key/KeyDidRegistrar.ts
+++ b/packages/core/src/modules/dids/methods/key/KeyDidRegistrar.ts
@@ -3,22 +3,17 @@ import type { KeyType } from '../../../../crypto'
 import type { DidRegistrar } from '../../domain/DidRegistrar'
 import type { DidCreateOptions, DidCreateResult, DidDeactivateResult, DidUpdateResult } from '../../types'
 
-import { injectable } from '../../../../plugins'
 import { DidDocumentRole } from '../../domain/DidDocumentRole'
 import { DidRepository, DidRecord } from '../../repository'
 
 import { DidKey } from './DidKey'
 
-@injectable()
 export class KeyDidRegistrar implements DidRegistrar {
   public readonly supportedMethods = ['key']
-  private didRepository: DidRepository
-
-  public constructor(didRepository: DidRepository) {
-    this.didRepository = didRepository
-  }
 
   public async create(agentContext: AgentContext, options: KeyDidCreateOptions): Promise<DidCreateResult> {
+    const didRepository = agentContext.dependencyManager.resolve(DidRepository)
+
     const keyType = options.options.keyType
     const seed = options.secret?.seed
 
@@ -57,7 +52,7 @@ export class KeyDidRegistrar implements DidRegistrar {
         id: didKey.did,
         role: DidDocumentRole.Created,
       })
-      await this.didRepository.save(agentContext, didRecord)
+      await didRepository.save(agentContext, didRecord)
 
       return {
         didDocumentMetadata: {},

--- a/packages/core/src/modules/dids/methods/key/KeyDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/key/KeyDidResolver.ts
@@ -2,11 +2,8 @@ import type { AgentContext } from '../../../../agent'
 import type { DidResolver } from '../../domain/DidResolver'
 import type { DidResolutionResult } from '../../types'
 
-import { injectable } from '../../../../plugins'
-
 import { DidKey } from './DidKey'
 
-@injectable()
 export class KeyDidResolver implements DidResolver {
   public readonly supportedMethods = ['key']
 

--- a/packages/core/src/modules/dids/methods/key/__tests__/KeyDidRegistrar.test.ts
+++ b/packages/core/src/modules/dids/methods/key/__tests__/KeyDidRegistrar.test.ts
@@ -17,20 +17,20 @@ const walletMock = {
   createKey: jest.fn(() => Key.fromFingerprint('z6MksLeew51QS6Ca6tVKM56LQNbxCNVcLHv4xXj4jMkAhPWU')),
 } as unknown as Wallet
 
+const didRepositoryMock = new DidRepositoryMock()
+const keyDidRegistrar = new KeyDidRegistrar()
+
 const agentContext = getAgentContext({
   wallet: walletMock,
+  registerInstances: [[DidRepository, didRepositoryMock]],
 })
 
 describe('DidRegistrar', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('KeyDidRegistrar', () => {
-    let keyDidRegistrar: KeyDidRegistrar
-    let didRepositoryMock: DidRepository
-
-    beforeEach(() => {
-      didRepositoryMock = new DidRepositoryMock()
-      keyDidRegistrar = new KeyDidRegistrar(didRepositoryMock)
-    })
-
     it('should correctly create a did:key document using Ed25519 key type', async () => {
       const seed = '96213c3d7fc8d4d6754c712fd969598e'
 

--- a/packages/core/src/modules/dids/methods/peer/PeerDidRegistrar.ts
+++ b/packages/core/src/modules/dids/methods/peer/PeerDidRegistrar.ts
@@ -3,7 +3,6 @@ import type { KeyType } from '../../../../crypto'
 import type { DidRegistrar } from '../../domain/DidRegistrar'
 import type { DidCreateOptions, DidCreateResult, DidDeactivateResult, DidUpdateResult } from '../../types'
 
-import { injectable } from '../../../../plugins'
 import { JsonTransformer } from '../../../../utils'
 import { DidDocument } from '../../domain'
 import { DidDocumentRole } from '../../domain/DidDocumentRole'
@@ -14,19 +13,14 @@ import { keyToNumAlgo0DidDocument } from './peerDidNumAlgo0'
 import { didDocumentJsonToNumAlgo1Did } from './peerDidNumAlgo1'
 import { didDocumentToNumAlgo2Did } from './peerDidNumAlgo2'
 
-@injectable()
 export class PeerDidRegistrar implements DidRegistrar {
   public readonly supportedMethods = ['peer']
-  private didRepository: DidRepository
-
-  public constructor(didRepository: DidRepository) {
-    this.didRepository = didRepository
-  }
 
   public async create(
     agentContext: AgentContext,
     options: PeerDidNumAlgo0CreateOptions | PeerDidNumAlgo1CreateOptions | PeerDidNumAlgo2CreateOptions
   ): Promise<DidCreateResult> {
+    const didRepository = agentContext.dependencyManager.resolve(DidRepository)
     let didDocument: DidDocument
 
     try {
@@ -96,7 +90,7 @@ export class PeerDidRegistrar implements DidRegistrar {
           recipientKeyFingerprints: didDocument.recipientKeys.map((key) => key.fingerprint),
         },
       })
-      await this.didRepository.save(agentContext, didRecord)
+      await didRepository.save(agentContext, didRecord)
 
       return {
         didDocumentMetadata: {},

--- a/packages/core/src/modules/dids/methods/peer/PeerDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/peer/PeerDidResolver.ts
@@ -4,24 +4,18 @@ import type { DidResolver } from '../../domain/DidResolver'
 import type { DidResolutionResult } from '../../types'
 
 import { AriesFrameworkError } from '../../../../error'
-import { injectable } from '../../../../plugins'
 import { DidRepository } from '../../repository'
 
 import { getNumAlgoFromPeerDid, isValidPeerDid, PeerDidNumAlgo } from './didPeer'
 import { didToNumAlgo0DidDocument } from './peerDidNumAlgo0'
 import { didToNumAlgo2DidDocument } from './peerDidNumAlgo2'
 
-@injectable()
 export class PeerDidResolver implements DidResolver {
   public readonly supportedMethods = ['peer']
 
-  private didRepository: DidRepository
-
-  public constructor(didRepository: DidRepository) {
-    this.didRepository = didRepository
-  }
-
   public async resolve(agentContext: AgentContext, did: string): Promise<DidResolutionResult> {
+    const didRepository = agentContext.dependencyManager.resolve(DidRepository)
+
     const didDocumentMetadata = {}
 
     try {
@@ -39,7 +33,7 @@ export class PeerDidResolver implements DidResolver {
       }
       // For Method 1, retrieve from storage
       else if (numAlgo === PeerDidNumAlgo.GenesisDoc) {
-        const didDocumentRecord = await this.didRepository.getById(agentContext, did)
+        const didDocumentRecord = await didRepository.getById(agentContext, did)
 
         if (!didDocumentRecord.didDocument) {
           throw new AriesFrameworkError(`Found did record for method 1 peer did (${did}), but no did document.`)

--- a/packages/core/src/modules/dids/methods/peer/__tests__/PeerDidRegistrar.test.ts
+++ b/packages/core/src/modules/dids/methods/peer/__tests__/PeerDidRegistrar.test.ts
@@ -19,18 +19,17 @@ const DidRepositoryMock = DidRepository as jest.Mock<DidRepository>
 const walletMock = {
   createKey: jest.fn(() => Key.fromFingerprint('z6MksLeew51QS6Ca6tVKM56LQNbxCNVcLHv4xXj4jMkAhPWU')),
 } as unknown as Wallet
-const agentContext = getAgentContext({ wallet: walletMock })
+const didRepositoryMock = new DidRepositoryMock()
+
+const agentContext = getAgentContext({ wallet: walletMock, registerInstances: [[DidRepository, didRepositoryMock]] })
+const peerDidRegistrar = new PeerDidRegistrar()
 
 describe('DidRegistrar', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('PeerDidRegistrar', () => {
-    let peerDidRegistrar: PeerDidRegistrar
-    let didRepositoryMock: DidRepository
-
-    beforeEach(() => {
-      didRepositoryMock = new DidRepositoryMock()
-      peerDidRegistrar = new PeerDidRegistrar(didRepositoryMock)
-    })
-
     describe('did:peer:0', () => {
       it('should correctly create a did:peer:0 document using Ed25519 key type', async () => {
         const seed = '96213c3d7fc8d4d6754c712fd969598e'

--- a/packages/core/src/modules/dids/methods/sov/__tests__/IndySdkSovDidRegistrar.test.ts
+++ b/packages/core/src/modules/dids/methods/sov/__tests__/IndySdkSovDidRegistrar.test.ts
@@ -1,3 +1,4 @@
+import type { AgentConfig } from '../../../../../agent/AgentConfig'
 import type { Wallet } from '../../../../../wallet'
 import type { IndyPool } from '../../../../ledger'
 import type * as Indy from 'indy-sdk'
@@ -22,26 +23,28 @@ mockFunction(indyPoolServiceMock.getPoolForNamespace).mockReturnValue({
 } as IndyPool)
 
 const agentConfig = getAgentConfig('IndySdkSovDidRegistrar')
-
 const createDidMock = jest.fn(async () => ['R1xKJw17sUoXhejEpugMYJ', 'E6D1m3eERqCueX4ZgMCY14B4NceAr6XP2HyVqt55gDhu'])
 
 const wallet = new IndyWallet(agentConfig.agentDependencies, agentConfig.logger, new SigningProviderRegistry([]))
 mockProperty(wallet, 'handle', 10)
 
+const didRepositoryMock = new DidRepositoryMock()
 const agentContext = getAgentContext({
   wallet,
+  registerInstances: [
+    [DidRepository, didRepositoryMock],
+    [IndyPoolService, indyPoolServiceMock],
+  ],
+  agentConfig: {
+    ...agentConfig,
+    agentDependencies: {
+      ...agentConfig.agentDependencies,
+      indy: { createAndStoreMyDid: createDidMock } as unknown as typeof Indy,
+    },
+  } as AgentConfig,
 })
 
-const didRepositoryMock = new DidRepositoryMock()
-const indySdkSovDidRegistrar = new IndySdkSovDidRegistrar(
-  didRepositoryMock,
-  indyPoolServiceMock,
-  {
-    ...agentConfig.agentDependencies,
-    indy: { createAndStoreMyDid: createDidMock } as unknown as typeof Indy,
-  },
-  agentConfig.logger
-)
+const indySdkSovDidRegistrar = new IndySdkSovDidRegistrar()
 
 describe('DidRegistrar', () => {
   describe('IndySdkSovDidRegistrar', () => {
@@ -75,6 +78,7 @@ describe('DidRegistrar', () => {
     it('should return an error state if the wallet is not an indy wallet', async () => {
       const agentContext = getAgentContext({
         wallet: {} as unknown as Wallet,
+        agentConfig,
       })
 
       const result = await indySdkSovDidRegistrar.create(agentContext, {

--- a/packages/core/src/modules/dids/methods/sov/__tests__/IndySdkSovDidResolver.test.ts
+++ b/packages/core/src/modules/dids/methods/sov/__tests__/IndySdkSovDidResolver.test.ts
@@ -1,4 +1,3 @@
-import type { AgentContext } from '../../../../../agent'
 import type { IndyPool } from '../../../../ledger'
 import type { IndyEndpointAttrib } from '../../../../ledger/services/IndyLedgerService'
 import type { GetNymResponse } from 'indy-sdk'
@@ -25,20 +24,15 @@ const agentConfig = getAgentConfig('IndySdkSovDidResolver')
 const wallet = new IndyWallet(agentConfig.agentDependencies, agentConfig.logger, new SigningProviderRegistry([]))
 mockProperty(wallet, 'handle', 10)
 
+const agentContext = getAgentContext({
+  agentConfig,
+  registerInstances: [[IndyPoolService, indyPoolServiceMock]],
+})
+
+const indySdkSovDidResolver = new IndySdkSovDidResolver()
+
 describe('DidResolver', () => {
   describe('IndySdkSovDidResolver', () => {
-    let indySdkSovDidResolver: IndySdkSovDidResolver
-    let agentContext: AgentContext
-
-    beforeEach(() => {
-      indySdkSovDidResolver = new IndySdkSovDidResolver(
-        indyPoolServiceMock,
-        agentConfig.agentDependencies,
-        agentConfig.logger
-      )
-      agentContext = getAgentContext()
-    })
-
     it('should correctly resolve a did:sov document', async () => {
       const did = 'did:sov:R1xKJw17sUoXhejEpugMYJ'
 

--- a/packages/core/src/modules/dids/methods/web/WebDidResolver.ts
+++ b/packages/core/src/modules/dids/methods/web/WebDidResolver.ts
@@ -5,11 +5,9 @@ import type { ParsedDid, DidResolutionResult, DidResolutionOptions } from '../..
 import { Resolver } from 'did-resolver'
 import * as didWeb from 'web-did-resolver'
 
-import { injectable } from '../../../../plugins'
 import { JsonTransformer } from '../../../../utils/JsonTransformer'
 import { DidDocument } from '../../domain'
 
-@injectable()
 export class WebDidResolver implements DidResolver {
   public readonly supportedMethods
 

--- a/packages/core/src/modules/dids/services/DidRegistrarService.ts
+++ b/packages/core/src/modules/dids/services/DidRegistrarService.ts
@@ -11,21 +11,18 @@ import type {
 
 import { InjectionSymbols } from '../../../constants'
 import { Logger } from '../../../logger'
-import { inject, injectable, injectAll } from '../../../plugins'
-import { DidRegistrarToken } from '../domain/DidRegistrar'
+import { inject, injectable } from '../../../plugins'
+import { DidsModuleConfig } from '../DidsModuleConfig'
 import { tryParseDid } from '../domain/parse'
 
 @injectable()
 export class DidRegistrarService {
   private logger: Logger
-  private registrars: DidRegistrar[]
+  private didsModuleConfig: DidsModuleConfig
 
-  public constructor(
-    @inject(InjectionSymbols.Logger) logger: Logger,
-    @injectAll(DidRegistrarToken) registrars: DidRegistrar[]
-  ) {
+  public constructor(@inject(InjectionSymbols.Logger) logger: Logger, didsModuleConfig: DidsModuleConfig) {
     this.logger = logger
-    this.registrars = registrars
+    this.didsModuleConfig = didsModuleConfig
   }
 
   public async create<CreateOptions extends DidCreateOptions = DidCreateOptions>(
@@ -154,6 +151,6 @@ export class DidRegistrarService {
   }
 
   private findRegistrarForMethod(method: string): DidRegistrar | null {
-    return this.registrars.find((r) => r.supportedMethods.includes(method)) ?? null
+    return this.didsModuleConfig.registrars.find((r) => r.supportedMethods.includes(method)) ?? null
   }
 }

--- a/packages/core/src/modules/dids/services/DidResolverService.ts
+++ b/packages/core/src/modules/dids/services/DidResolverService.ts
@@ -5,21 +5,18 @@ import type { DidResolutionOptions, DidResolutionResult, ParsedDid } from '../ty
 import { InjectionSymbols } from '../../../constants'
 import { AriesFrameworkError } from '../../../error'
 import { Logger } from '../../../logger'
-import { injectable, inject, injectAll } from '../../../plugins'
-import { DidResolverToken } from '../domain/DidResolver'
+import { injectable, inject } from '../../../plugins'
+import { DidsModuleConfig } from '../DidsModuleConfig'
 import { parseDid } from '../domain/parse'
 
 @injectable()
 export class DidResolverService {
   private logger: Logger
-  private resolvers: DidResolver[]
+  private didsModuleConfig: DidsModuleConfig
 
-  public constructor(
-    @inject(InjectionSymbols.Logger) logger: Logger,
-    @injectAll(DidResolverToken) resolvers: DidResolver[]
-  ) {
+  public constructor(@inject(InjectionSymbols.Logger) logger: Logger, didsModuleConfig: DidsModuleConfig) {
     this.logger = logger
-    this.resolvers = resolvers
+    this.didsModuleConfig = didsModuleConfig
   }
 
   public async resolve(
@@ -69,6 +66,6 @@ export class DidResolverService {
   }
 
   private findResolver(parsed: ParsedDid): DidResolver | null {
-    return this.resolvers.find((r) => r.supportedMethods.includes(parsed.method)) ?? null
+    return this.didsModuleConfig.resolvers.find((r) => r.supportedMethods.includes(parsed.method)) ?? null
   }
 }

--- a/packages/core/src/modules/dids/services/__tests__/DidRegistrarService.test.ts
+++ b/packages/core/src/modules/dids/services/__tests__/DidRegistrarService.test.ts
@@ -1,6 +1,7 @@
 import type { DidDocument, DidRegistrar } from '../../domain'
 
 import { getAgentConfig, getAgentContext, mockFunction } from '../../../../../tests/helpers'
+import { DidsModuleConfig } from '../../DidsModuleConfig'
 import { DidRegistrarService } from '../DidRegistrarService'
 
 const agentConfig = getAgentConfig('DidResolverService')
@@ -13,7 +14,12 @@ const didRegistrarMock = {
   deactivate: jest.fn(),
 } as DidRegistrar
 
-const didRegistrarService = new DidRegistrarService(agentConfig.logger, [didRegistrarMock])
+const didRegistrarService = new DidRegistrarService(
+  agentConfig.logger,
+  new DidsModuleConfig({
+    registrars: [didRegistrarMock],
+  })
+)
 
 describe('DidResolverService', () => {
   afterEach(() => {

--- a/packages/core/src/modules/dids/services/__tests__/DidResolverService.test.ts
+++ b/packages/core/src/modules/dids/services/__tests__/DidResolverService.test.ts
@@ -2,6 +2,7 @@ import type { DidResolver } from '../../domain'
 
 import { getAgentConfig, getAgentContext, mockFunction } from '../../../../../tests/helpers'
 import { JsonTransformer } from '../../../../utils/JsonTransformer'
+import { DidsModuleConfig } from '../../DidsModuleConfig'
 import didKeyEd25519Fixture from '../../__tests__/__fixtures__/didKeyEd25519.json'
 import { DidDocument } from '../../domain'
 import { parseDid } from '../../domain/parse'
@@ -16,7 +17,10 @@ const agentConfig = getAgentConfig('DidResolverService')
 const agentContext = getAgentContext()
 
 describe('DidResolverService', () => {
-  const didResolverService = new DidResolverService(agentConfig.logger, [didResolverMock])
+  const didResolverService = new DidResolverService(
+    agentConfig.logger,
+    new DidsModuleConfig({ resolvers: [didResolverMock] })
+  )
 
   it('should correctly find and call the correct resolver for a specified did', async () => {
     const returnValue = {


### PR DESCRIPTION
Makes the registration of did resolvers and registrars consistent with how we do it in the credentials module by requiring class instances to be passed.

Not really a breaking change as 0.2.0 doesn't allow custom modules yet