### PR TITLE
chore: deprecate injectionContainer on agent

### DIFF
--- a/packages/bbs-signatures/tests/v2.ldproof.credentials.propose-offerBbs.test.ts
+++ b/packages/bbs-signatures/tests/v2.ldproof.credentials.propose-offerBbs.test.ts
@@ -35,7 +35,7 @@ describeSkipNode17And18('credentials, BBS+ signature', () => {
       'Faber Agent Credentials LD BBS+',
       'Alice Agent Credentials LD BBS+'
     ))
-    wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
+    wallet = faberAgent.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
     await wallet.createKey({ keyType: KeyType.Ed25519, seed })
     const key = await wallet.createKey({ keyType: KeyType.Bls12381g2, seed })
 

--- a/packages/core/src/agent/BaseAgent.ts
+++ b/packages/core/src/agent/BaseAgent.ts
@@ -194,6 +194,9 @@ export abstract class BaseAgent<AgentModules extends ModulesMap = EmptyModuleMap
     })
   }
 
+  /**
+   * @deprecated The injectionContainer property has been deprecated in favour of the dependencyManager property.
+   */
   public get injectionContainer() {
     return this.dependencyManager.container
   }

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.connectionless-credentials.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.connectionless-credentials.test.ts
@@ -104,7 +104,7 @@ describe('credentials', () => {
     aliceAgent.events
       .observable<CredentialStateChangedEvent>(CredentialEventTypes.CredentialStateChanged)
       .subscribe(aliceReplay)
-    wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
+    wallet = faberAgent.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
 
     await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
 

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials-auto-accept.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials-auto-accept.test.ts
@@ -43,7 +43,7 @@ describe('credentials', () => {
         AutoAcceptCredential.Always
       ))
 
-      wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
+      wallet = faberAgent.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
       await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
       signCredentialOptions = {
         credential: TEST_LD_DOCUMENT,
@@ -142,7 +142,7 @@ describe('credentials', () => {
         'alice agent: content-approved v2 jsonld',
         AutoAcceptCredential.ContentApproved
       ))
-      wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
+      wallet = faberAgent.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
       await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
       signCredentialOptions = {
         credential: TEST_LD_DOCUMENT,

--- a/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials.propose-offerED25519.test.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/__tests__/v2.ldproof.credentials.propose-offerED25519.test.ts
@@ -65,7 +65,7 @@ describe('credentials', () => {
       'Faber Agent Credentials LD',
       'Alice Agent Credentials LD'
     ))
-    wallet = faberAgent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
+    wallet = faberAgent.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
     await wallet.createKey({ seed, keyType: KeyType.Ed25519 })
     signCredentialOptions = {
       credential: inputDocAsJson,
@@ -312,7 +312,6 @@ describe('credentials', () => {
       threadId: faberCredentialRecord.threadId,
       state: CredentialState.OfferReceived,
     })
-    // didCommMessageRepository = faberAgent.injectionContainer.resolve(DidCommMessageRepository)
     didCommMessageRepository = faberAgent.dependencyManager.resolve(DidCommMessageRepository)
 
     const offerMessage = await didCommMessageRepository.findAgentMessage(faberAgent.context, {

--- a/packages/core/src/modules/dids/__tests__/dids-registrar.e2e.test.ts
+++ b/packages/core/src/modules/dids/__tests__/dids-registrar.e2e.test.ts
@@ -177,7 +177,7 @@ describe('dids', () => {
     const ed25519PublicKeyBase58 = TypedArrayEncoder.toBase58(publicKeyEd25519)
     const indyDid = indyDidFromPublicKeyBase58(ed25519PublicKeyBase58)
 
-    const wallet = agent.injectionContainer.resolve<Wallet>(InjectionSymbols.Wallet)
+    const wallet = agent.dependencyManager.resolve<Wallet>(InjectionSymbols.Wallet)
     // eslint-disable-next-line @typescript-eslint/no-non-null-asserted-optional-chain, @typescript-eslint/no-non-null-assertion
     const submitterDid = `did:sov:${wallet.publicDid?.did!}`
 

--- a/packages/core/src/modules/proofs/protocol/v1/__tests__/indy-proof-negotiation.test.ts
+++ b/packages/core/src/modules/proofs/protocol/v1/__tests__/indy-proof-negotiation.test.ts
@@ -66,7 +66,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     let proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -159,7 +159,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for proof request from Faber')
     aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     let request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -212,7 +212,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -266,7 +266,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for proof request from Faber')
     aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/core/src/modules/proofs/protocol/v1/__tests__/indy-proof-presentation.test.ts
+++ b/packages/core/src/modules/proofs/protocol/v1/__tests__/indy-proof-presentation.test.ts
@@ -60,7 +60,7 @@ describe('Present Proof', () => {
 
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -118,7 +118,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for proof request from Faber')
     aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/core/src/modules/proofs/protocol/v1/__tests__/indy-proof-proposal.test.ts
+++ b/packages/core/src/modules/proofs/protocol/v1/__tests__/indy-proof-proposal.test.ts
@@ -58,7 +58,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/core/src/modules/proofs/protocol/v1/__tests__/indy-proof-request.test.ts
+++ b/packages/core/src/modules/proofs/protocol/v1/__tests__/indy-proof-request.test.ts
@@ -60,7 +60,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -120,7 +120,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for proof request from Faber')
     aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/core/src/modules/proofs/protocol/v2/__tests__/indy-proof-negotiation.test.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/__tests__/indy-proof-negotiation.test.ts
@@ -69,7 +69,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     let proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -188,7 +188,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for proof request from Faber')
     aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     let request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -241,7 +241,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -319,7 +319,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for proof request from Faber')
     aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/core/src/modules/proofs/protocol/v2/__tests__/indy-proof-presentation.test.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/__tests__/indy-proof-presentation.test.ts
@@ -66,7 +66,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberProofExchangeRecord = await faberPresentationRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -118,7 +118,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for proof request from Faber')
     aliceProofExchangeRecord = await alicePresentationRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/core/src/modules/proofs/protocol/v2/__tests__/indy-proof-proposal.test.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/__tests__/indy-proof-proposal.test.ts
@@ -59,7 +59,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberPresentationRecord = await faberPresentationRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberPresentationRecord.id,

--- a/packages/core/src/modules/proofs/protocol/v2/__tests__/indy-proof-request.test.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/__tests__/indy-proof-request.test.ts
@@ -62,7 +62,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for presentation from Alice')
     faberProofExchangeRecord = await faberPresentationRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -114,7 +114,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for proof request from Faber')
     aliceProofExchangeRecord = await alicePresentationRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/core/src/storage/migration/__tests__/0.1.test.ts
+++ b/packages/core/src/storage/migration/__tests__/0.1.test.ts
@@ -48,7 +48,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
         dependencyManager
       )
 
-      const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+      const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
 
       const updateAssistant = new UpdateAssistant(agent, {
         v0_1ToV0_2: {
@@ -110,7 +110,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
       dependencyManager
     )
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
 
     const updateAssistant = new UpdateAssistant(agent, {
       v0_1ToV0_2: {
@@ -174,7 +174,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
       dependencyManager
     )
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
 
     const updateAssistant = new UpdateAssistant(agent, {
       v0_1ToV0_2: {
@@ -242,7 +242,7 @@ describe('UpdateAssistant | v0.1 - v0.2', () => {
       dependencyManager
     )
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
 
     const updateAssistant = new UpdateAssistant(agent, {
       v0_1ToV0_2: {

--- a/packages/core/src/storage/migration/__tests__/0.2.test.ts
+++ b/packages/core/src/storage/migration/__tests__/0.2.test.ts
@@ -46,7 +46,7 @@ describe('UpdateAssistant | v0.2 - v0.3.1', () => {
       dependencyManager
     )
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
 
     const updateAssistant = new UpdateAssistant(agent, {
       v0_1ToV0_2: {
@@ -119,7 +119,7 @@ describe('UpdateAssistant | v0.2 - v0.3.1', () => {
       dependencyManager
     )
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
 
     // We need to manually initialize the wallet as we're using the in memory wallet service
     // When we call agent.initialize() it will create the wallet and store the current framework
@@ -170,7 +170,7 @@ describe('UpdateAssistant | v0.2 - v0.3.1', () => {
       dependencyManager
     )
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
 
     // We need to manually initialize the wallet as we're using the in memory wallet service
     // When we call agent.initialize() it will create the wallet and store the current framework

--- a/packages/core/src/storage/migration/__tests__/0.3.test.ts
+++ b/packages/core/src/storage/migration/__tests__/0.3.test.ts
@@ -43,7 +43,7 @@ describe('UpdateAssistant | v0.3 - v0.3.1', () => {
       dependencyManager
     )
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
 
     const updateAssistant = new UpdateAssistant(agent, {
       v0_1ToV0_2: {

--- a/packages/core/src/storage/migration/__tests__/backup.test.ts
+++ b/packages/core/src/storage/migration/__tests__/backup.test.ts
@@ -81,7 +81,7 @@ describe('UpdateAssistant | Backup', () => {
     // Expect an update is needed
     expect(await updateAssistant.isUpToDate()).toBe(false)
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
     // Backup should not exist before update
     expect(await fileSystem.exists(backupPath)).toBe(false)
 
@@ -128,7 +128,7 @@ describe('UpdateAssistant | Backup', () => {
       },
     ])
 
-    const fileSystem = agent.injectionContainer.resolve<FileSystem>(InjectionSymbols.FileSystem)
+    const fileSystem = agent.dependencyManager.resolve<FileSystem>(InjectionSymbols.FileSystem)
     // Backup should not exist before update
     expect(await fileSystem.exists(backupPath)).toBe(false)
 

--- a/packages/core/tests/v1-indy-proofs.test.ts
+++ b/packages/core/tests/v1-indy-proofs.test.ts
@@ -71,7 +71,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for a presentation proposal from Alice')
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -390,7 +390,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for presentation request from Faber')
     aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,
@@ -615,7 +615,7 @@ describe('Present Proof', () => {
     testLogger.test('Alice waits for presentation request from Faber')
     aliceProofExchangeRecord = await aliceProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const request = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/core/tests/v2-indy-proofs.test.ts
+++ b/packages/core/tests/v2-indy-proofs.test.ts
@@ -78,7 +78,7 @@ describe('Present Proof', () => {
     testLogger.test('Faber waits for a presentation proposal from Alice')
     faberProofExchangeRecord = await faberProofExchangeRecordPromise
 
-    didCommMessageRepository = faberAgent.injectionContainer.resolve<DidCommMessageRepository>(DidCommMessageRepository)
+    didCommMessageRepository = faberAgent.dependencyManager.resolve<DidCommMessageRepository>(DidCommMessageRepository)
 
     const proposal = await didCommMessageRepository.findAgentMessage(faberAgent.context, {
       associatedRecordId: faberProofExchangeRecord.id,

--- a/packages/node/src/transport/WsInboundTransport.ts
+++ b/packages/node/src/transport/WsInboundTransport.ts
@@ -58,7 +58,7 @@ export class WsInboundTransport implements InboundTransport {
   }
 
   private listenOnWebSocketMessages(agent: Agent, socket: WebSocket, session: TransportSession) {
-    const messageReceiver = agent.injectionContainer.resolve(MessageReceiver)
+    const messageReceiver = agent.dependencyManager.resolve(MessageReceiver)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     socket.addEventListener('message', async (event: any) => {

--- a/tests/transport/SubjectOutboundTransport.ts
+++ b/tests/transport/SubjectOutboundTransport.ts
@@ -29,7 +29,7 @@ export class SubjectOutboundTransport implements OutboundTransport {
   }
 
   public async sendMessage(outboundPackage: OutboundPackage) {
-    const messageReceiver = this.agent.injectionContainer.resolve(MessageReceiver)
+    const messageReceiver = this.agent.dependencyManager.resolve(MessageReceiver)
     this.logger.debug(`Sending outbound message to endpoint ${outboundPackage.endpoint}`, {
       endpoint: outboundPackage.endpoint,
     })


### PR DESCRIPTION
Marks the `agent.injectionContainer` as deprecated. We now have the `dependencyManager` that wraps the injection container from tsyringe.

This doesn't remove the property yet, but updates all usage of it in the codebase and marks it as deprecated so we can remove it in 0.4.0.