### PR TITLE
fix(indy-sdk): import from core

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,8 +5,10 @@ module.exports = {
     'plugin:import/recommended',
     'plugin:import/typescript',
     'plugin:@typescript-eslint/recommended',
+    'plugin:workspaces/recommended',
     'plugin:prettier/recommended', // Enables eslint-plugin-prettier and displays prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
   ],
+  plugins: ['workspaces'],
   parserOptions: {
     tsconfigRootDir: __dirname,
     project: ['./tsconfig.eslint.json'],
@@ -44,6 +46,7 @@ module.exports = {
         'newlines-between': 'always',
       },
     ],
+    'workspaces/no-relative-imports': 'error',
     '@typescript-eslint/no-non-null-assertion': 'error',
     'import/no-extraneous-dependencies': [
       'error',
@@ -120,6 +123,14 @@ module.exports = {
             devDependencies: true,
           },
         ],
+      },
+    },
+    {
+      files: ['*.test.ts', '**/__tests__/**', '**/tests/**', '**/tests/**'],
+      rules: {
+        'workspaces/no-relative-imports': 'off',
+        'workspaces/require-dependency': 'off',
+        'workspaces/no-absolute-imports': 'off',
       },
     },
   ],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,7 +46,6 @@ module.exports = {
         'newlines-between': 'always',
       },
     ],
-    'workspaces/no-relative-imports': 'error',
     '@typescript-eslint/no-non-null-assertion': 'error',
     'import/no-extraneous-dependencies': [
       'error',

--- a/demo/src/BaseAgent.ts
+++ b/demo/src/BaseAgent.ts
@@ -1,6 +1,6 @@
-import type { IndySdkPoolConfig } from '../../packages/indy-sdk/src/ledger'
-import type { IndyVdrPoolConfig } from '../../packages/indy-vdr/src/pool'
 import type { InitConfig } from '@aries-framework/core'
+import type { IndySdkPoolConfig } from '@aries-framework/indy-sdk'
+import type { IndyVdrPoolConfig } from '@aries-framework/indy-vdr'
 
 import {
   AnonCredsModule,

--- a/demo/src/Faber.ts
+++ b/demo/src/Faber.ts
@@ -1,4 +1,4 @@
-import type { RegisterCredentialDefinitionReturnStateFinished } from '../../packages/anoncreds/src'
+import type { RegisterCredentialDefinitionReturnStateFinished } from '@aries-framework/anoncreds'
 import type { ConnectionRecord, ConnectionStateChangedEvent } from '@aries-framework/core'
 import type BottomBar from 'inquirer/lib/ui/bottom-bar'
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-import-resolver-typescript": "^2.4.0",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-prettier": "^3.4.0",
+    "eslint-plugin-workspaces": "^0.7.0",
     "express": "^4.17.1",
     "indy-sdk": "^1.16.0-dev-1655",
     "jest": "^27.0.4",

--- a/packages/indy-sdk/src/ledger/serializeRequestForSignature.ts
+++ b/packages/indy-sdk/src/ledger/serializeRequestForSignature.ts
@@ -1,4 +1,4 @@
-import { Hasher, TypedArrayEncoder } from '../../../core/src'
+import { Hasher, TypedArrayEncoder } from '@aries-framework/core'
 
 const ATTRIB_TYPE = '100'
 const GET_ATTR_TYPE = '104'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,6 +1116,14 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@joshuajaco/get-monorepo-packages@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@joshuajaco/get-monorepo-packages/-/get-monorepo-packages-1.2.1.tgz#070bdc4268f5e14d2dd593b02f32bc4c5601d06d"
+  integrity sha512-3I32bp/UB4UmLqEj/yrBEWTYuCzojn8nR34PZ9Jwb2OeHV95l4Kw0ax1xnnA4yYWU1E1krM2RIWghP3U725dGQ==
+  dependencies:
+    globby "^7.1.1"
+    load-json-file "^4.0.0"
+
 "@jridgewell/gen-mapping@^0.1.0":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz#e5d2e450306a9491e3bd77e323e38d7aff315996"
@@ -3175,10 +3183,22 @@ array-reduce@~0.0.0:
   resolved "https://registry.yarnpkg.com/array-reduce/-/array-reduce-0.0.0.tgz#173899d3ffd1c7d9383e4479525dbe278cab5f2b"
   integrity sha512-8jR+StqaC636u7h3ye1co3lQRefgVVUQUhuAmRbDqIMeR2yuXzRvkCNQiQ5J/wbREmoBLNtp13dhaaVpZQDRUw==
 
+array-union@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
+  integrity sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==
+  dependencies:
+    array-uniq "^1.0.1"
+
 array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+array-uniq@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
+  integrity sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==
 
 array-unique@^0.3.2:
   version "0.3.2"
@@ -4658,6 +4678,13 @@ diff@^4.0.1:
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
+dir-glob@^2.0.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
+  integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
+  dependencies:
+    path-type "^3.0.0"
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -4992,6 +5019,13 @@ eslint-plugin-prettier@^3.4.0:
   integrity sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==
   dependencies:
     prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-workspaces@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-workspaces/-/eslint-plugin-workspaces-0.7.0.tgz#be97fad9d25ab7430074c526f046b0e5c037633f"
+  integrity sha512-1+qzAM/iFFJ4MR3IOSY7n6Kw9XW/Fc+eVzWfN9nCcneDHr21rccZWUtGyMesk35bFnOWyp9dmJbYL0v5KYZ14w==
+  dependencies:
+    "@joshuajaco/get-monorepo-packages" "^1.2.1"
 
 eslint-scope@^5.1.1:
   version "5.1.1"
@@ -5889,6 +5923,18 @@ globby@^11.0.2, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha512-yANWAN2DUcBtuus5Cpd+SKROzXHs2iVXFZt/Ykrfz6SAXqacLX25NZpltE+39ceMexYF4TtEadjuSTw8+3wX4g==
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
+
 gopd@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.0.1.tgz#29ff76de69dac7489b7c0918a5788e56477c332c"
@@ -6128,6 +6174,11 @@ ignore-walk@^3.0.1, ignore-walk@^3.0.3:
   integrity sha512-PY6Ii8o1jMRA1z4F2hRkH/xN59ox43DavKvD3oDpfurRlOJyAHpifIwpbdv1n4jt4ov0jSpw3kQ4GhJnpBL6WQ==
   dependencies:
     minimatch "^3.0.4"
+
+ignore@^3.3.5:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -10255,6 +10306,11 @@ sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+slash@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
+  integrity sha512-3TYDR7xWt4dIqV2JauJr+EJeW356RXijHeUlO+8djJ+uBXPn8/2dpzBc8yQhh583sVvc9CvFAeQVgijsH+PNNg==
 
 slash@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
A relative import from core was preventing indy-sdk from being built correctly.

Here we add an eslint plugin to check these relative imports and other stuff that can be useful now we have plenty of packages in this repo.