### PR TITLE
fix(core): repository event when calling deleteById

### DIFF
--- a/packages/core/src/storage/Repository.ts
+++ b/packages/core/src/storage/Repository.ts
@@ -68,12 +68,13 @@ export class Repository<T extends BaseRecord<any, any, any>> {
   }
 
   /**
-   * Delete record by id. Returns null if no record is found
+   * Delete record by id. Throws {RecordNotFoundError} if no record is found
    * @param id the id of the record to delete
    * @returns
    */
   public async deleteById(agentContext: AgentContext, id: string): Promise<void> {
-    await this.storageService.deleteById(agentContext, this.recordClass, id)
+    const record = await this.getById(agentContext, id)
+    await this.delete(agentContext, record)
   }
 
   /** @inheritDoc {StorageService#getById} */

--- a/packages/core/src/storage/__tests__/Repository.test.ts
+++ b/packages/core/src/storage/__tests__/Repository.test.ts
@@ -142,9 +142,34 @@ describe('Repository', () => {
 
   describe('deleteById()', () => {
     it('should delete the record by record id', async () => {
-      await repository.deleteById(agentContext, 'test-id')
+      const record = getRecord({ id: 'test-id' })
+      mockFunction(storageMock.getById).mockResolvedValueOnce(record)
 
-      expect(storageMock.deleteById).toBeCalledWith(agentContext, TestRecord, 'test-id')
+      await repository.deleteById(agentContext, record.id)
+
+      expect(storageMock.delete).toBeCalledWith(agentContext, record)
+    })
+
+    it(`should emit deleted event`, async () => {
+      const eventListenerMock = jest.fn()
+      eventEmitter.on<RecordDeletedEvent<TestRecord>>(RepositoryEventTypes.RecordDeleted, eventListenerMock)
+
+      const record = getRecord({ id: 'test-id' })
+      mockFunction(storageMock.getById).mockResolvedValueOnce(record)
+
+      await repository.deleteById(agentContext, record.id)
+
+      expect(eventListenerMock).toHaveBeenCalledWith({
+        type: 'RecordDeleted',
+        metadata: {
+          contextCorrelationId: 'mock',
+        },
+        payload: {
+          record: expect.objectContaining({
+            id: record.id,
+          }),
+        },
+      })
     })
   })
 


### PR DESCRIPTION
When calling Repository method `deleteById`, no `RecordEvent` event is emitted. This PR fixes this by internally getting the record by id and then calling `delete` method, which does emit the event.

Even if it could be more efficient to avoid the need of getById, we need to get the whole record in order to be able to emit the event with the record object (otherwise we would only have its id), being consistent with other repository events.