### PR TITLE
feat: add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,43 +1,20 @@
-FROM ubuntu:21.10
+# arm + amd compatible Dockerfile
+FROM ghcr.io/findy-network/findy-base:indy-1.16.ubuntu-18.04 AS indy-base
 
-ENV TZ=UTC
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
-    echo $TZ > /etc/timezone
+FROM ubuntu:18.04
 
-RUN apt-get update && \
-    apt-get install -y tzdata curl gnupg git \
-    software-properties-common iproute2
+# install indy deps and files from base
+RUN apt-get update && apt-get install -y libsodium23 libssl1.1 libzmq5 git zsh
 
-RUN apt-get install -y \
-    build-essential \
-    pkg-config \
-    cmake \
-    libssl-dev \
-    libsqlite3-dev \
-    libzmq3-dev \
-    libncursesw5-dev
+COPY --from=indy-base /usr/include/indy /usr/include/indy
+COPY --from=indy-base /usr/lib/libindy.a /usr/lib/libindy.a
+COPY --from=indy-base /usr/lib/libindy.so /usr/lib/libindy.so
 
-RUN curl -Ls https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz | \
-    tar -zx -C / && \
-    cd /libsodium-1.0.18 && \
-    ./configure --disable-sharedmake && \
-    make && \
-    make check && \
-    make install && \
-    cd - && \
-    rm -rf /libsodium-1.0.18
+RUN apt-get install -y curl python3 build-essential ca-certificates && \
+  curl https://raw.githubusercontent.com/creationix/nvm/master/install.sh | bash && \
+  export NVM_DIR="$HOME/.nvm" && \
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+  nvm install v16 && \
+  npm install yarn -g
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-RUN git clone https://github.com/hyperledger/indy-sdk.git && \
-    cd ./indy-sdk/libindy && \
-    /root/.cargo/bin/cargo build && \
-    echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/indy-sdk/libindy/target/debug" >> ~/.bashrc && \
-    ldconfig && \
-    . ~/.bashrc
-
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash && \
-    . ~/.bashrc && \
-    nvm install v12.22.1 && \
-    nvm install-latest-npm && \
-    npm install --global yarn
+RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,43 @@
+FROM ubuntu:21.10
+
+ENV TZ=UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone
+
+RUN apt-get update && \
+    apt-get install -y tzdata curl gnupg git \
+    software-properties-common iproute2
+
+RUN apt-get install -y \
+    build-essential \
+    pkg-config \
+    cmake \
+    libssl-dev \
+    libsqlite3-dev \
+    libzmq3-dev \
+    libncursesw5-dev
+
+RUN curl -Ls https://download.libsodium.org/libsodium/releases/libsodium-1.0.18.tar.gz | \
+    tar -zx -C / && \
+    cd /libsodium-1.0.18 && \
+    ./configure --disable-sharedmake && \
+    make && \
+    make check && \
+    make install && \
+    cd - && \
+    rm -rf /libsodium-1.0.18
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+RUN git clone https://github.com/hyperledger/indy-sdk.git && \
+    cd ./indy-sdk/libindy && \
+    /root/.cargo/bin/cargo build && \
+    echo "export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/indy-sdk/libindy/target/debug" >> ~/.bashrc && \
+    ldconfig && \
+    . ~/.bashrc
+
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash && \
+    . ~/.bashrc && \
+    nvm install v12.22.1 && \
+    nvm install-latest-npm && \
+    npm install --global yarn

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,5 +16,3 @@ RUN apt-get install -y curl python3 build-essential ca-certificates && \
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
   nvm install v16 && \
   npm install yarn -g
-
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -2,3 +2,6 @@
 # Any environment variables that the container needs
 # go in here.
 #
+# Example(s)
+# GENESIS_TXN_PATH=network/genesis/local-genesis.txn
+#

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -3,5 +3,5 @@
 # go in here.
 #
 # Example(s)
