### PR TITLE
fix(anoncreds): Buffer not imported from core

### DIFF
--- a/packages/anoncreds/src/utils/credential.ts
+++ b/packages/anoncreds/src/utils/credential.ts
@@ -1,7 +1,7 @@
 import type { AnonCredsSchema, AnonCredsCredentialValues } from '../models'
 import type { CredentialPreviewAttributeOptions, LinkedAttachment } from '@aries-framework/core'
 
-import { AriesFrameworkError, Hasher, encodeAttachment } from '@aries-framework/core'
+import { AriesFrameworkError, Hasher, encodeAttachment, Buffer } from '@aries-framework/core'
 import BigNumber from 'bn.js'
 
 const isString = (value: unknown): value is string => typeof value === 'string'


### PR DESCRIPTION
Subtle omission that was causing `encodeCredentialValue` to fail under React Native.