### PR TITLE
fix(anoncreds-rs): save revocation registry index

### DIFF
--- a/packages/anoncreds-rs/src/services/AnonCredsRsHolderService.ts
+++ b/packages/anoncreds-rs/src/services/AnonCredsRsHolderService.ts
@@ -251,6 +251,7 @@ export class AnonCredsRsHolderService implements AnonCredsHolderService {
         schemaName: schema.name,
         schemaIssuerId: schema.issuerId,
         schemaVersion: schema.version,
+        credentialRevocationId: processedCredential.revocationRegistryIndex?.toString(),
       })
     )
 


### PR DESCRIPTION
When storing AnonCreds credentials, we weren't saving the revocation registry index, making it impossible to properly search for the credential in `RevocationNotificationService`.