### PR TITLE
test: increase timeout to 120 seconds

### DIFF
--- a/packages/action-menu/tests/setup.ts
+++ b/packages/action-menu/tests/setup.ts
@@ -1,3 +1,3 @@
 import 'reflect-metadata'
 
-jest.setTimeout(20000)
+jest.setTimeout(120000)

--- a/packages/anoncreds-rs/tests/setup.ts
+++ b/packages/anoncreds-rs/tests/setup.ts
@@ -1,3 +1,3 @@
 import '@hyperledger/anoncreds-nodejs'
 
-jest.setTimeout(60000)
+jest.setTimeout(120000)

--- a/packages/anoncreds/tests/setup.ts
+++ b/packages/anoncreds/tests/setup.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(50000)
+jest.setTimeout(120000)

--- a/packages/askar/tests/setup.ts
+++ b/packages/askar/tests/setup.ts
@@ -1,11 +1,10 @@
 import 'reflect-metadata'
 
+jest.setTimeout(180000)
+
 try {
   // eslint-disable-next-line import/no-extraneous-dependencies
   require('@hyperledger/aries-askar-nodejs')
 } catch (error) {
   throw new Error('Could not load aries-askar bindings')
 }
-
-// FIXME: Remove when Askar JS Wrapper performance issues are solved
-jest.setTimeout(180000)

--- a/packages/bbs-signatures/tests/setup.ts
+++ b/packages/bbs-signatures/tests/setup.ts
@@ -1,3 +1,3 @@
 import 'reflect-metadata'
 
-jest.setTimeout(30000)
+jest.setTimeout(120000)

--- a/packages/indy-sdk/tests/setup.ts
+++ b/packages/indy-sdk/tests/setup.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(60000)
+jest.setTimeout(120000)

--- a/packages/indy-vdr/tests/setup.ts
+++ b/packages/indy-vdr/tests/setup.ts
@@ -3,4 +3,4 @@ import '../src/index'
 
 require('@hyperledger/indy-vdr-nodejs')
 
-jest.setTimeout(60000)
+jest.setTimeout(120000)

--- a/packages/openid4vc-client/tests/setup.ts
+++ b/packages/openid4vc-client/tests/setup.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(20000)
+jest.setTimeout(120000)

--- a/packages/question-answer/tests/setup.ts
+++ b/packages/question-answer/tests/setup.ts
@@ -1,3 +1,3 @@
 import 'reflect-metadata'
 
-jest.setTimeout(20000)
+jest.setTimeout(120000)

--- a/packages/tenants/tests/setup.ts
+++ b/packages/tenants/tests/setup.ts
@@ -1,3 +1,3 @@
 import 'reflect-metadata'
 
-jest.setTimeout(50000)
+jest.setTimeout(120000)

--- a/samples/extension-module/tests/setup.ts
+++ b/samples/extension-module/tests/setup.ts
@@ -1,1 +1,1 @@
-jest.setTimeout(20000)
+jest.setTimeout(120000)


### PR DESCRIPTION
Github action runners are slow as fuck, so I've just increased them all to 2 minutes now.