### PR TITLE
docs: update readme packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Some features are not yet supported, but are on our roadmap. Check [the roadmap]
 - ✅ Smart Auto Acceptance of Connections, Credentials and Proofs
 - 🚧 Receiving and Verifying revocable Indy Credentials
 - 🚧 W3C Linked Data VCs, BBS+ Signatures
-- 🚧 Multi Tenancy
+- ✅ Multi Tenancy
 - ❌ Browser
 
 ### Packages
@@ -98,6 +98,38 @@ Some features are not yet supported, but are on our roadmap. Check [the roadmap]
     <td>
       <a href="https://npmjs.com/package/@aries-framework/react-native">
         <img alt="@aries-framework/react-native version" src="https://img.shields.io/npm/v/@aries-framework/react-native"/>
+      </a>
+    </td>
+  </tr>
+   <tr>
+    <td>@aries-framework/action-menu</td>
+    <td>
+      <a href="https://npmjs.com/package/@aries-framework/action-menu">
+        <img alt="@aries-framework/action-menu version" src="https://img.shields.io/npm/v/@aries-framework/action-menu"/>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td>@aries-framework/bbs-signatures</td>
+    <td>
+      <a href="https://npmjs.com/package/@aries-framework/bbs-signatures">
+        <img alt="@aries-framework/bbs-signatures version" src="https://img.shields.io/npm/v/@aries-framework/bbs-signatures"/>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td>@aries-framework/action-menu</td>
+    <td>
+      <a href="https://npmjs.com/package/@aries-framework/question-answer">
+        <img alt="@aries-framework/question-answer version" src="https://img.shields.io/npm/v/@aries-framework/question-answer"/>
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td>@aries-framework/action-menu</td>
+    <td>
+      <a href="https://npmjs.com/package/@aries-framework/tenants">
+        <img alt="@aries-framework/tenants version" src="https://img.shields.io/npm/v/@aries-framework/tenants"/>
       </a>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Some features are not yet supported, but are on our roadmap. Check [the roadmap]
     </td>
   </tr>
   <tr>
-    <td>@aries-framework/action-menu</td>
+    <td>@aries-framework/question-answer</td>
     <td>
       <a href="https://npmjs.com/package/@aries-framework/question-answer">
         <img alt="@aries-framework/question-answer version" src="https://img.shields.io/npm/v/@aries-framework/question-answer"/>

--- a/README.md
+++ b/README.md
@@ -109,15 +109,6 @@ Some features are not yet supported, but are on our roadmap. Check [the roadmap]
       </a>
     </td>
   </tr>
-  <tr>
-    <td>@aries-framework/bbs-signatures</td>
-    <td>
-      <a href="https://npmjs.com/package/@aries-framework/bbs-signatures">
-        <img alt="@aries-framework/bbs-signatures version" src="https://img.shields.io/npm/v/@aries-framework/bbs-signatures"/>
-      </a>
-    </td>
-  </tr>
-  <tr>
     <td>@aries-framework/question-answer</td>
     <td>
       <a href="https://npmjs.com/package/@aries-framework/question-answer">

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Some features are not yet supported, but are on our roadmap. Check [the roadmap]
     </td>
   </tr>
   <tr>
-    <td>@aries-framework/action-menu</td>
+    <td>@aries-framework/tenants</td>
     <td>
       <a href="https://npmjs.com/package/@aries-framework/tenants">
         <img alt="@aries-framework/tenants version" src="https://img.shields.io/npm/v/@aries-framework/tenants"/>


### PR DESCRIPTION
I noticed only the `core`, `node` and `react-native` packages were listed in the `README.md`. I'm not sure if this was done on purpose or just forgotten. I've added the `bbs-signatures`, `action-menu`, `question-answer`, and `tenants` modules and updated the `tenants` roadmap state from 🚧  to  ✅. Please comment/reject if this is incorrect.

Also, I've just appended the missing modules to the table for now. I'm not sure about the ordering of these modules/table rows. One approach is to order them alphabetically, but my personal preference is to order them by relevance.

**Example:**
1. `core` -- as you'll always need it
2. `node` & `react-native` (in random order) -- as you'll always need one of the two
3. Other modules -- as they really depend on your use case.

Signed-off-by: Karim Stekelenburg <karim@animo.id>