### PR TITLE
refactor!: set default outbound content type to didcomm v1

### DIFF
--- a/packages/core/src/agent/AgentConfig.ts
+++ b/packages/core/src/agent/AgentConfig.ts
@@ -86,7 +86,7 @@ export class AgentConfig {
   }
 
   public get didCommMimeType() {
-    return this.initConfig.didCommMimeType ?? DidCommMimeType.V0
+    return this.initConfig.didCommMimeType ?? DidCommMimeType.V1
   }
 
   /**


### PR DESCRIPTION
Sets the default didcomm content type for outbound http transport to v1. I think it's a good time to switch the default from v0 to v1