### PR TITLE
refactor(wallet)!: remove wallet.createDid method

### DIFF
--- a/packages/bbs-signatures/tests/bbs-signatures.e2e.test.ts
+++ b/packages/bbs-signatures/tests/bbs-signatures.e2e.test.ts
@@ -6,7 +6,6 @@ import {
   KeyType,
   JsonTransformer,
   DidKey,
-  Key,
   SigningProviderRegistry,
   W3cVerifiableCredential,
   W3cCredentialService,
@@ -220,7 +219,7 @@ describeSkipNode17And18('BBS W3cCredentialService', () => {
 
     describe('signPresentation', () => {
       it('should sign the presentation successfully', async () => {
-        const signingKey = Key.fromPublicKeyBase58((await wallet.createDid({ seed })).verkey, KeyType.Ed25519)
+        const signingKey = await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
         const signingDidKey = new DidKey(signingKey)
         const verificationMethod = `${signingDidKey.did}#${signingDidKey.key.fingerprint}`
         const presentation = JsonTransformer.fromJSON(BbsBlsSignature2020Fixtures.TEST_VP_DOCUMENT, W3cPresentation)

--- a/packages/bbs-signatures/tests/bbs-signing-provider.e2e.test.ts
+++ b/packages/bbs-signatures/tests/bbs-signing-provider.e2e.test.ts
@@ -18,7 +18,7 @@ import { describeSkipNode17And18 } from './util'
 
 // use raw key derivation method to speed up wallet creating / opening / closing between tests
 const walletConfig: WalletConfig = {
-  id: 'Wallet: IndyWalletTest',
+  id: 'Wallet: BBS Signing Provider',
   // generated using indy.generateWalletKey
   key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
   keyDerivationMethod: KeyDerivationMethod.Raw,

--- a/packages/bbs-signatures/tests/v2.ldproof.credentials.propose-offerBbs.test.ts
+++ b/packages/bbs-signatures/tests/v2.ldproof.credentials.propose-offerBbs.test.ts
@@ -36,7 +36,7 @@ describeSkipNode17And18('credentials, BBS+ signature', () => {
       'Alice Agent Credentials LD BBS+'
     ))
     wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
-    await wallet.createDid({ seed })
+    await wallet.createKey({ keyType: KeyType.Ed25519, seed })
     const key = await wallet.createKey({ keyType: KeyType.Bls12381g2, seed })
 
     issuerDidKey = new DidKey(key)

--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -39,7 +39,10 @@ export class AgentConfig {
   }
 
   /**
-   * @todo remove once did registrar module is available
+   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
+   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
+   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
+   * use the `DidsModule`.
    */
   public get publicDidSeed() {
     return this.initConfig.publicDidSeed

--- a/packages/core/src/agent/BaseAgent.ts
+++ b/packages/core/src/agent/BaseAgent.ts
@@ -170,6 +170,12 @@ export abstract class BaseAgent<AgentModules extends ModulesMap = EmptyModuleMap
     }
   }
 
+  /**
+   * @deprecated The publicDid property has been deprecated in favour of the DidsModule, which can be used to
+   * create and resolve dids. Currently the global agent `publicDid` property is still used by the `LedgerModule`, but
+   * will be removed once the LedgerApi has been refactored. Do not use this property for new functionality, but rather
+   * use the `DidsModule`.
+   */
   public get publicDid() {
     return this.agentContext.wallet.publicDid
   }

--- a/packages/core/src/crypto/__tests__/JwsService.test.ts
+++ b/packages/core/src/crypto/__tests__/JwsService.test.ts
@@ -6,7 +6,6 @@ import { DidKey } from '../../modules/dids'
 import { Buffer, JsonEncoder } from '../../utils'
 import { IndyWallet } from '../../wallet/IndyWallet'
 import { JwsService } from '../JwsService'
-import { Key } from '../Key'
 import { KeyType } from '../KeyType'
 import { SigningProviderRegistry } from '../signing-provider'
 
@@ -36,15 +35,15 @@ describe('JwsService', () => {
 
   describe('createJws', () => {
     it('creates a jws for the payload with the key associated with the verkey', async () => {
-      const { verkey } = await wallet.createDid({ seed: didJwsz6Mkf.SEED })
+      const key = await wallet.createKey({ seed: didJwsz6Mkf.SEED, keyType: KeyType.Ed25519 })
 
       const payload = JsonEncoder.toBuffer(didJwsz6Mkf.DATA_JSON)
-      const key = Key.fromPublicKeyBase58(verkey, KeyType.Ed25519)
       const kid = new DidKey(key).did
 
       const jws = await jwsService.createJws(agentContext, {
         payload,
-        verkey,
+        // FIXME: update to use key instance instead of verkey
+        verkey: key.publicKeyBase58,
         header: { kid },
       })
 

--- a/packages/core/src/decorators/signature/SignatureDecoratorUtils.test.ts
+++ b/packages/core/src/decorators/signature/SignatureDecoratorUtils.test.ts
@@ -1,4 +1,5 @@
 import { getAgentConfig } from '../../../tests/helpers'
+import { KeyType } from '../../crypto'
 import { SigningProviderRegistry } from '../../crypto/signing-provider'
 import { IndyWallet } from '../../wallet/IndyWallet'
 
@@ -53,9 +54,9 @@ describe('Decorators | Signature | SignatureDecoratorUtils', () => {
 
   test('signData signs json object and returns SignatureDecorator', async () => {
     const seed1 = '00000000000000000000000000000My1'
-    const { verkey } = await wallet.createDid({ seed: seed1 })
+    const key = await wallet.createKey({ seed: seed1, keyType: KeyType.Ed25519 })
 
-    const result = await signData(data, wallet, verkey)
+    const result = await signData(data, wallet, key.publicKeyBase58)
 
     expect(result).toEqual(signedData)
   })

--- a/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -19,6 +19,7 @@ import { Key, KeyType } from '../../../crypto'
 import { SigningProviderRegistry } from '../../../crypto/signing-provider'
 import { signData, unpackAndVerifySignatureDecorator } from '../../../decorators/signature/SignatureDecoratorUtils'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
+import { indyDidFromPublicKeyBase58 } from '../../../utils/did'
 import { uuid } from '../../../utils/uuid'
 import { IndyWallet } from '../../../wallet/IndyWallet'
 import { AckMessage, AckStatus } from '../../common'
@@ -388,8 +389,10 @@ describe('ConnectionService', () => {
     it('returns a connection response message containing the information from the connection record', async () => {
       expect.assertions(2)
 
+      const key = await wallet.createKey({ keyType: KeyType.Ed25519 })
+      const did = indyDidFromPublicKeyBase58(key.publicKeyBase58)
+
       // Needed for signing connection~sig
-      const { did, verkey } = await wallet.createDid()
       const mockConnection = getMockConnection({
         state: DidExchangeState.RequestReceived,
         role: DidExchangeRole.Responder,
@@ -398,13 +401,13 @@ describe('ConnectionService', () => {
         },
       })
 
-      const recipientKeys = [new DidKey(Key.fromPublicKeyBase58(verkey, KeyType.Ed25519))]
+      const recipientKeys = [new DidKey(key)]
       const outOfBand = getMockOutOfBand({ recipientKeys: recipientKeys.map((did) => did.did) })
 
       const publicKey = new Ed25119Sig2018({
         id: `${did}#1`,
         controller: did,
-        publicKeyBase58: verkey,
+        publicKeyBase58: key.publicKeyBase58,
       })
       const mockDidDoc = new DidDoc({
         id: did,
@@ -477,16 +480,17 @@ describe('ConnectionService', () => {
     it('returns a connection record containing the information from the connection response', async () => {
       expect.assertions(2)
 
-      const { did, verkey } = await wallet.createDid()
-      const { did: theirDid, verkey: theirVerkey } = await wallet.createDid()
+      const key = await wallet.createKey({ keyType: KeyType.Ed25519 })
+      const did = indyDidFromPublicKeyBase58(key.publicKeyBase58)
+
+      const theirKey = await wallet.createKey({ keyType: KeyType.Ed25519 })
+      const theirDid = indyDidFromPublicKeyBase58(key.publicKeyBase58)
 
       const connectionRecord = getMockConnection({
         did,
         state: DidExchangeState.RequestSent,
         role: DidExchangeRole.Requester,
       })
-
-      const theirKey = Key.fromPublicKeyBase58(theirVerkey, KeyType.Ed25519)
 
       const otherPartyConnection = new Connection({
         did: theirDid,
@@ -513,7 +517,7 @@ describe('ConnectionService', () => {
       })
 
       const plainConnection = JsonTransformer.toJSON(otherPartyConnection)
-      const connectionSig = await signData(plainConnection, wallet, theirVerkey)
+      const connectionSig = await signData(plainConnection, wallet, theirKey.publicKeyBase58)
 
       const connectionResponse = new ConnectionResponseMessage({
         threadId: uuid(),
@@ -527,7 +531,7 @@ describe('ConnectionService', () => {
         agentContext,
         connection: connectionRecord,
         senderKey: theirKey,
-        recipientKey: Key.fromPublicKeyBase58(verkey, KeyType.Ed25519),
+        recipientKey: key,
       })
 
       const processedConnection = await connectionService.processResponse(messageContext, outOfBandRecord)
@@ -562,15 +566,16 @@ describe('ConnectionService', () => {
     it('throws an error when the connection sig is not signed with the same key as the recipient key from the invitation', async () => {
       expect.assertions(1)
 
-      const { did, verkey } = await wallet.createDid()
-      const { did: theirDid, verkey: theirVerkey } = await wallet.createDid()
+      const key = await wallet.createKey({ keyType: KeyType.Ed25519 })
+      const did = indyDidFromPublicKeyBase58(key.publicKeyBase58)
+
+      const theirKey = await wallet.createKey({ keyType: KeyType.Ed25519 })
+      const theirDid = indyDidFromPublicKeyBase58(key.publicKeyBase58)
       const connectionRecord = getMockConnection({
         did,
         role: DidExchangeRole.Requester,
         state: DidExchangeState.RequestSent,
       })
-
-      const theirKey = Key.fromPublicKeyBase58(theirVerkey, KeyType.Ed25519)
 
       const otherPartyConnection = new Connection({
         did: theirDid,
@@ -596,7 +601,7 @@ describe('ConnectionService', () => {
         }),
       })
       const plainConnection = JsonTransformer.toJSON(otherPartyConnection)
-      const connectionSig = await signData(plainConnection, wallet, theirVerkey)
+      const connectionSig = await signData(plainConnection, wallet, theirKey.publicKeyBase58)
 
       const connectionResponse = new ConnectionResponseMessage({
         threadId: uuid(),
@@ -606,13 +611,13 @@ describe('ConnectionService', () => {
       // Recipient key `verkey` is not the same as theirVerkey which was used to sign message,
       // therefore it should cause a failure.
       const outOfBandRecord = getMockOutOfBand({
-        recipientKeys: [new DidKey(Key.fromPublicKeyBase58(verkey, KeyType.Ed25519)).did],
+        recipientKeys: [new DidKey(key).did],
       })
       const messageContext = new InboundMessageContext(connectionResponse, {
         agentContext,
         connection: connectionRecord,
         senderKey: theirKey,
-        recipientKey: Key.fromPublicKeyBase58(verkey, KeyType.Ed25519),
+        recipientKey: key,
       })
 
       return expect(connectionService.processResponse(messageContext, outOfBandRecord)).rejects.toThrowError(
@@ -625,19 +630,20 @@ describe('ConnectionService', () => {
     it('throws an error when the message does not contain a DID Document', async () => {
       expect.assertions(1)
 
-      const { did } = await wallet.createDid()
-      const { did: theirDid, verkey: theirVerkey } = await wallet.createDid()
+      const key = await wallet.createKey({ keyType: KeyType.Ed25519 })
+      const did = indyDidFromPublicKeyBase58(key.publicKeyBase58)
+
+      const theirKey = await wallet.createKey({ keyType: KeyType.Ed25519 })
+      const theirDid = indyDidFromPublicKeyBase58(key.publicKeyBase58)
       const connectionRecord = getMockConnection({
         did,
         state: DidExchangeState.RequestSent,
         theirDid: undefined,
       })
 
-      const theirKey = Key.fromPublicKeyBase58(theirVerkey, KeyType.Ed25519)
-
       const otherPartyConnection = new Connection({ did: theirDid })
       const plainConnection = JsonTransformer.toJSON(otherPartyConnection)
-      const connectionSig = await signData(plainConnection, wallet, theirVerkey)
+      const connectionSig = await signData(plainConnection, wallet, theirKey.publicKeyBase58)
 
       const connectionResponse = new ConnectionResponseMessage({ threadId: uuid(), connectionSig })
 

--- a/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
+++ b/packages/core/src/modules/credentials/formats/indy/IndyCredentialFormatService.ts
@@ -22,11 +22,13 @@ import type {
 import type { IndyCredentialFormat } from './IndyCredentialFormat'
 import type * as Indy from 'indy-sdk'
 
+import { KeyType } from '../../../../crypto'
 import { Attachment, AttachmentData } from '../../../../decorators/attachment/Attachment'
 import { AriesFrameworkError } from '../../../../error'
 import { JsonEncoder } from '../../../../utils/JsonEncoder'
 import { JsonTransformer } from '../../../../utils/JsonTransformer'
 import { MessageValidator } from '../../../../utils/MessageValidator'
+import { TypedArrayEncoder } from '../../../../utils/TypedArrayEncoder'
 import { getIndyDidFromVerificationMethod } from '../../../../utils/did'
 import { uuid } from '../../../../utils/uuid'
 import { ConnectionService } from '../../../connections'
@@ -517,7 +519,8 @@ export class IndyCredentialFormatService implements CredentialFormatService<Indy
     // If it wasn't successful to extract the did from the connection, we'll create a new key (e.g. if using connection-less)
     // FIXME: we already create a did for the exchange when using connection-less, but this is on a higher level. We should look at
     // a way to reuse this key, but for now this is easier.
-    const { did } = await agentContext.wallet.createDid()
+    const key = await agentContext.wallet.createKey({ keyType: KeyType.Ed25519 })
+    const did = TypedArrayEncoder.toBase58(key.publicKey.slice(0, 16))
 
     return did
   }

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.connectionless-credentials.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.connectionless-credentials.test.ts
@@ -12,6 +12,7 @@ import { getAgentOptions, prepareForIssuance, waitForCredentialRecordSubject } f
 import testLogger from '../../../../../../tests/logger'
 import { Agent } from '../../../../../agent/Agent'
 import { InjectionSymbols } from '../../../../../constants'
+import { KeyType } from '../../../../../crypto'
 import { JsonEncoder } from '../../../../../utils/JsonEncoder'
 import { W3cVcModule } from '../../../../vc'
 import { customDocumentLoader } from '../../../../vc/__tests__/documentLoader'
@@ -104,7 +105,8 @@ describe('credentials', () => {
       .observable<CredentialStateChangedEvent>(CredentialEventTypes.CredentialStateChanged)
       .subscribe(aliceReplay)
     wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
-    await wallet.createDid({ seed })
+
+    await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
 
     signCredentialOptions = {
       credential: TEST_LD_DOCUMENT,

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials-auto-accept.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials-auto-accept.test.ts
@@ -6,6 +6,7 @@ import type { JsonCredential, JsonLdCredentialDetailFormat } from '../../../form
 import { setupCredentialTests, waitForCredentialRecord } from '../../../../../../tests/helpers'
 import testLogger from '../../../../../../tests/logger'
 import { InjectionSymbols } from '../../../../../constants'
+import { KeyType } from '../../../../../crypto'
 import { AriesFrameworkError } from '../../../../../error/AriesFrameworkError'
 import { CREDENTIALS_CONTEXT_V1_URL } from '../../../../vc/constants'
 import { AutoAcceptCredential, CredentialState } from '../../../models'
@@ -43,7 +44,7 @@ describe('credentials', () => {
       ))
 
       wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
-      await wallet.createDid({ seed })
+      await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
       signCredentialOptions = {
         credential: TEST_LD_DOCUMENT,
         options: {
@@ -142,7 +143,7 @@ describe('credentials', () => {
         AutoAcceptCredential.ContentApproved
       ))
       wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
-      await wallet.createDid({ seed })
+      await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
       signCredentialOptions = {
         credential: TEST_LD_DOCUMENT,
         options: {

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials.propose-offerED25519.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials.propose-offerED25519.test.ts
@@ -6,6 +6,7 @@ import type { JsonCredential, JsonLdCredentialDetailFormat } from '../../../form
 import { setupCredentialTests, waitForCredentialRecord } from '../../../../../../tests/helpers'
 import testLogger from '../../../../../../tests/logger'
 import { InjectionSymbols } from '../../../../../constants'
+import { KeyType } from '../../../../../crypto'
 import { DidCommMessageRepository } from '../../../../../storage'
 import { JsonTransformer } from '../../../../../utils/JsonTransformer'
 import { CredentialState } from '../../../models'
@@ -65,7 +66,7 @@ describe('credentials', () => {
       'Alice Agent Credentials LD'
     ))
     wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
-    await wallet.createDid({ seed })
+    await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
     signCredentialOptions = {
       credential: inputDocAsJson,
       options: {

--- a/packages/core/src/modules/dids/__tests__/peer-did.test.ts
+++ b/packages/core/src/modules/dids/__tests__/peer-did.test.ts
@@ -52,10 +52,12 @@ describe('peer dids', () => {
   test('create a peer did method 1 document from ed25519 keys with a service', async () => {
     // The following scenario show how we could create a key and create a did document from it for DID Exchange
 
-    const { verkey: publicKeyBase58 } = await wallet.createDid({ seed: 'astringoftotalin32characterslong' })
-    const { verkey: mediatorPublicKeyBase58 } = await wallet.createDid({ seed: 'anotherstringof32characterslong1' })
+    const ed25519Key = await wallet.createKey({ seed: 'astringoftotalin32characterslong', keyType: KeyType.Ed25519 })
+    const mediatorEd25519Key = await wallet.createKey({
+      seed: 'anotherstringof32characterslong1',
+      keyType: KeyType.Ed25519,
+    })
 
-    const ed25519Key = Key.fromPublicKeyBase58(publicKeyBase58, KeyType.Ed25519)
     const x25519Key = Key.fromPublicKey(convertPublicKeyToX25519(ed25519Key.publicKey), KeyType.X25519)
 
     const ed25519VerificationMethod = getEd25519VerificationMethod({
@@ -77,10 +79,9 @@ describe('peer dids', () => {
       controller: '#id',
     })
 
-    const mediatorEd25519Key = Key.fromPublicKeyBase58(mediatorPublicKeyBase58, KeyType.Ed25519)
     const mediatorEd25519DidKey = new DidKey(mediatorEd25519Key)
-
     const mediatorX25519Key = Key.fromPublicKey(convertPublicKeyToX25519(mediatorEd25519Key.publicKey), KeyType.X25519)
+
     // Use ed25519 did:key, which also includes the x25519 key used for didcomm
     const mediatorRoutingKey = `${mediatorEd25519DidKey.did}#${mediatorX25519Key.fingerprint}`
 

--- a/packages/core/src/modules/routing/services/MediatorService.ts
+++ b/packages/core/src/modules/routing/services/MediatorService.ts
@@ -8,6 +8,7 @@ import type { ForwardMessage, MediationRequestMessage } from '../messages'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
 import { InjectionSymbols } from '../../../constants'
+import { KeyType } from '../../../crypto'
 import { AriesFrameworkError } from '../../../error'
 import { Logger } from '../../../logger'
 import { injectable, inject } from '../../../plugins'
@@ -199,11 +200,14 @@ export class MediatorService {
   }
 
   public async createMediatorRoutingRecord(agentContext: AgentContext): Promise<MediatorRoutingRecord | null> {
-    const { verkey } = await agentContext.wallet.createDid()
+    const routingKey = await agentContext.wallet.createKey({
+      keyType: KeyType.Ed25519,
+    })
 
     const routingRecord = new MediatorRoutingRecord({
       id: this.mediatorRoutingRepository.MEDIATOR_ROUTING_RECORD_ID,
-      routingKeys: [verkey],
+      // FIXME: update to fingerprint to include the key type
+      routingKeys: [routingKey.publicKeyBase58],
     })
 
     await this.mediatorRoutingRepository.save(agentContext, routingRecord)

--- a/packages/core/src/modules/routing/services/RoutingService.ts
+++ b/packages/core/src/modules/routing/services/RoutingService.ts
@@ -1,9 +1,10 @@
 import type { AgentContext } from '../../../agent'
+import type { Key } from '../../../crypto'
 import type { Routing } from '../../connections'
 import type { RoutingCreatedEvent } from '../RoutingEvents'
 
 import { EventEmitter } from '../../../agent/EventEmitter'
-import { Key, KeyType } from '../../../crypto'
+import { KeyType } from '../../../crypto'
 import { injectable } from '../../../plugins'
 import { RoutingEventTypes } from '../RoutingEvents'
 
@@ -26,9 +27,7 @@ export class RoutingService {
     { mediatorId, useDefaultMediator = true }: GetRoutingOptions = {}
   ): Promise<Routing> {
     // Create and store new key
-    const { verkey: publicKeyBase58 } = await agentContext.wallet.createDid()
-
-    const recipientKey = Key.fromPublicKeyBase58(publicKeyBase58, KeyType.Ed25519)
+    const recipientKey = await agentContext.wallet.createKey({ keyType: KeyType.Ed25519 })
 
     let routing: Routing = {
       endpoints: agentContext.config.endpoints,

--- a/packages/core/src/modules/routing/services/__tests__/RoutingService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/RoutingService.test.ts
@@ -34,10 +34,7 @@ const routing = {
   routingKeys: [],
 }
 mockFunction(mediationRecipientService.addMediationRouting).mockResolvedValue(routing)
-mockFunction(wallet.createDid).mockResolvedValue({
-  did: 'some-did',
-  verkey: recipientKey.publicKeyBase58,
-})
+mockFunction(wallet.createKey).mockResolvedValue(recipientKey)
 
 describe('RoutingService', () => {
   afterEach(() => {

--- a/packages/core/src/modules/vc/__tests__/W3cCredentialService.test.ts
+++ b/packages/core/src/modules/vc/__tests__/W3cCredentialService.test.ts
@@ -2,7 +2,6 @@ import type { AgentContext } from '../../../agent'
 
 import { getAgentConfig, getAgentContext, mockFunction } from '../../../../tests/helpers'
 import { KeyType } from '../../../crypto'
-import { Key } from '../../../crypto/Key'
 import { SigningProviderRegistry } from '../../../crypto/signing-provider'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
 import { IndyWallet } from '../../../wallet/IndyWallet'
@@ -116,9 +115,8 @@ describe('W3cCredentialService', () => {
     let issuerDidKey: DidKey
     let verificationMethod: string
     beforeAll(async () => {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const issuerDidInfo = await wallet.createDid({ seed })
-      const issuerKey = Key.fromPublicKeyBase58(issuerDidInfo.verkey, KeyType.Ed25519)
+      // TODO: update to use did registrar
+      const issuerKey = await wallet.createKey({ keyType: KeyType.Ed25519, seed })
       issuerDidKey = new DidKey(issuerKey)
       verificationMethod = `${issuerDidKey.did}#${issuerDidKey.key.fingerprint}`
     })

--- a/packages/core/src/wallet/IndyWallet.test.ts
+++ b/packages/core/src/wallet/IndyWallet.test.ts
@@ -68,14 +68,6 @@ describe('IndyWallet', () => {
     })
   })
 
-  test('Create DID', async () => {
-    const didInfo = await indyWallet.createDid({ seed: '00000000000000000000000Forward01' })
-    expect(didInfo).toMatchObject({
-      did: 'DtWRdd6C5dN5vpcN6XRAvu',
-      verkey: '82RBSn3heLgXzZd74UsMC8Q8YRfEEhQoAM7LUqE6bevJ',
-    })
-  })
-
   test('Generate Nonce', async () => {
     await expect(indyWallet.generateNonce()).resolves.toEqual(expect.any(String))
   })

--- a/packages/core/src/wallet/IndyWallet.ts
+++ b/packages/core/src/wallet/IndyWallet.ts
@@ -448,24 +448,14 @@ export class IndyWallet implements Wallet {
    * use the `DidsModule`.
    */
   public async initPublicDid(didConfig: DidConfig) {
-    const { did, verkey } = await this.createDid(didConfig)
-    this.publicDidInfo = {
-      did,
-      verkey,
-    }
-  }
-
-  /**
-   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
-   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
-   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
-   * use the `DidsModule`.
-   */
-  public async createDid(didConfig?: DidConfig): Promise<DidInfo> {
+    // The Indy SDK cannot use a key to sign a request for the ledger. This is the only place where we need to call createDid
     try {
       const [did, verkey] = await this.indy.createAndStoreMyDid(this.handle, didConfig || {})
 
-      return { did, verkey }
+      this.publicDidInfo = {
+        did,
+        verkey,
+      }
     } catch (error) {
       if (!isError(error)) {
         throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error')

--- a/packages/core/src/wallet/IndyWallet.ts
+++ b/packages/core/src/wallet/IndyWallet.ts
@@ -63,6 +63,12 @@ export class IndyWallet implements Wallet {
     return this.walletHandle !== undefined
   }
 
+  /**
+   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
+   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
+   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
+   * use the `DidsModule`.
+   */
   public get publicDid() {
     return this.publicDidInfo
   }
@@ -435,6 +441,12 @@ export class IndyWallet implements Wallet {
     }
   }
 
+  /**
+   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
+   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
+   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
+   * use the `DidsModule`.
+   */
   public async initPublicDid(didConfig: DidConfig) {
     const { did, verkey } = await this.createDid(didConfig)
     this.publicDidInfo = {
@@ -443,6 +455,12 @@ export class IndyWallet implements Wallet {
     }
   }
 
+  /**
+   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
+   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
+   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
+   * use the `DidsModule`.
+   */
   public async createDid(didConfig?: DidConfig): Promise<DidInfo> {
     try {
       const [did, verkey] = await this.indy.createAndStoreMyDid(this.handle, didConfig || {})

--- a/packages/core/src/wallet/Wallet.ts
+++ b/packages/core/src/wallet/Wallet.ts
@@ -10,7 +10,14 @@ import type {
 import type { Buffer } from '../utils/buffer'
 
 export interface Wallet extends Disposable {
+  /**
+   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
+   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
+   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
+   * use the `DidsModule`.
+   */
   publicDid: DidInfo | undefined
+
   isInitialized: boolean
   isProvisioned: boolean
 
@@ -27,8 +34,22 @@ export interface Wallet extends Disposable {
   sign(options: WalletSignOptions): Promise<Buffer>
   verify(options: WalletVerifyOptions): Promise<boolean>
 
+  /**
+   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
+   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
+   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
+   * use the `DidsModule`.
+   */
   initPublicDid(didConfig: DidConfig): Promise<void>
+
+  /**
+   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
+   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
+   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
+   * use the `DidsModule`.
+   */
   createDid(didConfig?: DidConfig): Promise<DidInfo>
+
   pack(payload: Record<string, unknown>, recipientKeys: string[], senderVerkey?: string): Promise<EncryptedMessage>
   unpack(encryptedMessage: EncryptedMessage): Promise<UnpackedMessageContext>
   generateNonce(): Promise<string>

--- a/packages/core/src/wallet/Wallet.ts
+++ b/packages/core/src/wallet/Wallet.ts
@@ -42,14 +42,6 @@ export interface Wallet extends Disposable {
    */
   initPublicDid(didConfig: DidConfig): Promise<void>
 
-  /**
-   * @deprecated The public did functionality of the wallet has been deprecated in favour of the DidsModule, which can be
-   * used to create and resolve dids. Currently the global agent public did functionality is still used by the `LedgerModule`, but
-   * will be removed once the `LedgerModule` has been deprecated. Do not use this property for new functionality, but rather
-   * use the `DidsModule`.
-   */
-  createDid(didConfig?: DidConfig): Promise<DidInfo>
-
   pack(payload: Record<string, unknown>, recipientKeys: string[], senderVerkey?: string): Promise<EncryptedMessage>
   unpack(encryptedMessage: EncryptedMessage): Promise<UnpackedMessageContext>
   generateNonce(): Promise<string>

--- a/packages/core/tests/ledger.test.ts
+++ b/packages/core/tests/ledger.test.ts
@@ -1,8 +1,15 @@
 import { promises } from 'fs'
 import * as indy from 'indy-sdk'
 
+import { KeyType } from '../src'
 import { Agent } from '../src/agent/Agent'
-import { DID_IDENTIFIER_REGEX, isAbbreviatedVerkey, isFullVerkey, VERKEY_REGEX } from '../src/utils/did'
+import {
+  DID_IDENTIFIER_REGEX,
+  indyDidFromPublicKeyBase58,
+  isAbbreviatedVerkey,
+  isFullVerkey,
+  VERKEY_REGEX,
+} from '../src/utils/did'
 import { sleep } from '../src/utils/sleep'
 
 import { genesisPath, getAgentOptions } from './helpers'
@@ -63,11 +70,12 @@ describe('ledger', () => {
     }
 
     const faberWallet = faberAgent.context.wallet
-    const didInfo = await faberWallet.createDid()
+    const key = await faberWallet.createKey({ keyType: KeyType.Ed25519 })
+    const did = indyDidFromPublicKeyBase58(key.publicKeyBase58)
 
-    const result = await faberAgent.ledger.registerPublicDid(didInfo.did, didInfo.verkey, 'alias', 'TRUST_ANCHOR')
+    const result = await faberAgent.ledger.registerPublicDid(did, key.publicKeyBase58, 'alias', 'TRUST_ANCHOR')
 
-    expect(result).toEqual(didInfo.did)
+    expect(result).toEqual(did)
   })
 
   test('register schema on ledger', async () => {

--- a/packages/core/tests/mocks/MockWallet.ts
+++ b/packages/core/tests/mocks/MockWallet.ts
@@ -44,9 +44,6 @@ export class MockWallet implements Wallet {
   public initPublicDid(didConfig: DidConfig): Promise<void> {
     throw new Error('Method not implemented.')
   }
-  public createDid(didConfig?: DidConfig): Promise<DidInfo> {
-    throw new Error('Method not implemented.')
-  }
   public pack(
     payload: Record<string, unknown>,
     recipientKeys: string[],


### PR DESCRIPTION
Removes the `wallet.createDid()` method from the agent. The did registrar module should be used instead to create indy dids. 

The agent.publicDid is kept in for now as it is needed by the ledger module, and we need it to add the endorser did to the agent. Intend to add a feature soon to add an existing did to the agent (for endorsement)

Also adds `@deprecated` tags to all wallet / agent public did functionality that is left to indicate these are deprecated and will be removed once we have replaced the ledger module (which will be when the new anoncreds module is ready). 

I think this is a big step in making AFJ not Indy focused.

There's some gaps in the dids module we need to resolve before it can be fully replaced, mainly:
- Migrate public dids created with the wallet to did records (can be done using a migration script I think)
- Allow to store a created did without necesarily writing it to the ledger. This is the case with endorser dids, where I add the did based on a seed, and the did is already registered on the ledger. I think a method like `storeCreatedDid` where you pass the did, it will resolve it to get the did document with recipientKeys and you'll then be able to use it.