### PR TITLE
chore: remove husky pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,0 @@
-yarn validate

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test": "jest",
     "lint": "eslint --ignore-path .gitignore .",
     "validate": "yarn lint && yarn check-types && yarn check-format",
-    "prepare": "husky install",
     "run-mediator": "ts-node ./samples/mediator.ts",
     "next-version-bump": "ts-node ./scripts/get-next-bump.ts"
   },
@@ -48,7 +47,6 @@
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-prettier": "^3.4.0",
     "express": "^4.17.1",
-    "husky": "^7.0.1",
     "indy-sdk": "^1.16.0-dev-1636",
     "jest": "^27.0.4",
     "lerna": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5871,11 +5871,6 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
-husky@^7.0.1:
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.4.tgz#242048245dc49c8fb1bf0cc7cfb98dd722531535"
-  integrity sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==
-
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Removes the husky pre-push hook, as the command takes way too long to run, and we have CI to make sure we aren't including broken code.