-# GENESIS_TXN_PATH=network/genesis/local-genesis.txn
+# GENESIS_TXN_PATH=/work/network/genesis/local-genesis.txn
 #

--- a/.devcontainer/devcontainer.env
+++ b/.devcontainer/devcontainer.env
@@ -1,0 +1,4 @@
+#
+# Any environment variables that the container needs
+# go in here.
+#

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,11 @@
 {
   "build": { 
-    "dockerfile": "Dockerfile"
+    "dockerfile": "Dockerfile" 
   },
-  "forwardPorts": [8088, 8089],
   "runArgs": [
-    "--network=bridge"
-  ]
+    "--env-file",
+    ".devcontainer/devcontainer.env"
+  ],
+  "workspaceMount": "source=${localWorkspaceFolder},target=/work,type=bind",
+  "workspaceFolder": "/work"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,8 @@
 {
-  "build": { 
-    "dockerfile": "Dockerfile" 
+  "build": {
+    "dockerfile": "Dockerfile"
   },
-  "runArgs": [
-    "--env-file",
-    ".devcontainer/devcontainer.env"
-  ],
+  "runArgs": ["--env-file", ".devcontainer/devcontainer.env"],
   "workspaceMount": "source=${localWorkspaceFolder},target=/work,type=bind",
   "workspaceFolder": "/work"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,9 @@
+{
+  "build": { 
+    "dockerfile": "Dockerfile"
+  },
+  "forwardPorts": [8088, 8089],
+  "runArgs": [
+    "--network=bridge"
+  ]
+}

--- a/DEVREADME.md
+++ b/DEVREADME.md
@@ -6,7 +6,15 @@ This file is intended for developers working on the internals of the framework. 
 
 ## VSCode devContainer
 
-This project comes with a [.devcontainer](./devcontainer) to make it as easy as possible to setup your dev environment and begin contributing to this project. All the [environment variables](https://code.visualstudio.com/remote/advancedcontainers/environment-variables) noted below can be added to [devcontainer.env](./devcontainer.env) and exposed to the development docker container.
+This project comes with a [.devcontainer](./devcontainer) to make it as easy as possible to setup your dev environment and begin contributing to this project.
+
+All the [environment variables](https://code.visualstudio.com/remote/advancedcontainers/environment-variables) noted below can be added to [devcontainer.env](./devcontainer.env) and exposed to the development docker container.
+
+When running in a container your project root directory will be `/work`. Use this to correctly path any environment variables, for example:
+
+```console
+GENESIS_TXN_PATH=/work/network/genesis/local-genesis.txn
+```
 
 ## Running tests
 

--- a/DEVREADME.md
+++ b/DEVREADME.md
@@ -2,6 +2,12 @@
 
 This file is intended for developers working on the internals of the framework. If you're just looking how to get started with the framework, see the [docs](./docs)
 
+# Environment Setup
+
+## VSCode devContainer
+
+This project comes with a [.devcontainer](./devcontainer) to make it as easy as possible to setup your dev environment and begin contributing to this project. All the [environment variables](https://code.visualstudio.com/remote/advancedcontainers/environment-variables) noted below can be added to [devcontainer.env](./devcontainer.env) and exposed to the development docker container.
+
 ## Running tests
 
 Test are executed using jest. Some test require either the **mediator agents** or the **ledger** to be running. When running tests that require a connection to the ledger pool, you need to set the `TEST_AGENT_PUBLIC_DID_SEED` and `GENESIS_TXN_PATH` environment variables.


### PR DESCRIPTION
Initial work on adding devcontainer support to make development easier for Mac, Windows and Linux. The [Dockerfile](.devcontainer/Dockerfile) located in the `.devcontainer` directory is used to build the working container.

Fixes #1281

![screenshot](https://user-images.githubusercontent.com/390891/217969554-e7e530dc-fada-40db-bd33-35938b4f1290.jpg)

