### PR TITLE
test: various improvements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,9 +89,13 @@ module.exports = {
       },
     },
     {
-      files: ['jest.config.ts', '.eslintrc.js'],
+      files: ['jest.config.ts', '.eslintrc.js', './scripts/**'],
       env: {
         node: true,
+      },
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+        'no-undef': 'off',
       },
     },
     {

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -111,6 +111,11 @@ jobs:
         uses: ./.github/actions/setup-node
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Add ref-napi resolution in Node18
+        run: node ./scripts/add-ref-napi-resolution.js
+        if: matrix.node-version == '18.x'
+
       - name: Install dependencies
         run: yarn install
 

--- a/packages/anoncreds/tests/setup.ts
+++ b/packages/anoncreds/tests/setup.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(25000)
+jest.setTimeout(50000)

--- a/packages/askar/src/storage/__tests__/AskarStorageService.test.ts
+++ b/packages/askar/src/storage/__tests__/AskarStorageService.test.ts
@@ -8,6 +8,7 @@ import {
 } from '@aries-framework/core'
 import { ariesAskar } from '@hyperledger/aries-askar-shared'
 
+import { describeRunInNodeVersion } from '../../../../../tests/runInVersion'
 import { TestRecord } from '../../../../core/src/storage/__tests__/TestRecord'
 import { agentDependencies, getAgentConfig, getAgentContext } from '../../../../core/tests/helpers'
 import { AskarWallet } from '../../wallet/AskarWallet'
@@ -16,7 +17,7 @@ import { askarQueryFromSearchQuery } from '../utils'
 
 const startDate = Date.now()
 
-describe('AskarStorageService', () => {
+describeRunInNodeVersion([18], 'AskarStorageService', () => {
   let wallet: AskarWallet
   let storageService: AskarStorageService<TestRecord>
   let agentContext: AgentContext

--- a/packages/askar/src/wallet/__tests__/AskarWallet.test.ts
+++ b/packages/askar/src/wallet/__tests__/AskarWallet.test.ts
@@ -22,6 +22,7 @@ import {
 } from '@aries-framework/core'
 import { Store } from '@hyperledger/aries-askar-shared'
 
+import { describeRunInNodeVersion } from '../../../../../tests/runInVersion'
 import { encodeToBase58 } from '../../../../core/src/utils/base58'
 import { agentDependencies } from '../../../../core/tests/helpers'
 import testLogger from '../../../../core/tests/logger'
@@ -35,7 +36,7 @@ const walletConfig: WalletConfig = {
   keyDerivationMethod: KeyDerivationMethod.Raw,
 }
 
-describe('AskarWallet basic operations', () => {
+describeRunInNodeVersion([18], 'AskarWallet basic operations', () => {
   let askarWallet: AskarWallet
 
   const seed = TypedArrayEncoder.fromString('sample-seed-min-of-32-bytes-long')

--- a/packages/askar/src/wallet/__tests__/packing.test.ts
+++ b/packages/askar/src/wallet/__tests__/packing.test.ts
@@ -8,6 +8,7 @@ import {
   KeyDerivationMethod,
 } from '@aries-framework/core'
 
+import { describeRunInNodeVersion } from '../../../../../tests/runInVersion'
 import { agentDependencies } from '../../../../core/tests/helpers'
 import testLogger from '../../../../core/tests/logger'
 import { AskarWallet } from '../AskarWallet'
@@ -20,7 +21,7 @@ const walletConfig: WalletConfig = {
   keyDerivationMethod: KeyDerivationMethod.Raw,
 }
 
-describe('askarWallet packing', () => {
+describeRunInNodeVersion([18], 'askarWallet packing', () => {
   let askarWallet: AskarWallet
 
   beforeEach(async () => {

--- a/packages/bbs-signatures/tests/util.ts
+++ b/packages/bbs-signatures/tests/util.ts
@@ -1,13 +1,3 @@
-export function testSkipNode17And18(...parameters: Parameters<typeof test>) {
-  const version = process.version
-
-  if (version.startsWith('v17.') || version.startsWith('v18.')) {
-    test.skip(...parameters)
-  } else {
-    test(...parameters)
-  }
-}
-
 export function describeSkipNode17And18(...parameters: Parameters<typeof describe>) {
   const version = process.version
 

--- a/packages/tenants/tests/setup.ts
+++ b/packages/tenants/tests/setup.ts
@@ -1,3 +1,3 @@
 import 'reflect-metadata'
 
-jest.setTimeout(20000)
+jest.setTimeout(50000)

--- a/scripts/add-ref-napi-resolution.js
+++ b/scripts/add-ref-napi-resolution.js
@@ -1,0 +1,15 @@
+const fs = require('fs')
+const path = require('path')
+
+// Read package.json
+const packageJsonPath = path.join(__dirname, '..', 'package.json')
+const packageJson = JSON.parse(fs.readFileSync(packageJsonPath))
+
+// Add ref-napi resolution
+packageJson.resolutions = {
+  ...packageJson.resolutions,
+  'ref-napi': 'npm:@2060.io/ref-napi',
+}
+
+// Write package.json
+fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))

--- a/tests/e2e-askar-indy-sdk-wallet-subject.test.ts
+++ b/tests/e2e-askar-indy-sdk-wallet-subject.test.ts
@@ -12,6 +12,7 @@ import { getAgentOptions } from '../packages/core/tests/helpers'
 import { Agent, AutoAcceptCredential, MediatorPickupStrategy } from '@aries-framework/core'
 
 import { e2eTest } from './e2e-test'
+import { describeRunInNodeVersion } from './runInVersion'
 import { SubjectInboundTransport } from './transport/SubjectInboundTransport'
 import { SubjectOutboundTransport } from './transport/SubjectOutboundTransport'
 
@@ -46,7 +47,8 @@ const senderAgentOptions = getAgentOptions(
   })
 )
 
-describe.skip('E2E Askar-AnonCredsRS-IndyVDR Subject tests', () => {
+// Performance issues outside of Node 18
+describeRunInNodeVersion([18], 'E2E Askar-AnonCredsRS-IndyVDR Subject tests', () => {
   let recipientAgent: AnonCredsTestsAgent
   let mediatorAgent: AnonCredsTestsAgent
   let senderAgent: AnonCredsTestsAgent

--- a/tests/runInVersion.ts
+++ b/tests/runInVersion.ts
@@ -1,0 +1,12 @@
+type NodeVersions = 14 | 16 | 17 | 18
+
+export function describeRunInNodeVersion(versions: NodeVersions[], ...parameters: Parameters<typeof describe>) {
+  const runtimeVersion = process.version
+  const mappedVersions = versions.map((version) => `v${version}.`)
+
+  if (mappedVersions.some((version) => runtimeVersion.startsWith(version))) {
+    describe(...parameters)
+  } else {
+    describe.skip(...parameters)
+  }
+}


### PR DESCRIPTION
This PR adds a few improvements to the test setup that should hopefully prevent timeouts, but also make sure we test the askar setup:
- only run askar related tests in node18
- add ref-napi resolution in node18
- increase timeout for some packages that often timeout