### PR TITLE
fix(openid): remove unnecessary scope check

### DIFF
--- a/packages/openid4vc-client/src/OpenId4VcClientService.ts
+++ b/packages/openid4vc-client/src/OpenId4VcClientService.ts
@@ -155,15 +155,6 @@ export class OpenId4VcClientService {
 
     this.logger.info('Fetched server accessToken', accessToken)
 
-    // We currently need the ts-ignore because the type
-    // inside of OpenID4VCIClient needs to be updated.
-    // @ts-ignore
-    if (!accessToken.scope) {
-      throw new AriesFrameworkError(
-        "Access token response doesn't contain a scope. Only scoped issuer URIs are supported at this time."
-      )
-    }
-
     const serverMetadata = await client.retrieveServerMetadata()
 
     // @ts-ignore


### PR DESCRIPTION
The OpenID4VC-client module was throwing errors due to the absence of the optional scope property in some access_token responses, leading to valid tokens being treated as invalid.

Related to #1322 

Signed-off-by: Karim Stekelenburg <karim@animo.id>
