### PR TITLE
refactor!: remove Dispatcher.registerMessageHandler

### DIFF
--- a/packages/action-menu/src/ActionMenuApi.ts
+++ b/packages/action-menu/src/ActionMenuApi.ts
@@ -10,7 +10,6 @@ import {
   AgentContext,
   AriesFrameworkError,
   ConnectionService,
-  MessageHandlerRegistry,
   MessageSender,
   OutboundMessageContext,
   injectable,
@@ -36,7 +35,6 @@ export class ActionMenuApi {
   private agentContext: AgentContext
 
   public constructor(
-    messageHandlerRegistry: MessageHandlerRegistry,
     connectionService: ConnectionService,
     messageSender: MessageSender,
     actionMenuService: ActionMenuService,
@@ -46,7 +44,13 @@ export class ActionMenuApi {
     this.messageSender = messageSender
     this.actionMenuService = actionMenuService
     this.agentContext = agentContext
-    this.registerMessageHandlers(messageHandlerRegistry)
+
+    this.agentContext.dependencyManager.registerMessageHandlers([
+      new ActionMenuProblemReportHandler(this.actionMenuService),
+      new MenuMessageHandler(this.actionMenuService),
+      new MenuRequestMessageHandler(this.actionMenuService),
+      new PerformMessageHandler(this.actionMenuService),
+    ])
   }
 
   /**
@@ -159,12 +163,5 @@ export class ActionMenuApi {
     })
 
     return actionMenuRecord ? await this.actionMenuService.clearMenu(this.agentContext, { actionMenuRecord }) : null
-  }
-
-  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
-    messageHandlerRegistry.registerMessageHandler(new ActionMenuProblemReportHandler(this.actionMenuService))
-    messageHandlerRegistry.registerMessageHandler(new MenuMessageHandler(this.actionMenuService))
-    messageHandlerRegistry.registerMessageHandler(new MenuRequestMessageHandler(this.actionMenuService))
-    messageHandlerRegistry.registerMessageHandler(new PerformMessageHandler(this.actionMenuService))
   }
 }

--- a/packages/action-menu/src/ActionMenuApi.ts
+++ b/packages/action-menu/src/ActionMenuApi.ts
@@ -10,7 +10,7 @@ import {
   AgentContext,
   AriesFrameworkError,
   ConnectionService,
-  Dispatcher,
+  MessageHandlerRegistry,
   MessageSender,
   OutboundMessageContext,
   injectable,
@@ -36,7 +36,7 @@ export class ActionMenuApi {
   private agentContext: AgentContext
 
   public constructor(
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     connectionService: ConnectionService,
     messageSender: MessageSender,
     actionMenuService: ActionMenuService,
@@ -46,7 +46,7 @@ export class ActionMenuApi {
     this.messageSender = messageSender
     this.actionMenuService = actionMenuService
     this.agentContext = agentContext
-    this.registerMessageHandlers(dispatcher)
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   /**
@@ -161,10 +161,10 @@ export class ActionMenuApi {
     return actionMenuRecord ? await this.actionMenuService.clearMenu(this.agentContext, { actionMenuRecord }) : null
   }
 
-  private registerMessageHandlers(dispatcher: Dispatcher) {
-    dispatcher.registerMessageHandler(new ActionMenuProblemReportHandler(this.actionMenuService))
-    dispatcher.registerMessageHandler(new MenuMessageHandler(this.actionMenuService))
-    dispatcher.registerMessageHandler(new MenuRequestMessageHandler(this.actionMenuService))
-    dispatcher.registerMessageHandler(new PerformMessageHandler(this.actionMenuService))
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new ActionMenuProblemReportHandler(this.actionMenuService))
+    messageHandlerRegistry.registerMessageHandler(new MenuMessageHandler(this.actionMenuService))
+    messageHandlerRegistry.registerMessageHandler(new MenuRequestMessageHandler(this.actionMenuService))
+    messageHandlerRegistry.registerMessageHandler(new PerformMessageHandler(this.actionMenuService))
   }
 }

--- a/packages/core/src/agent/Dispatcher.ts
+++ b/packages/core/src/agent/Dispatcher.ts
@@ -1,6 +1,5 @@
 import type { AgentMessage } from './AgentMessage'
 import type { AgentMessageProcessedEvent } from './Events'
-import type { MessageHandler } from './MessageHandler'
 import type { InboundMessageContext } from './models/InboundMessageContext'
 
 import { InjectionSymbols } from '../constants'
@@ -33,13 +32,6 @@ class Dispatcher {
     this.eventEmitter = eventEmitter
     this.messageHandlerRegistry = messageHandlerRegistry
     this.logger = logger
-  }
-
-  /**
-   * @deprecated Use {@link MessageHandlerRegistry.registerMessageHandler} directly
-   */
-  public registerMessageHandler(messageHandler: MessageHandler) {
-    this.messageHandlerRegistry.registerMessageHandler(messageHandler)
   }
 
   public async dispatch(messageContext: InboundMessageContext): Promise<void> {

--- a/packages/core/src/agent/__tests__/Dispatcher.test.ts
+++ b/packages/core/src/agent/__tests__/Dispatcher.test.ts
@@ -22,17 +22,18 @@ describe('Dispatcher', () => {
 
   describe('dispatch()', () => {
     it('calls the handle method of the handler', async () => {
+      const messageHandlerRegistry = new MessageHandlerRegistry()
       const dispatcher = new Dispatcher(
         new MessageSenderMock(),
         eventEmitter,
-        new MessageHandlerRegistry(),
+        messageHandlerRegistry,
         agentConfig.logger
       )
       const customProtocolMessage = new CustomProtocolMessage()
       const inboundMessageContext = new InboundMessageContext(customProtocolMessage, { agentContext })
 
       const mockHandle = jest.fn()
-      dispatcher.registerMessageHandler({ supportedMessages: [CustomProtocolMessage], handle: mockHandle })
+      messageHandlerRegistry.registerMessageHandler({ supportedMessages: [CustomProtocolMessage], handle: mockHandle })
 
       await dispatcher.dispatch(inboundMessageContext)
 
@@ -40,6 +41,7 @@ describe('Dispatcher', () => {
     })
 
     it('throws an error if no handler for the message could be found', async () => {
+      const messageHandlerRegistry = new MessageHandlerRegistry()
       const dispatcher = new Dispatcher(
         new MessageSenderMock(),
         eventEmitter,
@@ -50,7 +52,7 @@ describe('Dispatcher', () => {
       const inboundMessageContext = new InboundMessageContext(customProtocolMessage, { agentContext })
 
       const mockHandle = jest.fn()
-      dispatcher.registerMessageHandler({ supportedMessages: [], handle: mockHandle })
+      messageHandlerRegistry.registerMessageHandler({ supportedMessages: [], handle: mockHandle })
 
       await expect(dispatcher.dispatch(inboundMessageContext)).rejects.toThrow(
         'No handler for message type "https://didcomm.org/fake-protocol/1.5/message" found'

--- a/packages/core/src/modules/basic-messages/BasicMessagesApi.ts
+++ b/packages/core/src/modules/basic-messages/BasicMessagesApi.ts
@@ -2,7 +2,7 @@ import type { BasicMessageRecord } from './repository/BasicMessageRecord'
 import type { Query } from '../../storage/StorageService'
 
 import { AgentContext } from '../../agent'
-import { Dispatcher } from '../../agent/Dispatcher'
+import { MessageHandlerRegistry } from '../../agent/MessageHandlerRegistry'
 import { MessageSender } from '../../agent/MessageSender'
 import { OutboundMessageContext } from '../../agent/models'
 import { injectable } from '../../plugins'
@@ -19,7 +19,7 @@ export class BasicMessagesApi {
   private agentContext: AgentContext
 
   public constructor(
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     basicMessageService: BasicMessageService,
     messageSender: MessageSender,
     connectionService: ConnectionService,
@@ -29,7 +29,7 @@ export class BasicMessagesApi {
     this.messageSender = messageSender
     this.connectionService = connectionService
     this.agentContext = agentContext
-    this.registerMessageHandlers(dispatcher)
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   /**
@@ -91,7 +91,7 @@ export class BasicMessagesApi {
     await this.basicMessageService.deleteById(this.agentContext, basicMessageRecordId)
   }
 
-  private registerMessageHandlers(dispatcher: Dispatcher) {
-    dispatcher.registerMessageHandler(new BasicMessageHandler(this.basicMessageService))
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new BasicMessageHandler(this.basicMessageService))
   }
 }

--- a/packages/core/src/modules/credentials/protocol/revocation-notification/services/RevocationNotificationService.ts
+++ b/packages/core/src/modules/credentials/protocol/revocation-notification/services/RevocationNotificationService.ts
@@ -5,8 +5,8 @@ import type { RevocationNotificationReceivedEvent } from '../../../CredentialEve
 import type { V1RevocationNotificationMessage } from '../messages/V1RevocationNotificationMessage'
 import type { V2RevocationNotificationMessage } from '../messages/V2RevocationNotificationMessage'
 
-import { Dispatcher } from '../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../agent/EventEmitter'
+import { MessageHandlerRegistry } from '../../../../../agent/MessageHandlerRegistry'
 import { InjectionSymbols } from '../../../../../constants'
 import { AriesFrameworkError } from '../../../../../error/AriesFrameworkError'
 import { Logger } from '../../../../../logger'
@@ -22,21 +22,19 @@ import { v1ThreadRegex, v2IndyRevocationFormat, v2IndyRevocationIdentifierRegex 
 export class RevocationNotificationService {
   private credentialRepository: CredentialRepository
   private eventEmitter: EventEmitter
-  private dispatcher: Dispatcher
   private logger: Logger
 
   public constructor(
     credentialRepository: CredentialRepository,
     eventEmitter: EventEmitter,
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     @inject(InjectionSymbols.Logger) logger: Logger
   ) {
     this.credentialRepository = credentialRepository
     this.eventEmitter = eventEmitter
-    this.dispatcher = dispatcher
     this.logger = logger
 
-    this.registerMessageHandlers()
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   private async processRevocationNotification(
@@ -147,8 +145,8 @@ export class RevocationNotificationService {
     }
   }
 
-  private registerMessageHandlers() {
-    this.dispatcher.registerMessageHandler(new V1RevocationNotificationHandler(this))
-    this.dispatcher.registerMessageHandler(new V2RevocationNotificationHandler(this))
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new V1RevocationNotificationHandler(this))
+    messageHandlerRegistry.registerMessageHandler(new V2RevocationNotificationHandler(this))
   }
 }

--- a/packages/core/src/modules/credentials/protocol/revocation-notification/services/__tests__/RevocationNotificationService.test.ts
+++ b/packages/core/src/modules/credentials/protocol/revocation-notification/services/__tests__/RevocationNotificationService.test.ts
@@ -6,8 +6,8 @@ import { Subject } from 'rxjs'
 
 import { CredentialExchangeRecord, CredentialState, InboundMessageContext } from '../../../../../..'
 import { getAgentConfig, getAgentContext, getMockConnection, mockFunction } from '../../../../../../../tests/helpers'
-import { Dispatcher } from '../../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../../agent/EventEmitter'
+import { MessageHandlerRegistry } from '../../../../../../agent/MessageHandlerRegistry'
 import { DidExchangeState } from '../../../../../connections'
 import { CredentialEventTypes } from '../../../../CredentialEvents'
 import { CredentialRepository } from '../../../../repository/CredentialRepository'
@@ -18,9 +18,9 @@ jest.mock('../../../../repository/CredentialRepository')
 const CredentialRepositoryMock = CredentialRepository as jest.Mock<CredentialRepository>
 const credentialRepository = new CredentialRepositoryMock()
 
-jest.mock('../../../../../../agent/Dispatcher')
-const DispatcherMock = Dispatcher as jest.Mock<Dispatcher>
-const dispatcher = new DispatcherMock()
+jest.mock('../../../../../../agent/MessageHandlerRegistry')
+const MessageHandlerRegistryMock = MessageHandlerRegistry as jest.Mock<MessageHandlerRegistry>
+const messageHandlerRegistry = new MessageHandlerRegistryMock()
 
 const connection = getMockConnection({
   state: DidExchangeState.Completed,
@@ -40,7 +40,7 @@ describe('RevocationNotificationService', () => {
     revocationNotificationService = new RevocationNotificationService(
       credentialRepository,
       eventEmitter,
-      dispatcher,
+      messageHandlerRegistry,
       agentConfig.logger
     )
   })

--- a/packages/core/src/modules/discover-features/protocol/v1/V1DiscoverFeaturesService.ts
+++ b/packages/core/src/modules/discover-features/protocol/v1/V1DiscoverFeaturesService.ts
@@ -10,9 +10,9 @@ import type {
   DiscoverFeaturesProtocolMsgReturnType,
 } from '../../DiscoverFeaturesServiceOptions'
 
-import { Dispatcher } from '../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../agent/EventEmitter'
 import { FeatureRegistry } from '../../../../agent/FeatureRegistry'
+import { MessageHandlerRegistry } from '../../../../agent/MessageHandlerRegistry'
 import { Protocol } from '../../../../agent/models'
 import { InjectionSymbols } from '../../../../constants'
 import { AriesFrameworkError } from '../../../../error'
@@ -30,13 +30,13 @@ export class V1DiscoverFeaturesService extends DiscoverFeaturesService {
   public constructor(
     featureRegistry: FeatureRegistry,
     eventEmitter: EventEmitter,
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     @inject(InjectionSymbols.Logger) logger: Logger,
     discoverFeaturesConfig: DiscoverFeaturesModuleConfig
   ) {
-    super(featureRegistry, eventEmitter, dispatcher, logger, discoverFeaturesConfig)
+    super(featureRegistry, eventEmitter, logger, discoverFeaturesConfig)
 
-    this.registerMessageHandlers(dispatcher)
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   /**
@@ -44,9 +44,9 @@ export class V1DiscoverFeaturesService extends DiscoverFeaturesService {
    */
   public readonly version = 'v1'
 
-  private registerMessageHandlers(dispatcher: Dispatcher) {
-    dispatcher.registerMessageHandler(new V1DiscloseMessageHandler(this))
-    dispatcher.registerMessageHandler(new V1QueryMessageHandler(this))
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new V1DiscloseMessageHandler(this))
+    messageHandlerRegistry.registerMessageHandler(new V1QueryMessageHandler(this))
   }
 
   public async createQuery(

--- a/packages/core/src/modules/discover-features/protocol/v1/__tests__/V1DiscoverFeaturesService.test.ts
+++ b/packages/core/src/modules/discover-features/protocol/v1/__tests__/V1DiscoverFeaturesService.test.ts
@@ -7,9 +7,9 @@ import type { DiscoverFeaturesProtocolMsgReturnType } from '../../../DiscoverFea
 import { Subject } from 'rxjs'
 
 import { agentDependencies, getAgentContext, getMockConnection } from '../../../../../../tests/helpers'
-import { Dispatcher } from '../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../agent/EventEmitter'
 import { FeatureRegistry } from '../../../../../agent/FeatureRegistry'
+import { MessageHandlerRegistry } from '../../../../../agent/MessageHandlerRegistry'
 import { Protocol } from '../../../../../agent/models'
 import { InboundMessageContext } from '../../../../../agent/models/InboundMessageContext'
 import { ConsoleLogger } from '../../../../../logger/ConsoleLogger'
@@ -19,8 +19,8 @@ import { DiscoverFeaturesModuleConfig } from '../../../DiscoverFeaturesModuleCon
 import { V1DiscoverFeaturesService } from '../V1DiscoverFeaturesService'
 import { V1DiscloseMessage, V1QueryMessage } from '../messages'
 
-jest.mock('../../../../../agent/Dispatcher')
-const DispatcherMock = Dispatcher as jest.Mock<Dispatcher>
+jest.mock('../../../../../agent/MessageHandlerRegistry')
+const MessageHandlerRegistryMock = MessageHandlerRegistry as jest.Mock<MessageHandlerRegistry>
 const eventEmitter = new EventEmitter(agentDependencies, new Subject())
 const featureRegistry = new FeatureRegistry()
 featureRegistry.register(new Protocol({ id: 'https://didcomm.org/connections/1.0' }))
@@ -36,7 +36,7 @@ describe('V1DiscoverFeaturesService - auto accept queries', () => {
   const discoverFeaturesService = new V1DiscoverFeaturesService(
     featureRegistry,
     eventEmitter,
-    new DispatcherMock(),
+    new MessageHandlerRegistryMock(),
     new LoggerMock(),
     discoverFeaturesModuleConfig
   )
@@ -239,7 +239,7 @@ describe('V1DiscoverFeaturesService - auto accept disabled', () => {
   const discoverFeaturesService = new V1DiscoverFeaturesService(
     featureRegistry,
     eventEmitter,
-    new DispatcherMock(),
+    new MessageHandlerRegistry(),
     new LoggerMock(),
     discoverFeaturesModuleConfig
   )

--- a/packages/core/src/modules/discover-features/protocol/v2/V2DiscoverFeaturesService.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/V2DiscoverFeaturesService.ts
@@ -9,9 +9,9 @@ import type {
   CreateDisclosureOptions,
 } from '../../DiscoverFeaturesServiceOptions'
 
-import { Dispatcher } from '../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../agent/EventEmitter'
 import { FeatureRegistry } from '../../../../agent/FeatureRegistry'
+import { MessageHandlerRegistry } from '../../../../agent/MessageHandlerRegistry'
 import { InjectionSymbols } from '../../../../constants'
 import { Logger } from '../../../../logger'
 import { inject, injectable } from '../../../../plugins'
@@ -27,12 +27,12 @@ export class V2DiscoverFeaturesService extends DiscoverFeaturesService {
   public constructor(
     featureRegistry: FeatureRegistry,
     eventEmitter: EventEmitter,
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     @inject(InjectionSymbols.Logger) logger: Logger,
     discoverFeaturesModuleConfig: DiscoverFeaturesModuleConfig
   ) {
-    super(featureRegistry, eventEmitter, dispatcher, logger, discoverFeaturesModuleConfig)
-    this.registerMessageHandlers(dispatcher)
+    super(featureRegistry, eventEmitter, logger, discoverFeaturesModuleConfig)
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   /**
@@ -40,9 +40,9 @@ export class V2DiscoverFeaturesService extends DiscoverFeaturesService {
    */
   public readonly version = 'v2'
 
-  private registerMessageHandlers(dispatcher: Dispatcher) {
-    dispatcher.registerMessageHandler(new V2DisclosuresMessageHandler(this))
-    dispatcher.registerMessageHandler(new V2QueriesMessageHandler(this))
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new V2DisclosuresMessageHandler(this))
+    messageHandlerRegistry.registerMessageHandler(new V2QueriesMessageHandler(this))
   }
 
   public async createQuery(

--- a/packages/core/src/modules/discover-features/protocol/v2/__tests__/V2DiscoverFeaturesService.test.ts
+++ b/packages/core/src/modules/discover-features/protocol/v2/__tests__/V2DiscoverFeaturesService.test.ts
@@ -7,9 +7,9 @@ import type { DiscoverFeaturesProtocolMsgReturnType } from '../../../DiscoverFea
 import { Subject } from 'rxjs'
 
 import { agentDependencies, getAgentContext, getMockConnection } from '../../../../../../tests/helpers'
-import { Dispatcher } from '../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../agent/EventEmitter'
 import { FeatureRegistry } from '../../../../../agent/FeatureRegistry'
+import { MessageHandlerRegistry } from '../../../../../agent/MessageHandlerRegistry'
 import { InboundMessageContext, Protocol, GoalCode } from '../../../../../agent/models'
 import { ConsoleLogger } from '../../../../../logger/ConsoleLogger'
 import { DidExchangeState } from '../../../../connections'
@@ -18,8 +18,8 @@ import { DiscoverFeaturesModuleConfig } from '../../../DiscoverFeaturesModuleCon
 import { V2DiscoverFeaturesService } from '../V2DiscoverFeaturesService'
 import { V2DisclosuresMessage, V2QueriesMessage } from '../messages'
 
-jest.mock('../../../../../agent/Dispatcher')
-const DispatcherMock = Dispatcher as jest.Mock<Dispatcher>
+jest.mock('../../../../../agent/MessageHandlerRegistry')
+const MessageHandlerRegistryMock = MessageHandlerRegistry as jest.Mock<MessageHandlerRegistry>
 const eventEmitter = new EventEmitter(agentDependencies, new Subject())
 const featureRegistry = new FeatureRegistry()
 featureRegistry.register(new Protocol({ id: 'https://didcomm.org/connections/1.0' }))
@@ -38,7 +38,7 @@ describe('V2DiscoverFeaturesService - auto accept queries', () => {
   const discoverFeaturesService = new V2DiscoverFeaturesService(
     featureRegistry,
     eventEmitter,
-    new DispatcherMock(),
+    new MessageHandlerRegistryMock(),
     new LoggerMock(),
     discoverFeaturesModuleConfig
   )
@@ -250,7 +250,7 @@ describe('V2DiscoverFeaturesService - auto accept disabled', () => {
   const discoverFeaturesService = new V2DiscoverFeaturesService(
     featureRegistry,
     eventEmitter,
-    new DispatcherMock(),
+    new MessageHandlerRegistryMock(),
     new LoggerMock(),
     discoverFeaturesModuleConfig
   )

--- a/packages/core/src/modules/discover-features/services/DiscoverFeaturesService.ts
+++ b/packages/core/src/modules/discover-features/services/DiscoverFeaturesService.ts
@@ -1,5 +1,4 @@
 import type { AgentMessage } from '../../../agent/AgentMessage'
-import type { Dispatcher } from '../../../agent/Dispatcher'
 import type { EventEmitter } from '../../../agent/EventEmitter'
 import type { FeatureRegistry } from '../../../agent/FeatureRegistry'
 import type { InboundMessageContext } from '../../../agent/models/InboundMessageContext'
@@ -14,20 +13,17 @@ import type {
 export abstract class DiscoverFeaturesService {
   protected featureRegistry: FeatureRegistry
   protected eventEmitter: EventEmitter
-  protected dispatcher: Dispatcher
   protected logger: Logger
   protected discoverFeaturesModuleConfig: DiscoverFeaturesModuleConfig
 
   public constructor(
     featureRegistry: FeatureRegistry,
     eventEmitter: EventEmitter,
-    dispatcher: Dispatcher,
     logger: Logger,
     discoverFeaturesModuleConfig: DiscoverFeaturesModuleConfig
   ) {
     this.featureRegistry = featureRegistry
     this.eventEmitter = eventEmitter
-    this.dispatcher = dispatcher
     this.logger = logger
     this.discoverFeaturesModuleConfig = discoverFeaturesModuleConfig
   }

--- a/packages/core/src/modules/routing/MediatorApi.ts
+++ b/packages/core/src/modules/routing/MediatorApi.ts
@@ -2,8 +2,8 @@ import type { MediationRecord } from './repository'
 import type { EncryptedMessage } from '../../types'
 
 import { AgentContext } from '../../agent'
-import { Dispatcher } from '../../agent/Dispatcher'
 import { EventEmitter } from '../../agent/EventEmitter'
+import { MessageHandlerRegistry } from '../../agent/MessageHandlerRegistry'
 import { MessageSender } from '../../agent/MessageSender'
 import { OutboundMessageContext } from '../../agent/models'
 import { injectable } from '../../plugins'
@@ -28,7 +28,7 @@ export class MediatorApi {
   private connectionService: ConnectionService
 
   public constructor(
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     mediationService: MediatorService,
     messagePickupService: MessagePickupService,
     // Only imported so it is injected and handlers are registered
@@ -46,7 +46,7 @@ export class MediatorApi {
     this.connectionService = connectionService
     this.agentContext = agentContext
     this.config = config
-    this.registerMessageHandlers(dispatcher)
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   public async initialize() {
@@ -85,13 +85,13 @@ export class MediatorApi {
     return this.messagePickupService.queueMessage(connectionId, message)
   }
 
-  private registerMessageHandlers(dispatcher: Dispatcher) {
-    dispatcher.registerMessageHandler(new KeylistUpdateHandler(this.mediatorService))
-    dispatcher.registerMessageHandler(
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new KeylistUpdateHandler(this.mediatorService))
+    messageHandlerRegistry.registerMessageHandler(
       new ForwardHandler(this.mediatorService, this.connectionService, this.messageSender)
     )
-    dispatcher.registerMessageHandler(new BatchPickupHandler(this.messagePickupService))
-    dispatcher.registerMessageHandler(new BatchHandler(this.eventEmitter))
-    dispatcher.registerMessageHandler(new MediationRequestHandler(this.mediatorService, this.config))
+    messageHandlerRegistry.registerMessageHandler(new BatchPickupHandler(this.messagePickupService))
+    messageHandlerRegistry.registerMessageHandler(new BatchHandler(this.eventEmitter))
+    messageHandlerRegistry.registerMessageHandler(new MediationRequestHandler(this.mediatorService, this.config))
   }
 }

--- a/packages/core/src/modules/routing/RecipientApi.ts
+++ b/packages/core/src/modules/routing/RecipientApi.ts
@@ -8,9 +8,9 @@ import { firstValueFrom, interval, merge, ReplaySubject, Subject, timer } from '
 import { delayWhen, filter, first, takeUntil, tap, throttleTime, timeout } from 'rxjs/operators'
 
 import { AgentContext } from '../../agent'
-import { Dispatcher } from '../../agent/Dispatcher'
 import { EventEmitter } from '../../agent/EventEmitter'
 import { filterContextCorrelationId } from '../../agent/Events'
+import { MessageHandlerRegistry } from '../../agent/MessageHandlerRegistry'
 import { MessageSender } from '../../agent/MessageSender'
 import { OutboundMessageContext } from '../../agent/models'
 import { InjectionSymbols } from '../../constants'
@@ -58,7 +58,7 @@ export class RecipientApi {
   private readonly stopMessagePickup$ = new Subject<boolean>()
 
   public constructor(
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     mediationRecipientService: MediationRecipientService,
     connectionService: ConnectionService,
     dids: DidsApi,
@@ -84,7 +84,7 @@ export class RecipientApi {
     this.agentContext = agentContext
     this.stop$ = stop$
     this.config = recipientModuleConfig
-    this.registerMessageHandlers(dispatcher)
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   public async initialize() {
@@ -484,12 +484,12 @@ export class RecipientApi {
   }
 
   // Register handlers for the several messages for the mediator.
-  private registerMessageHandlers(dispatcher: Dispatcher) {
-    dispatcher.registerMessageHandler(new KeylistUpdateResponseHandler(this.mediationRecipientService))
-    dispatcher.registerMessageHandler(new MediationGrantHandler(this.mediationRecipientService))
-    dispatcher.registerMessageHandler(new MediationDenyHandler(this.mediationRecipientService))
-    dispatcher.registerMessageHandler(new StatusHandler(this.mediationRecipientService))
-    dispatcher.registerMessageHandler(new MessageDeliveryHandler(this.mediationRecipientService))
-    //dispatcher.registerMessageHandler(new KeylistListHandler(this.mediationRecipientService)) // TODO: write this
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new KeylistUpdateResponseHandler(this.mediationRecipientService))
+    messageHandlerRegistry.registerMessageHandler(new MediationGrantHandler(this.mediationRecipientService))
+    messageHandlerRegistry.registerMessageHandler(new MediationDenyHandler(this.mediationRecipientService))
+    messageHandlerRegistry.registerMessageHandler(new StatusHandler(this.mediationRecipientService))
+    messageHandlerRegistry.registerMessageHandler(new MessageDeliveryHandler(this.mediationRecipientService))
+    //messageHandlerRegistry.registerMessageHandler(new KeylistListHandler(this.mediationRecipientService)) // TODO: write this
   }
 }

--- a/packages/core/src/modules/routing/protocol/pickup/v1/MessagePickupService.ts
+++ b/packages/core/src/modules/routing/protocol/pickup/v1/MessagePickupService.ts
@@ -2,8 +2,8 @@ import type { BatchPickupMessage } from './messages'
 import type { InboundMessageContext } from '../../../../../agent/models/InboundMessageContext'
 import type { EncryptedMessage } from '../../../../../types'
 
-import { Dispatcher } from '../../../../../agent/Dispatcher'
 import { EventEmitter } from '../../../../../agent/EventEmitter'
+import { MessageHandlerRegistry } from '../../../../../agent/MessageHandlerRegistry'
 import { OutboundMessageContext } from '../../../../../agent/models'
 import { InjectionSymbols } from '../../../../../constants'
 import { inject, injectable } from '../../../../../plugins'
@@ -15,19 +15,17 @@ import { BatchMessage, BatchMessageMessage } from './messages'
 @injectable()
 export class MessagePickupService {
   private messageRepository: MessageRepository
-  private dispatcher: Dispatcher
   private eventEmitter: EventEmitter
 
   public constructor(
     @inject(InjectionSymbols.MessageRepository) messageRepository: MessageRepository,
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     eventEmitter: EventEmitter
   ) {
     this.messageRepository = messageRepository
-    this.dispatcher = dispatcher
     this.eventEmitter = eventEmitter
 
-    this.registerMessageHandlers()
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   public async batch(messageContext: InboundMessageContext<BatchPickupMessage>) {
@@ -57,8 +55,8 @@ export class MessagePickupService {
     await this.messageRepository.add(connectionId, message)
   }
 
-  protected registerMessageHandlers() {
-    this.dispatcher.registerMessageHandler(new BatchPickupHandler(this))
-    this.dispatcher.registerMessageHandler(new BatchHandler(this.eventEmitter))
+  protected registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new BatchPickupHandler(this))
+    messageHandlerRegistry.registerMessageHandler(new BatchHandler(this.eventEmitter))
   }
 }

--- a/packages/core/src/modules/routing/protocol/pickup/v2/V2MessagePickupService.ts
+++ b/packages/core/src/modules/routing/protocol/pickup/v2/V2MessagePickupService.ts
@@ -2,7 +2,7 @@ import type { DeliveryRequestMessage, MessagesReceivedMessage, StatusRequestMess
 import type { InboundMessageContext } from '../../../../../agent/models/InboundMessageContext'
 import type { EncryptedMessage } from '../../../../../types'
 
-import { Dispatcher } from '../../../../../agent/Dispatcher'
+import { MessageHandlerRegistry } from '../../../../../agent/MessageHandlerRegistry'
 import { OutboundMessageContext } from '../../../../../agent/models'
 import { InjectionSymbols } from '../../../../../constants'
 import { Attachment } from '../../../../../decorators/attachment/Attachment'
@@ -23,19 +23,17 @@ import { MessageDeliveryMessage, StatusMessage } from './messages'
 @injectable()
 export class V2MessagePickupService {
   private messageRepository: MessageRepository
-  private dispatcher: Dispatcher
   private mediationRecipientService: MediationRecipientService
 
   public constructor(
     @inject(InjectionSymbols.MessageRepository) messageRepository: MessageRepository,
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     mediationRecipientService: MediationRecipientService
   ) {
     this.messageRepository = messageRepository
-    this.dispatcher = dispatcher
     this.mediationRecipientService = mediationRecipientService
 
-    this.registerMessageHandlers()
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   public async processStatusRequest(messageContext: InboundMessageContext<StatusRequestMessage>) {
@@ -116,11 +114,11 @@ export class V2MessagePickupService {
     return new OutboundMessageContext(statusMessage, { agentContext: messageContext.agentContext, connection })
   }
 
-  protected registerMessageHandlers() {
-    this.dispatcher.registerMessageHandler(new StatusRequestHandler(this))
-    this.dispatcher.registerMessageHandler(new DeliveryRequestHandler(this))
-    this.dispatcher.registerMessageHandler(new MessagesReceivedHandler(this))
-    this.dispatcher.registerMessageHandler(new StatusHandler(this.mediationRecipientService))
-    this.dispatcher.registerMessageHandler(new MessageDeliveryHandler(this.mediationRecipientService))
+  protected registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new StatusRequestHandler(this))
+    messageHandlerRegistry.registerMessageHandler(new DeliveryRequestHandler(this))
+    messageHandlerRegistry.registerMessageHandler(new MessagesReceivedHandler(this))
+    messageHandlerRegistry.registerMessageHandler(new StatusHandler(this.mediationRecipientService))
+    messageHandlerRegistry.registerMessageHandler(new MessageDeliveryHandler(this.mediationRecipientService))
   }
 }

--- a/packages/core/src/modules/routing/services/__tests__/V2MessagePickupService.test.ts
+++ b/packages/core/src/modules/routing/services/__tests__/V2MessagePickupService.test.ts
@@ -2,7 +2,7 @@ import type { MessageRepository } from '../../../../storage/MessageRepository'
 import type { EncryptedMessage } from '../../../../types'
 
 import { getAgentContext, getMockConnection, mockFunction } from '../../../../../tests/helpers'
-import { Dispatcher } from '../../../../agent/Dispatcher'
+import { MessageHandlerRegistry } from '../../../../agent/MessageHandlerRegistry'
 import { InboundMessageContext } from '../../../../agent/models/InboundMessageContext'
 import { InMemoryMessageRepository } from '../../../../storage/InMemoryMessageRepository'
 import { DidExchangeState } from '../../../connections'
@@ -23,11 +23,11 @@ const mockConnection = getMockConnection({
 // Mock classes
 jest.mock('../MediationRecipientService')
 jest.mock('../../../../storage/InMemoryMessageRepository')
-jest.mock('../../../../agent/Dispatcher')
+jest.mock('../../../../agent/MessageHandlerRegistry')
 
 // Mock typed object
 const MediationRecipientServiceMock = MediationRecipientService as jest.Mock<MediationRecipientService>
-const DispatcherMock = Dispatcher as jest.Mock<Dispatcher>
+const MessageHandlerRegistryMock = MessageHandlerRegistry as jest.Mock<MessageHandlerRegistry>
 const InMessageRepositoryMock = InMemoryMessageRepository as jest.Mock<InMemoryMessageRepository>
 
 const agentContext = getAgentContext()
@@ -45,11 +45,11 @@ describe('V2MessagePickupService', () => {
   let messageRepository: MessageRepository
 
   beforeEach(async () => {
-    const dispatcher = new DispatcherMock()
+    const messageHandlerRegistry = new MessageHandlerRegistryMock()
     const mediationRecipientService = new MediationRecipientServiceMock()
 
     messageRepository = new InMessageRepositoryMock()
-    pickupService = new V2MessagePickupService(messageRepository, dispatcher, mediationRecipientService)
+    pickupService = new V2MessagePickupService(messageRepository, messageHandlerRegistry, mediationRecipientService)
   })
 
   describe('processStatusRequest', () => {

--- a/packages/question-answer/src/QuestionAnswerApi.ts
+++ b/packages/question-answer/src/QuestionAnswerApi.ts
@@ -5,7 +5,7 @@ import {
   AgentContext,
   ConnectionService,
   OutboundMessageContext,
-  Dispatcher,
+  MessageHandlerRegistry,
   injectable,
   MessageSender,
 } from '@aries-framework/core'
@@ -22,7 +22,7 @@ export class QuestionAnswerApi {
   private agentContext: AgentContext
 
   public constructor(
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     questionAnswerService: QuestionAnswerService,
     messageSender: MessageSender,
     connectionService: ConnectionService,
@@ -32,7 +32,7 @@ export class QuestionAnswerApi {
     this.messageSender = messageSender
     this.connectionService = connectionService
     this.agentContext = agentContext
-    this.registerMessageHandlers(dispatcher)
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   /**
@@ -132,8 +132,8 @@ export class QuestionAnswerApi {
     return this.questionAnswerService.findById(this.agentContext, questionAnswerId)
   }
 
-  private registerMessageHandlers(dispatcher: Dispatcher) {
-    dispatcher.registerMessageHandler(new QuestionMessageHandler(this.questionAnswerService))
-    dispatcher.registerMessageHandler(new AnswerMessageHandler(this.questionAnswerService))
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new QuestionMessageHandler(this.questionAnswerService))
+    messageHandlerRegistry.registerMessageHandler(new AnswerMessageHandler(this.questionAnswerService))
   }
 }

--- a/packages/question-answer/src/QuestionAnswerApi.ts
+++ b/packages/question-answer/src/QuestionAnswerApi.ts
@@ -5,7 +5,6 @@ import {
   AgentContext,
   ConnectionService,
   OutboundMessageContext,
-  MessageHandlerRegistry,
   injectable,
   MessageSender,
 } from '@aries-framework/core'
@@ -22,7 +21,6 @@ export class QuestionAnswerApi {
   private agentContext: AgentContext
 
   public constructor(
-    messageHandlerRegistry: MessageHandlerRegistry,
     questionAnswerService: QuestionAnswerService,
     messageSender: MessageSender,
     connectionService: ConnectionService,
@@ -32,7 +30,11 @@ export class QuestionAnswerApi {
     this.messageSender = messageSender
     this.connectionService = connectionService
     this.agentContext = agentContext
-    this.registerMessageHandlers(messageHandlerRegistry)
+
+    this.agentContext.dependencyManager.registerMessageHandlers([
+      new QuestionMessageHandler(this.questionAnswerService),
+      new AnswerMessageHandler(this.questionAnswerService),
+    ])
   }
 
   /**
@@ -130,10 +132,5 @@ export class QuestionAnswerApi {
    */
   public findById(questionAnswerId: string) {
     return this.questionAnswerService.findById(this.agentContext, questionAnswerId)
-  }
-
-  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
-    messageHandlerRegistry.registerMessageHandler(new QuestionMessageHandler(this.questionAnswerService))
-    messageHandlerRegistry.registerMessageHandler(new AnswerMessageHandler(this.questionAnswerService))
   }
 }

--- a/samples/extension-module/dummy/DummyApi.ts
+++ b/samples/extension-module/dummy/DummyApi.ts
@@ -5,7 +5,7 @@ import {
   OutboundMessageContext,
   AgentContext,
   ConnectionService,
-  Dispatcher,
+  MessageHandlerRegistry,
   injectable,
   MessageSender,
 } from '@aries-framework/core'
@@ -22,7 +22,7 @@ export class DummyApi {
   private agentContext: AgentContext
 
   public constructor(
-    dispatcher: Dispatcher,
+    messageHandlerRegistry: MessageHandlerRegistry,
     messageSender: MessageSender,
     dummyService: DummyService,
     connectionService: ConnectionService,
@@ -33,7 +33,7 @@ export class DummyApi {
     this.connectionService = connectionService
     this.agentContext = agentContext
 
-    this.registerMessageHandlers(dispatcher)
+    this.registerMessageHandlers(messageHandlerRegistry)
   }
 
   /**
@@ -94,8 +94,8 @@ export class DummyApi {
     return this.dummyService.findAllByQuery(this.agentContext, query)
   }
 
-  private registerMessageHandlers(dispatcher: Dispatcher) {
-    dispatcher.registerMessageHandler(new DummyRequestHandler(this.dummyService))
-    dispatcher.registerMessageHandler(new DummyResponseHandler(this.dummyService))
+  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
+    messageHandlerRegistry.registerMessageHandler(new DummyRequestHandler(this.dummyService))
+    messageHandlerRegistry.registerMessageHandler(new DummyResponseHandler(this.dummyService))
   }
 }

--- a/samples/extension-module/dummy/DummyApi.ts
+++ b/samples/extension-module/dummy/DummyApi.ts
@@ -5,7 +5,6 @@ import {
   OutboundMessageContext,
   AgentContext,
   ConnectionService,
-  MessageHandlerRegistry,
   injectable,
   MessageSender,
 } from '@aries-framework/core'
@@ -22,7 +21,6 @@ export class DummyApi {
   private agentContext: AgentContext
 
   public constructor(
-    messageHandlerRegistry: MessageHandlerRegistry,
     messageSender: MessageSender,
     dummyService: DummyService,
     connectionService: ConnectionService,
@@ -33,7 +31,10 @@ export class DummyApi {
     this.connectionService = connectionService
     this.agentContext = agentContext
 
-    this.registerMessageHandlers(messageHandlerRegistry)
+    this.agentContext.dependencyManager.registerMessageHandlers([
+      new DummyRequestHandler(this.dummyService),
+      new DummyResponseHandler(this.dummyService),
+    ])
   }
 
   /**
@@ -92,10 +93,5 @@ export class DummyApi {
    */
   public findAllByQuery(query: Query<DummyRecord>): Promise<DummyRecord[]> {
     return this.dummyService.findAllByQuery(this.agentContext, query)
-  }
-
-  private registerMessageHandlers(messageHandlerRegistry: MessageHandlerRegistry) {
-    messageHandlerRegistry.registerMessageHandler(new DummyRequestHandler(this.dummyService))
-    messageHandlerRegistry.registerMessageHandler(new DummyResponseHandler(this.dummyService))
   }
 }


### PR DESCRIPTION
It was marked as deprecated since 0.3.0

BREAKING CHANGE:

`Dispatcher.registerMessageHandler` has been removed in favour of `MessageHandlerRegistry.registerMessageHandler`