### PR TITLE
fix: connection id in sessions for new connections

### DIFF
--- a/packages/core/src/agent/TransportService.ts
+++ b/packages/core/src/agent/TransportService.ts
@@ -4,6 +4,7 @@ import type { DidDocument } from '../modules/dids'
 import type { EncryptedMessage } from '../types'
 
 import { DID_COMM_TRANSPORT_QUEUE } from '../constants'
+import { AriesFrameworkError } from '../error'
 import { injectable } from '../plugins'
 
 @injectable()
@@ -16,6 +17,15 @@ export class TransportService {
 
   public findSessionByConnectionId(connectionId: string) {
     return Object.values(this.transportSessionTable).find((session) => session?.connectionId === connectionId)
+  }
+
+  public setConnectionIdForSession(sessionId: string, connectionId: string) {
+    const session = this.findSessionById(sessionId)
+    if (!session) {
+      throw new AriesFrameworkError(`Session not found with id ${sessionId}`)
+    }
+    session.connectionId = connectionId
+    this.saveSession(session)
   }
 
   public hasInboundEndpoint(didDocument: DidDocument): boolean {

--- a/packages/core/src/modules/routing/__tests__/pickup.test.ts
+++ b/packages/core/src/modules/routing/__tests__/pickup.test.ts
@@ -78,6 +78,13 @@ describe('E2E Pick Up protocol', () => {
 
     mediatorRecipientConnection = await mediatorAgent.connections.returnWhenIsConnected(mediatorRecipientConnection!.id)
 
+    // Now they are connected, reinitialize recipient agent in order to lose the session (as with SubjectTransport it remains open)
+    await recipientAgent.shutdown()
+
+    recipientAgent = new Agent(recipientOptions)
+    recipientAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
+    await recipientAgent.initialize()
+
     const message = 'hello pickup V1'
     await mediatorAgent.basicMessages.sendMessage(mediatorRecipientConnection.id, message)
 


### PR DESCRIPTION
When a message for a connection request (either for DID Exchange or Connection protocol) is received, a session is created without any connection id associated to it (as it is not created yet).

If the party requesting a connection does not have a public endpoint (e.g. a edge agent connecting to a mediator) and the responder does not have `autoAcceptConnections` enabled, it will not associate this session to the newly created connection, forcing any call to `agent.connections.acceptRequest` to queue the messages, even if the transport used allows a persistent connection (typical case for WebSockets).

So here what we do is simply to associate the connection to the session as soon as it is created. At the moment I don't see any drawback of this strategy but will be happy to hear any situation where this could represent a problem.