### PR TITLE
feat(askar): import/export wallet support for SQLite

### DIFF
--- a/packages/askar/src/wallet/__tests__/AskarWallet.test.ts
+++ b/packages/askar/src/wallet/__tests__/AskarWallet.test.ts
@@ -267,7 +267,13 @@ describeRunInNodeVersion([18], 'AskarWallet management', () => {
     await askarWallet.close()
 
     const newKey = Store.generateRawKey()
-    await askarWallet.rotateKey({ ...walletConfig, id: 'AskarWallet Key Rotation', key: initialKey, rekey: newKey })
+    await askarWallet.rotateKey({
+      ...walletConfig,
+      id: 'AskarWallet Key Rotation',
+      key: initialKey,
+      rekey: newKey,
+      rekeyDerivationMethod: KeyDerivationMethod.Raw,
+    })
 
     await askarWallet.close()
 

--- a/packages/askar/tests/askar-sqlite.e2e.test.ts
+++ b/packages/askar/tests/askar-sqlite.e2e.test.ts
@@ -1,0 +1,187 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+import {
+  Agent,
+  BasicMessageRecord,
+  BasicMessageRepository,
+  BasicMessageRole,
+  KeyDerivationMethod,
+  TypedArrayEncoder,
+  utils,
+  WalletDuplicateError,
+  WalletInvalidKeyError,
+  WalletNotFoundError,
+} from '@aries-framework/core'
+import { Store } from '@hyperledger/aries-askar-shared'
+import { tmpdir } from 'os'
+import path from 'path'
+
+import { describeRunInNodeVersion } from '../../../tests/runInVersion'
+
+import { getSqliteAgentOptions } from './helpers'
+
+const aliceAgentOptions = getSqliteAgentOptions('AgentsAlice')
+const bobAgentOptions = getSqliteAgentOptions('AgentsBob')
+
+// FIXME: Re-include in tests when Askar NodeJS wrapper performance is improved
+describeRunInNodeVersion([18], 'Askar SQLite agents', () => {
+  let aliceAgent: Agent
+  let bobAgent: Agent
+
+  beforeEach(async () => {
+    aliceAgent = new Agent(aliceAgentOptions)
+    bobAgent = new Agent(bobAgentOptions)
+  })
+
+  afterEach(async () => {
+    await aliceAgent.shutdown()
+    await bobAgent.shutdown()
+
+    if (aliceAgent.wallet.isProvisioned) {
+      await aliceAgent.wallet.delete()
+    }
+    if (bobAgent.wallet.isProvisioned) {
+      await bobAgent.wallet.delete()
+    }
+  })
+
+  test('open, create and open wallet with different wallet key that it is in agent config', async () => {
+    const walletConfig = {
+      id: 'mywallet',
+      key: 'mysecretwalletkey-0',
+    }
+
+    try {
+      await aliceAgent.wallet.open(walletConfig)
+    } catch (error) {
+      if (error instanceof WalletNotFoundError) {
+        await aliceAgent.wallet.create(walletConfig)
+        await aliceAgent.wallet.open(walletConfig)
+      }
+    }
+
+    await aliceAgent.initialize()
+
+    expect(aliceAgent.isInitialized).toBe(true)
+  })
+
+  test('when opening non-existing wallet throw WalletNotFoundError', async () => {
+    const walletConfig = {
+      id: 'mywallet',
+      key: 'mysecretwalletkey-1',
+    }
+
+    await expect(aliceAgent.wallet.open(walletConfig)).rejects.toThrowError(WalletNotFoundError)
+  })
+
+  test('when create wallet and shutdown, wallet is closed', async () => {
+    const walletConfig = {
+      id: 'mywallet',
+      key: 'mysecretwalletkey-2',
+    }
+
+    await aliceAgent.wallet.create(walletConfig)
+
+    await aliceAgent.shutdown()
+
+    await expect(aliceAgent.wallet.open(walletConfig)).resolves.toBeUndefined()
+  })
+
+  test('create wallet with custom key derivation method', async () => {
+    const walletConfig = {
+      id: 'mywallet',
+      key: Store.generateRawKey(TypedArrayEncoder.fromString('mysecretwalletkey')),
+      keyDerivationMethod: KeyDerivationMethod.Raw,
+    }
+
+    await aliceAgent.wallet.createAndOpen(walletConfig)
+
+    expect(aliceAgent.wallet.isInitialized).toBe(true)
+  })
+
+  test('when exporting and importing a wallet, content is copied', async () => {
+    await bobAgent.initialize()
+    const bobBasicMessageRepository = bobAgent.dependencyManager.resolve(BasicMessageRepository)
+
+    const basicMessageRecord = new BasicMessageRecord({
+      id: 'some-id',
+      connectionId: 'connId',
+      content: 'hello',
+      role: BasicMessageRole.Receiver,
+      sentTime: 'sentIt',
+    })
+
+    // Save in wallet
+    await bobBasicMessageRepository.save(bobAgent.context, basicMessageRecord)
+
+    if (!bobAgent.config.walletConfig) {
+      throw new Error('No wallet config on bobAgent')
+    }
+
+    const backupKey = 'someBackupKey'
+    const backupWalletName = `backup-${utils.uuid()}`
+    const backupPath = path.join(tmpdir(), backupWalletName)
+
+    // Create backup and delete wallet
+    await bobAgent.wallet.export({ path: backupPath, key: backupKey })
+    await bobAgent.wallet.delete()
+
+    // Initialize the wallet again and assert record does not exist
+    // This should create a new wallet
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    await bobAgent.wallet.initialize(bobAgentOptions.config.walletConfig!)
+    expect(await bobBasicMessageRepository.findById(bobAgent.context, basicMessageRecord.id)).toBeNull()
+    await bobAgent.wallet.delete()
+
+    // Import backup with different wallet id and initialize
+    await bobAgent.wallet.import({ id: backupWalletName, key: backupWalletName }, { path: backupPath, key: backupKey })
+    await bobAgent.wallet.initialize({ id: backupWalletName, key: backupWalletName })
+
+    // Expect same basic message record to exist in new wallet
+    expect(await bobBasicMessageRepository.getById(bobAgent.context, basicMessageRecord.id)).toMatchObject(
+      basicMessageRecord
+    )
+  })
+
+  test('changing wallet key', async () => {
+    const walletConfig = {
+      id: 'mywallet',
+      key: 'mysecretwalletkey',
+    }
+
+    await aliceAgent.wallet.createAndOpen(walletConfig)
+    await aliceAgent.initialize()
+
+    //Close agent
+    const walletConfigRekey = {
+      id: 'mywallet',
+      key: 'mysecretwalletkey',
+      rekey: '123',
+    }
+
+    await aliceAgent.shutdown()
+    await aliceAgent.wallet.rotateKey(walletConfigRekey)
+    await aliceAgent.initialize()
+
+    expect(aliceAgent.isInitialized).toBe(true)
+  })
+
+  test('when creating already existing wallet throw WalletDuplicateError', async () => {
+    const walletConfig = {
+      id: 'mywallet',
+      key: 'mysecretwalletkey-2',
+    }
+
+    await aliceAgent.wallet.create(walletConfig)
+    await expect(aliceAgent.wallet.create(walletConfig)).rejects.toThrowError(WalletDuplicateError)
+  })
+
+  test('when opening wallet with invalid key throw WalletInvalidKeyError', async () => {
+    const walletConfig = {
+      id: 'mywallet',
+      key: 'mysecretwalletkey-3',
+    }
+
+    await aliceAgent.wallet.create(walletConfig)
+    await expect(aliceAgent.wallet.open({ ...walletConfig, key: 'abcd' })).rejects.toThrowError(WalletInvalidKeyError)
+  })
+})

--- a/packages/askar/tests/helpers.ts
+++ b/packages/askar/tests/helpers.ts
@@ -20,11 +20,31 @@ export function getPostgresAgentOptions(
   extraConfig: Partial<InitConfig> = {}
 ) {
   const config: InitConfig = {
-    label: `Agent: ${name}`,
+    label: `Agent: ${name} Postgres`,
     walletConfig: {
       id: `Wallet${name}`,
       key: `Key${name}`,
       storage: storageConfig,
+    },
+    autoAcceptConnections: true,
+    autoUpdateStorageOnStartup: false,
+    logger: new TestLogger(LogLevel.off, name),
+    ...extraConfig,
+  }
+  return {
+    config,
+    dependencies: agentDependencies,
+    modules: { askar: new AskarModule() },
+  } as const
+}
+
+export function getSqliteAgentOptions(name: string, extraConfig: Partial<InitConfig> = {}) {
+  const config: InitConfig = {
+    label: `Agent: ${name} SQLite`,
+    walletConfig: {
+      id: `Wallet${name}`,
+      key: `Key${name}`,
+      storage: { type: 'sqlite' },
     },
     autoAcceptConnections: true,
     autoUpdateStorageOnStartup: false,

--- a/packages/core/src/storage/FileSystem.ts
+++ b/packages/core/src/storage/FileSystem.ts
@@ -11,6 +11,7 @@ export interface FileSystem {
 
   exists(path: string): Promise<boolean>
   createDirectory(path: string): Promise<void>
+  copyFile(sourcePath: string, destinationPath: string): Promise<void>
   write(path: string, data: string): Promise<void>
   read(path: string): Promise<string>
   delete(path: string): Promise<void>

--- a/packages/node/src/NodeFileSystem.ts
+++ b/packages/node/src/NodeFileSystem.ts
@@ -8,7 +8,7 @@ import https from 'https'
 import { tmpdir, homedir } from 'os'
 import { dirname } from 'path'
 
-const { access, readFile, writeFile, mkdir, rm, unlink } = promises
+const { access, readFile, writeFile, mkdir, rm, unlink, copyFile } = promises
 
 export class NodeFileSystem implements FileSystem {
   public readonly dataPath
@@ -42,6 +42,10 @@ export class NodeFileSystem implements FileSystem {
 
   public async createDirectory(path: string): Promise<void> {
     await mkdir(dirname(path), { recursive: true })
+  }
+
+  public async copyFile(sourcePath: string, destinationPath: string): Promise<void> {
+    await copyFile(sourcePath, destinationPath)
   }
 
   public async write(path: string, data: string): Promise<void> {

--- a/packages/react-native/src/ReactNativeFileSystem.ts
+++ b/packages/react-native/src/ReactNativeFileSystem.ts
@@ -43,6 +43,10 @@ export class ReactNativeFileSystem implements FileSystem {
     await RNFS.mkdir(getDirFromFilePath(path))
   }
 
+  public async copyFile(sourcePath: string, destinationPath: string): Promise<void> {
+    await RNFS.copyFile(sourcePath, destinationPath)
+  }
+
   public async write(path: string, data: string): Promise<void> {
     // Make sure parent directories exist
     await RNFS.mkdir(getDirFromFilePath(path))


### PR DESCRIPTION
Add support for wallet export and import by copying sqlite file and executing a key rotation to the one specified in the `WalletExportImportConfig` object. Similarly, when importing the wallet it will copy the origin file to the expected directory according to wallet id and do a rekey to the key specified.

In addition, there are a few tweaks and fixes for things I found during testing such as: 

- Key object handles clearing in pack/unpack and key creation/signing/verification methods
- Check wallet database file is created before (not sure why, but Askar is not throwing Duplicate error in `Store.provision` when wallet exists). This only works for SQLite but it's better than nothing
- Use key derivation based in argon2 Int if nothing specified, as it's the default in Indy SDK AFAIK