### PR TITLE
fix: create new socket if socket state is 'closing'

### DIFF
--- a/packages/core/src/transport/WsOutboundTransport.ts
+++ b/packages/core/src/transport/WsOutboundTransport.ts
@@ -75,7 +75,7 @@ export class WsOutboundTransport implements OutboundTransport {
     // If we already have a socket connection use it
     let socket = this.transportTable.get(socketId)
 
-    if (!socket) {
+    if (!socket || socket.readyState === this.WebSocketClass.CLOSING) {
       if (!endpoint) {
         throw new AriesFrameworkError(`Missing endpoint. I don't know how and where to send the message.`)
       }


### PR DESCRIPTION
Found issue where sending message fails with `Socket is not open.` when only using websocket transports (no http transports).

WS is used to create initial connection, and then starts before mediation request, causing socket state to update to 'CLOSING'. Since this is done before the `close` event is emitted, the relevant socket map value  of `WsOutboundTransport` hasn't been deleted yet, so when we try to send the next message too quickly this error case can happen.