### PR TITLE
fix(openid4vc-client): set package to private

### DIFF
--- a/packages/openid4vc-client/package.json
+++ b/packages/openid4vc-client/package.json
@@ -6,6 +6,7 @@
   "files": [
     "build"
   ],
+  "private": true,
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
I didn't set the package to private by accident in my previous PR. Here is the fix to avoid this from happening again.

Signed-off-by: Karim Stekelenburg <karim@animo.id>