### PR TITLE
ci: forceExit and bail tests 

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -108,7 +108,7 @@ jobs:
         run: yarn install
 
       - name: Run tests
-        run: TEST_AGENT_PUBLIC_DID_SEED=${TEST_AGENT_PUBLIC_DID_SEED} GENESIS_TXN_PATH=${GENESIS_TXN_PATH} yarn test --coverage
+        run: TEST_AGENT_PUBLIC_DID_SEED=${TEST_AGENT_PUBLIC_DID_SEED} GENESIS_TXN_PATH=${GENESIS_TXN_PATH} yarn test --coverage --forceExit --bail
 
       - uses: codecov/codecov-action@v1
         if: always()

--- a/packages/anoncreds/jest.config.ts
+++ b/packages/anoncreds/jest.config.ts
@@ -8,7 +8,7 @@ const config: Config.InitialOptions = {
   ...base,
   name: packageJson.name,
   displayName: packageJson.name,
-  // setupFilesAfterEnv: ['./tests/setup.ts'],
+  setupFilesAfterEnv: ['./tests/setup.ts'],
 }
 
 export default config

--- a/packages/anoncreds/tests/setup.ts
+++ b/packages/anoncreds/tests/setup.ts
@@ -1,0 +1,1 @@
+jest.setTimeout(10000)


### PR DESCRIPTION
Signed-off-by: Timo Glastra <timo@animo.id>

This PR adds `--forceExit --bail` to the test script when running in CI. It won't necesarily fix the issues we have with flaky tests, but it should fix the tests keeping running even though a timeout has occurred. The `--bail` means it will also stop tests after one test has failed instead of continuing running. 

Ideally we don't use `--forceExit` as it's discouraged by Jest and you should gracefully exit. However, I've been doing tests with minimal setups and I think the issue of not exiting is because of the Indy SDK doing tasks while the test times out, and that prevents from a graceful exit. I'm not sure this is the case, but this is my current feeling.

I've tried migrating to vitest over jest as it has way better logging and feels quicker / simpler (that's how I discovered the test issues have something to do with the indy-sdk). However, vite doesn't support decorators at the moment (well, esbuild doesn't) so we can't switch at the moment.

I hope these changes will at least give us more insights into which tests are causing the flakyness