### PR TITLE
ci: configure max workers for jest

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -107,8 +107,11 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
+      - name: Get number of CPU cores
+        uses: SimenB/github-actions-cpu-cores@v1
+
       - name: Run tests
-        run: TEST_AGENT_PUBLIC_DID_SEED=${TEST_AGENT_PUBLIC_DID_SEED} GENESIS_TXN_PATH=${GENESIS_TXN_PATH} yarn test --coverage --forceExit --bail
+        run: TEST_AGENT_PUBLIC_DID_SEED=${TEST_AGENT_PUBLIC_DID_SEED} GENESIS_TXN_PATH=${GENESIS_TXN_PATH} yarn test --coverage --forceExit --bail --max-workers ${{ steps.cpu-cores.outputs.count }}
 
       - uses: codecov/codecov-action@v1
         if: always()


### PR DESCRIPTION
Test to see if it will speed up the jest test runs. It's using an action from one of the jest maintainers to determien the availalbe cores.

Another thing we can try is to use sharding. Jest supports the `--shard x/n` to split up your test run. This way we could e.g. split up the test in 3 shards. 

We could also look at running the postgres tests separately as they need the postgres plugin / postgres server installed and running which takes a few minutes.

So one possible thing could be:
- Test with postgres plugin that will only run postgres tests
- 2 or shards that will run all tests except for the postgres test

If we can get the time of test script to be reduced from ~25 min to ~10 minutes that would be great.