### PR TITLE
fix(askar): generate nonce suitable for anoncreds

### DIFF
--- a/packages/askar/package.json
+++ b/packages/askar/package.json
@@ -26,12 +26,14 @@
   "dependencies": {
     "@aries-framework/core": "0.3.3",
     "@hyperledger/aries-askar-shared": "^0.1.0-dev.1",
+    "bn.js": "^5.2.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "rxjs": "^7.2.0",
     "tsyringe": "^4.7.0"
   },
   "devDependencies": {
+    "@types/bn.js": "^5.1.0",
     "@hyperledger/aries-askar-nodejs": "^0.1.0-dev.1",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^4.0.7",

--- a/packages/askar/src/wallet/AskarWallet.ts
+++ b/packages/askar/src/wallet/AskarWallet.ts
@@ -34,7 +34,6 @@ import {
   FileSystem,
   WalletNotFoundError,
 } from '@aries-framework/core'
-// eslint-disable-next-line import/order
 import {
   StoreKeyMethod,
   KeyAlgs,
@@ -43,6 +42,8 @@ import {
   Key as AskarKey,
   keyAlgFromString,
 } from '@hyperledger/aries-askar-shared'
+// eslint-disable-next-line import/order
+import BigNumber from 'bn.js'
 
 const isError = (error: unknown): error is Error => error instanceof Error
 
@@ -669,7 +670,9 @@ export class AskarWallet implements Wallet {
 
   public async generateNonce(): Promise<string> {
     try {
-      return TypedArrayEncoder.toUtf8String(CryptoBox.randomNonce())
+      // generate an 80-bit nonce suitable for AnonCreds proofs
+      const nonce = CryptoBox.randomNonce().slice(0, 10)
+      return new BigNumber(nonce).toString()
     } catch (error) {
       if (!isError(error)) {
         throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })

--- a/packages/askar/src/wallet/__tests__/AskarWallet.test.ts
+++ b/packages/askar/src/wallet/__tests__/AskarWallet.test.ts
@@ -57,7 +57,9 @@ describe('AskarWallet basic operations', () => {
   })
 
   test('Generate Nonce', async () => {
-    await expect(askarWallet.generateNonce()).resolves.toEqual(expect.any(String))
+    const nonce = await askarWallet.generateNonce()
+
+    expect(nonce).toMatch(/[0-9]+/)
   })
 
   test('Create ed25519 keypair', async () => {


### PR DESCRIPTION
The one that was returned by `AskarWallet.generateNonce()` is not usable for AnonCreds proofs and credential issuance flow, so it is now adjusted to return something equivalent to what's in IndyWallet or anoncreds-rs.

As part of a further refactor, this functionality will be most likely moved to `anoncreds` package, as it is more related to AnonCreds specification than the Wallet itself.

