### PR TITLE
fix: isNewSocket logic

### DIFF
--- a/packages/core/src/transport/WsOutboundTransport.ts
+++ b/packages/core/src/transport/WsOutboundTransport.ts
@@ -47,7 +47,7 @@ export class WsOutboundTransport implements OutboundTransport {
       throw new AriesFrameworkError("Missing connection or endpoint. I don't know how and where to send the message.")
     }
 
-    const isNewSocket = this.hasOpenSocket(endpoint)
+    const isNewSocket = !this.hasOpenSocket(endpoint)
     const socket = await this.resolveSocket({ socketId: endpoint, endpoint, connectionId })
 
     socket.send(Buffer.from(JSON.stringify(payload)))


### PR DESCRIPTION
`isNewSocket` was holding whether the socket already exists to an endpoint. I think the logic for closing the socket in `sendMessage` should be : 
```ts
    const socket = await this.resolveSocket({ socketId: endpoint, endpoint, connectionId })

    socket.send(Buffer.from(JSON.stringify(payload)))

    // If the socket was created for this message and we don't have return routing enabled
    // We can close the socket as it shouldn't return messages anymore
    if (socket && !outboundPackage.responseRequested) {
      socket.close()
    }
```
As per current logic, the socket is closed only when a message has `responseRequested=false` and a new socket is created just for this message. Let's suppose a message (`responseRequested=false` and socket already exists), in this case sender won't call `socket.close()`. But the receiver will close the socket

https://github.com/hyperledger/aries-framework-javascript/blob/1bda3f0733a472b536059cee8d34e25fb04c9f2d/packages/core/src/agent/MessageReceiver.ts#L138-L156

it's true, when the receiver closes the socket from his side, the sender will also close the socket based on `socket.onclose` event. But the sender might send a message before receiving the `socket.onclose` event. I got this bug, while I was testing for an edge agent to setup a mediation with an afj mediator. This was console log (at agent/MessageReceiver.tsL#139 and L#154) from the mediator

```
received message with return routes session_id:  3018a3bb-c37b-4b22-a1f6-66c494fc3d14 <<< This is connection/1.0/request
closing session for session_id:  a1de283b-0e9c-421e-a0d6-c59ac311d048 <<<< This is didcom/trust_ping
received message with return routes session_id:  a1de283b-0e9c-421e-a0d6-c59ac311d048 <<<< this mediate-request.
```
@TimoGlastra 