### PR TITLE
refactor: jsonld credential format improvements

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,7 @@ const config: Config.InitialOptions = {
   ...base,
   roots: ['<rootDir>'],
   projects: [
-    '<rootDir>/packages/*',
+    '<rootDir>/packages/*/jest.config.ts',
     '<rootDir>/tests/jest.config.ts',
     '<rootDir>/samples/extension-module/jest.config.ts',
   ],

--- a/packages/bbs-signatures/tests/v2.ldproof.credentials.propose-offerBbs.test.ts
+++ b/packages/bbs-signatures/tests/v2.ldproof.credentials.propose-offerBbs.test.ts
@@ -1,6 +1,6 @@
 import type { Agent } from '../../core/src/agent/Agent'
 import type { ConnectionRecord } from '../../core/src/modules/connections'
-import type { JsonCredential, JsonLdSignCredentialFormat } from '../../core/src/modules/credentials/formats/jsonld'
+import type { JsonCredential, JsonLdCredentialDetailFormat } from '../../core/src/modules/credentials/formats/jsonld'
 import type { Wallet } from '../../core/src/wallet'
 
 import { InjectionSymbols } from '../../core/src/constants'
@@ -28,7 +28,7 @@ describeSkipNode17And18('credentials, BBS+ signature', () => {
   let wallet
   let issuerDidKey: DidKey
   let didCommMessageRepository: DidCommMessageRepository
-  let signCredentialOptions: JsonLdSignCredentialFormat
+  let signCredentialOptions: JsonLdCredentialDetailFormat
   const seed = 'testseed000000000000000000000001'
   beforeAll(async () => {
     ;({ faberAgent, aliceAgent, aliceConnection } = await setupCredentialTests(

--- a/packages/core/src/modules/credentials/formats/__tests__/JsonLdCredentialFormatService.test.ts
+++ b/packages/core/src/modules/credentials/formats/__tests__/JsonLdCredentialFormatService.test.ts
@@ -3,7 +3,7 @@ import type { CredentialFormatService } from '../../formats'
 import type {
   JsonCredential,
   JsonLdCredentialFormat,
-  JsonLdSignCredentialFormat,
+  JsonLdCredentialDetailFormat,
 } from '../../formats/jsonld/JsonLdCredentialFormat'
 import type { CredentialPreviewAttribute } from '../../models/CredentialPreviewAttribute'
 import type { V2OfferCredentialMessageOptions } from '../../protocol/v2/messages/V2OfferCredentialMessage'
@@ -155,7 +155,7 @@ const inputDocAsJson: JsonCredential = {
 }
 const verificationMethod = `8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K#8HH5gYEeNc3z7PYXmd54d4x6qAfCNrqQqEB3nS7Zfu7K`
 
-const signCredentialOptions: JsonLdSignCredentialFormat = {
+const signCredentialOptions: JsonLdCredentialDetailFormat = {
   credential: inputDocAsJson,
   options: {
     proofPurpose: 'assertionMethod',
@@ -310,7 +310,7 @@ describe('JsonLd CredentialFormatService', () => {
       ])
 
       const service = jsonLdFormatService as JsonLdCredentialFormatService
-      const credentialRequest = requestAttachment.getDataAsJson<JsonLdSignCredentialFormat>()
+      const credentialRequest = requestAttachment.getDataAsJson<JsonLdCredentialDetailFormat>()
 
       // calls private method in the format service
       const verificationMethod = await service['deriveVerificationMethod'](
@@ -373,7 +373,7 @@ describe('JsonLd CredentialFormatService', () => {
       state: CredentialState.RequestSent,
     })
     let w3c: W3cCredentialRecord
-    let signCredentialOptionsWithProperty: JsonLdSignCredentialFormat
+    let signCredentialOptionsWithProperty: JsonLdCredentialDetailFormat
     beforeEach(async () => {
       signCredentialOptionsWithProperty = signCredentialOptions
       signCredentialOptionsWithProperty.options = {
@@ -437,10 +437,13 @@ describe('JsonLd CredentialFormatService', () => {
           requestAttachment: requestAttachment,
           credentialRecord,
         })
-      ).rejects.toThrow('Received credential subject does not match subject from credential request')
+      ).rejects.toThrow('Received credential does not match credential request')
     })
 
     test('throws error if credential domain not equal to request domain', async () => {
+      // this property is not supported yet by us, but could be in the credential we received
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
       signCredentialOptionsWithProperty.options.domain = 'https://test.com'
       const requestAttachmentWithDomain = new Attachment({
         mimeType: 'application/json',
@@ -462,7 +465,11 @@ describe('JsonLd CredentialFormatService', () => {
     })
 
     test('throws error if credential challenge not equal to request challenge', async () => {
+      // this property is not supported yet by us, but could be in the credential we received
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-expect-error
       signCredentialOptionsWithProperty.options.challenge = '7bf32d0b-39d4-41f3-96b6-45de52988e4c'
+
       const requestAttachmentWithChallenge = new Attachment({
         mimeType: 'application/json',
         data: new AttachmentData({

--- a/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialDetail.ts
+++ b/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialDetail.ts
@@ -2,11 +2,11 @@ import { Expose, Type } from 'class-transformer'
 
 import { W3cCredential } from '../../../vc/models/credential/W3cCredential'
 
-import { JsonLdOptionsRFC0593 } from './JsonLdOptionsRFC0593'
+import { JsonLdCredentialDetailOptions } from './JsonLdCredentialDetailOptions'
 
-export interface JsonLdCredentialDetailOptions {
+export interface JsonLdCredentialDetailInputOptions {
   credential: W3cCredential
-  options: JsonLdOptionsRFC0593
+  options: JsonLdCredentialDetailOptions
 }
 
 /**
@@ -14,7 +14,7 @@ export interface JsonLdCredentialDetailOptions {
  *
  */
 export class JsonLdCredentialDetail {
-  public constructor(options: JsonLdCredentialDetailOptions) {
+  public constructor(options: JsonLdCredentialDetailInputOptions) {
     if (options) {
       this.credential = options.credential
       this.options = options.options
@@ -25,6 +25,6 @@ export class JsonLdCredentialDetail {
   public credential!: W3cCredential
 
   @Expose({ name: 'options' })
-  @Type(() => JsonLdOptionsRFC0593)
-  public options!: JsonLdOptionsRFC0593
+  @Type(() => JsonLdCredentialDetailOptions)
+  public options!: JsonLdCredentialDetailOptions
 }

--- a/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialDetailOptions.ts
+++ b/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialDetailOptions.ts
@@ -1,11 +1,11 @@
 import { IsObject, IsOptional, IsString } from 'class-validator'
 
-export interface JsonLdOptionsCredentialStatusOptions {
+export interface JsonLdCredentialDetailCredentialStatusOptions {
   type: string
 }
 
-export class JsonLdOptionsCredentialStatus {
-  public constructor(options: JsonLdOptionsCredentialStatusOptions) {
+export class JsonLdCredentialDetailCredentialStatus {
+  public constructor(options: JsonLdCredentialDetailCredentialStatusOptions) {
     if (options) {
       this.type = options.type
     }
@@ -14,17 +14,17 @@ export class JsonLdOptionsCredentialStatus {
   public type!: string
 }
 
-export interface JsonLdOptionsRFC0593Options {
+export interface JsonLdCredentialDetailOptionsOptions {
   proofPurpose: string
   created?: string
   domain?: string
   challenge?: string
-  credentialStatus?: JsonLdOptionsCredentialStatus
+  credentialStatus?: JsonLdCredentialDetailCredentialStatus
   proofType: string
 }
 
-export class JsonLdOptionsRFC0593 {
-  public constructor(options: JsonLdOptionsRFC0593Options) {
+export class JsonLdCredentialDetailOptions {
+  public constructor(options: JsonLdCredentialDetailOptionsOptions) {
     if (options) {
       this.proofPurpose = options.proofPurpose
       this.created = options.created
@@ -55,5 +55,5 @@ export class JsonLdOptionsRFC0593 {
 
   @IsOptional()
   @IsObject()
-  public credentialStatus?: JsonLdOptionsCredentialStatus
+  public credentialStatus?: JsonLdCredentialDetailCredentialStatus
 }

--- a/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialFormat.ts
+++ b/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialFormat.ts
@@ -2,7 +2,6 @@ import type { JsonObject } from '../../../../types'
 import type { SingleOrArray } from '../../../../utils'
 import type { IssuerOptions } from '../../../vc/models/credential/Issuer'
 import type { CredentialFormat } from '../CredentialFormat'
-import type { JsonLdOptionsRFC0593 } from './JsonLdOptionsRFC0593'
 
 export interface JsonCredential {
   '@context': Array<string> | JsonObject
@@ -15,19 +14,53 @@ export interface JsonCredential {
   [key: string]: unknown
 }
 
-// this is the API interface (only)
-export interface JsonLdSignCredentialFormat {
+/**
+ * Format for creating a jsonld proposal, offer or request.
+ */
+export interface JsonLdCredentialDetailFormat {
   credential: JsonCredential
-  options: JsonLdOptionsRFC0593
+  options: {
+    proofPurpose: string
+    proofType: string
+  }
 }
 
-// use this interface internally as the above may diverge in future
-export interface SignCredentialOptionsRFC0593 {
-  credential: JsonCredential
-  options: JsonLdOptionsRFC0593
+// use empty object in the acceptXXX jsonld format interface so we indicate that
+// the jsonld format service needs to be invoked
+type EmptyObject = Record<string, never>
+
+/**
+ * Format for accepting a jsonld credential request. Optionally allows the verification
+ * method to use to sign the credential.
+ */
+export interface JsonLdAcceptRequestFormat {
+  verificationMethod?: string
 }
 
-export interface JsonVerifiableCredential extends JsonLdSignCredentialFormat {
+export interface JsonLdCredentialFormat extends CredentialFormat {
+  formatKey: 'jsonld'
+  credentialRecordType: 'w3c'
+  credentialFormats: {
+    createProposal: JsonLdCredentialDetailFormat
+    acceptProposal: EmptyObject
+    createOffer: JsonLdCredentialDetailFormat
+    acceptOffer: EmptyObject
+    createRequest: JsonLdCredentialDetailFormat
+    acceptRequest: JsonLdAcceptRequestFormat
+  }
+  formatData: {
+    proposal: JsonLdFormatDataCredentialDetail
+    offer: JsonLdFormatDataCredentialDetail
+    request: JsonLdFormatDataCredentialDetail
+    credential: JsonLdFormatDataVerifiableCredential
+  }
+}
+
+/**
+ * Represents a signed verifiable credential. Only meant to be used for credential
+ * format data interfaces.
+ */
+export interface JsonLdFormatDataVerifiableCredential extends JsonCredential {
   proof: {
     type: string
     proofPurpose: string
@@ -42,30 +75,27 @@ export interface JsonVerifiableCredential extends JsonLdSignCredentialFormat {
   }
 }
 
-// use empty object in the acceptXXX jsonld format interface so we indicate that
-// the jsonld format service needs to be invoked
-type EmptyObject = Record<string, never>
-
-// it is an option to provide the verification method in acceptRequest
-export interface JsonLdCreateRequestFormat {
-  verificationMethod?: string
+/**
+ * Represents the jsonld credential detail. Only meant to be used for credential
+ * format data interfaces.
+ */
+export interface JsonLdFormatDataCredentialDetail {
+  credential: JsonCredential
+  options: JsonLdFormatDataCredentialDetailOptions
 }
 
-export interface JsonLdCredentialFormat extends CredentialFormat {
-  formatKey: 'jsonld'
-  credentialRecordType: 'w3c'
-  credentialFormats: {
-    createProposal: JsonLdSignCredentialFormat
-    acceptProposal: EmptyObject
-    createOffer: JsonLdSignCredentialFormat
-    acceptOffer: EmptyObject
-    createRequest: JsonLdSignCredentialFormat
-    acceptRequest: JsonLdCreateRequestFormat
-  }
-  formatData: {
-    proposal: JsonLdSignCredentialFormat
-    offer: JsonLdSignCredentialFormat
-    request: JsonLdSignCredentialFormat
-    credential: JsonVerifiableCredential
+/**
+ * Represents the jsonld credential detail options. Only meant to be used for credential
+ * format data interfaces.
+ */
+export interface JsonLdFormatDataCredentialDetailOptions {
+  proofPurpose: string
+  proofType: string
+  created?: string
+  domain?: string
+  challenge?: string
+  credentialStatus?: {
+    type: string
+    [key: string]: unknown
   }
 }

--- a/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialFormatService.ts
+++ b/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialFormatService.ts
@@ -230,9 +230,9 @@ export class JsonLdCredentialFormatService implements CredentialFormatService<Js
 
     // Get a list of fields found in the options that are not supported at the moment
     const unsupportedFields = ['challenge', 'domain', 'credentialStatus', 'created'] as const
-    const foundFields = unsupportedFields.filter((field) => options[field])
+    const foundFields = unsupportedFields.filter((field) => options[field] !== undefined)
 
-    if (foundFields) {
+    if (foundFields.length > 0) {
       throw new AriesFrameworkError(
         `The fields ${foundFields.join(', ')} are not currently supported in credential options`
       )

--- a/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialFormatService.ts
+++ b/packages/core/src/modules/credentials/formats/jsonld/JsonLdCredentialFormatService.ts
@@ -234,7 +234,7 @@ export class JsonLdCredentialFormatService implements CredentialFormatService<Js
 
     if (foundFields.length > 0) {
       throw new AriesFrameworkError(
-        `The fields ${foundFields.join(', ')} are not currently supported in credential options`
+        `Some fields are not currently supported in credential options: ${foundFields.join(', ')}`
       )
     }
 

--- a/packages/core/src/modules/credentials/formats/jsonld/index.ts
+++ b/packages/core/src/modules/credentials/formats/jsonld/index.ts
@@ -1,4 +1,4 @@
 export * from './JsonLdCredentialFormatService'
 export * from './JsonLdCredentialFormat'
-export * from './JsonLdCredentialOptions'
-export * from './JsonLdOptionsRFC0593'
+export * from './JsonLdCredentialDetail'
+export * from './JsonLdCredentialDetailOptions'

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.connectionless-credentials.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.connectionless-credentials.test.ts
@@ -1,7 +1,7 @@
 import type { SubjectMessage } from '../../../../../../../../tests/transport/SubjectInboundTransport'
 import type { Wallet } from '../../../../../wallet'
 import type { CredentialStateChangedEvent } from '../../../CredentialEvents'
-import type { JsonCredential, JsonLdSignCredentialFormat } from '../../../formats/jsonld/JsonLdCredentialFormat'
+import type { JsonCredential, JsonLdCredentialDetailFormat } from '../../../formats/jsonld/JsonLdCredentialFormat'
 import type { V2OfferCredentialMessage } from '../messages/V2OfferCredentialMessage'
 
 import { ReplaySubject, Subject } from 'rxjs'
@@ -54,7 +54,7 @@ const aliceAgentOptions = getAgentOptions(
 )
 
 let wallet
-let signCredentialOptions: JsonLdSignCredentialFormat
+let signCredentialOptions: JsonLdCredentialDetailFormat
 
 describe('credentials', () => {
   let faberAgent: Agent

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials-auto-accept.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials-auto-accept.test.ts
@@ -1,7 +1,7 @@
 import type { Agent } from '../../../../../agent/Agent'
 import type { Wallet } from '../../../../../wallet'
 import type { ConnectionRecord } from '../../../../connections'
-import type { JsonCredential, JsonLdSignCredentialFormat } from '../../../formats/jsonld/JsonLdCredentialFormat'
+import type { JsonCredential, JsonLdCredentialDetailFormat } from '../../../formats/jsonld/JsonLdCredentialFormat'
 
 import { setupCredentialTests, waitForCredentialRecord } from '../../../../../../tests/helpers'
 import testLogger from '../../../../../../tests/logger'
@@ -30,7 +30,7 @@ describe('credentials', () => {
   let faberConnection: ConnectionRecord
   let aliceConnection: ConnectionRecord
   let aliceCredentialRecord: CredentialExchangeRecord
-  let signCredentialOptions: JsonLdSignCredentialFormat
+  let signCredentialOptions: JsonLdCredentialDetailFormat
   let wallet
   const seed = 'testseed000000000000000000000001'
 

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials.propose-offerED25519.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials.propose-offerED25519.test.ts
@@ -1,7 +1,7 @@
 import type { Awaited } from '../../../../../types'
 import type { Wallet } from '../../../../../wallet'
 import type { ConnectionRecord } from '../../../../connections'
-import type { JsonCredential, JsonLdSignCredentialFormat } from '../../../formats/jsonld/JsonLdCredentialFormat'
+import type { JsonCredential, JsonLdCredentialDetailFormat } from '../../../formats/jsonld/JsonLdCredentialFormat'
 
 import { setupCredentialTests, waitForCredentialRecord } from '../../../../../../tests/helpers'
 import testLogger from '../../../../../../tests/logger'
@@ -53,7 +53,7 @@ describe('credentials', () => {
     },
   }
 
-  let signCredentialOptions: JsonLdSignCredentialFormat
+  let signCredentialOptions: JsonLdCredentialDetailFormat
 
   let wallet
   const seed = 'testseed000000000000000000000001'
@@ -319,7 +319,7 @@ describe('credentials', () => {
       messageClass: V2OfferCredentialMessage,
     })
 
-    const credOfferJson = offerMessage?.offerAttachments[1].getDataAsJson<JsonLdSignCredentialFormat>()
+    const credOfferJson = offerMessage?.offerAttachments[1].getDataAsJson<JsonLdCredentialDetailFormat>()
 
     expect(credOfferJson).toMatchObject({
       credential: {

--- a/packages/core/src/utils/deepEquality.ts
+++ b/packages/core/src/utils/deepEquality.ts
@@ -1,4 +1,4 @@
-import { objectEquality } from './objectEquality'
+import { areObjectsEqual } from './objectEquality'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function deepEquality(x: any, y: any): boolean {
@@ -7,7 +7,7 @@ export function deepEquality(x: any, y: any): boolean {
   const isXSimpleEqualY = simpleEqual(x, y)
   if (isXSimpleEqualY !== undefined) return isXSimpleEqualY
 
-  if (!(x instanceof Map) || !(y instanceof Map)) return objectEquality(x, y)
+  if (!(x instanceof Map) || !(y instanceof Map)) return areObjectsEqual(x, y)
 
   const xMap = x as Map<string, unknown>
   const yMap = y as Map<string, unknown>

--- a/packages/core/src/utils/objectEquality.ts
+++ b/packages/core/src/utils/objectEquality.ts
@@ -1,14 +1,14 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function objectEquality(a: any, b: any): boolean {
+export function areObjectsEqual(a: any, b: any): boolean {
   if (typeof a == 'object' && a != null && typeof b == 'object' && b != null) {
     if (Object.keys(a).length !== Object.keys(b).length) return false
     for (const key in a) {
-      if (!(key in b) || !objectEquality(a[key], b[key])) {
+      if (!(key in b) || !areObjectsEqual(a[key], b[key])) {
         return false
       }
     }
     for (const key in b) {
-      if (!(key in a) || !objectEquality(b[key], a[key])) {
+      if (!(key in a) || !areObjectsEqual(b[key], a[key])) {
         return false
       }
     }


### PR DESCRIPTION
Some small improvements to the jsonld credential format services of things I discovered when using the service. It mostly includes:
- check the whole credential instead of the credentialSubject against the request
- check the created property against the proof (if it was defined)
- do not require a class as input for the credential detail options in the credentials api
- fix incorrect interfaces
- remove redundant checks 