### PR TITLE
feat(anoncreds): add AnonCreds format services

### DIFF
--- a/packages/anoncreds-rs/tests/anoncreds-flow.test.ts
+++ b/packages/anoncreds-rs/tests/anoncreds-flow.test.ts
@@ -1,0 +1,358 @@
+import type { AnonCredsCredentialRequest } from '@aries-framework/anoncreds'
+import type { Wallet } from '@aries-framework/core'
+
+import {
+  AnonCredsModuleConfig,
+  AnonCredsHolderServiceSymbol,
+  AnonCredsIssuerServiceSymbol,
+  AnonCredsVerifierServiceSymbol,
+  AnonCredsSchemaRecord,
+  AnonCredsSchemaRepository,
+  AnonCredsCredentialDefinitionRepository,
+  AnonCredsCredentialDefinitionRecord,
+  AnonCredsCredentialDefinitionPrivateRepository,
+  AnonCredsCredentialDefinitionPrivateRecord,
+  AnonCredsKeyCorrectnessProofRepository,
+  AnonCredsKeyCorrectnessProofRecord,
+  AnonCredsLinkSecretRepository,
+  AnonCredsLinkSecretRecord,
+  AnonCredsProofFormatService,
+  AnonCredsCredentialFormatService,
+} from '@aries-framework/anoncreds'
+import {
+  CredentialState,
+  CredentialExchangeRecord,
+  CredentialPreviewAttribute,
+  InjectionSymbols,
+  ProofState,
+  ProofExchangeRecord,
+} from '@aries-framework/core'
+import { Subject } from 'rxjs'
+
+import { InMemoryStorageService } from '../../../tests/InMemoryStorageService'
+import { describeRunInNodeVersion } from '../../../tests/runInVersion'
+import { AnonCredsRegistryService } from '../../anoncreds/src/services/registry/AnonCredsRegistryService'
+import { InMemoryAnonCredsRegistry } from '../../anoncreds/tests/InMemoryAnonCredsRegistry'
+import { agentDependencies, getAgentConfig, getAgentContext } from '../../core/tests/helpers'
+import { AnonCredsRsHolderService } from '../src/services/AnonCredsRsHolderService'
+import { AnonCredsRsIssuerService } from '../src/services/AnonCredsRsIssuerService'
+import { AnonCredsRsVerifierService } from '../src/services/AnonCredsRsVerifierService'
+
+const registry = new InMemoryAnonCredsRegistry({ useLegacyIdentifiers: false })
+const anonCredsModuleConfig = new AnonCredsModuleConfig({
+  registries: [registry],
+})
+
+const agentConfig = getAgentConfig('AnonCreds format services using anoncreds-rs')
+const anonCredsVerifierService = new AnonCredsRsVerifierService()
+const anonCredsHolderService = new AnonCredsRsHolderService()
+const anonCredsIssuerService = new AnonCredsRsIssuerService()
+
+const wallet = { generateNonce: () => Promise.resolve('947121108704767252195123') } as Wallet
+
+const inMemoryStorageService = new InMemoryStorageService()
+const agentContext = getAgentContext({
+  registerInstances: [
+    [InjectionSymbols.Stop$, new Subject<boolean>()],
+    [InjectionSymbols.AgentDependencies, agentDependencies],
+    [InjectionSymbols.StorageService, inMemoryStorageService],
+    [AnonCredsIssuerServiceSymbol, anonCredsIssuerService],
+    [AnonCredsHolderServiceSymbol, anonCredsHolderService],
+    [AnonCredsVerifierServiceSymbol, anonCredsVerifierService],
+    [AnonCredsRegistryService, new AnonCredsRegistryService()],
+    [AnonCredsModuleConfig, anonCredsModuleConfig],
+  ],
+  agentConfig,
+  wallet,
+})
+
+const anoncredsCredentialFormatService = new AnonCredsCredentialFormatService()
+const anoncredsProofFormatService = new AnonCredsProofFormatService()
+
+const indyDid = 'did:indy:local:LjgpST2rjsoxYegQDRm7EL'
+
+// FIXME: Re-include in tests when NodeJS wrapper performance is improved
+describeRunInNodeVersion([18], 'AnonCreds format services using anoncreds-rs', () => {
+  test('issuance and verification flow starting from proposal without negotiation and without revocation', async () => {
+    const schema = await anonCredsIssuerService.createSchema(agentContext, {
+      attrNames: ['name', 'age'],
+      issuerId: indyDid,
+      name: 'Employee Credential',
+      version: '1.0.0',
+    })
+
+    const { schemaState } = await registry.registerSchema(agentContext, {
+      schema,
+      options: {},
+    })
+
+    const { credentialDefinition, credentialDefinitionPrivate, keyCorrectnessProof } =
+      await anonCredsIssuerService.createCredentialDefinition(agentContext, {
+        issuerId: indyDid,
+        schemaId: schemaState.schemaId as string,
+        schema,
+        tag: 'Employee Credential',
+        supportRevocation: false,
+      })
+
+    const { credentialDefinitionState } = await registry.registerCredentialDefinition(agentContext, {
+      credentialDefinition,
+      options: {},
+    })
+
+    if (
+      !credentialDefinitionState.credentialDefinition ||
+      !credentialDefinitionState.credentialDefinitionId ||
+      !schemaState.schema ||
+      !schemaState.schemaId
+    ) {
+      throw new Error('Failed to create schema or credential definition')
+    }
+
+    if (
+      !credentialDefinitionState.credentialDefinition ||
+      !credentialDefinitionState.credentialDefinitionId ||
+      !schemaState.schema ||
+      !schemaState.schemaId
+    ) {
+      throw new Error('Failed to create schema or credential definition')
+    }
+
+    if (!credentialDefinitionPrivate || !keyCorrectnessProof) {
+      throw new Error('Failed to get private part of credential definition')
+    }
+
+    await agentContext.dependencyManager.resolve(AnonCredsSchemaRepository).save(
+      agentContext,
+      new AnonCredsSchemaRecord({
+        schema: schemaState.schema,
+        schemaId: schemaState.schemaId,
+      })
+    )
+
+    await agentContext.dependencyManager.resolve(AnonCredsCredentialDefinitionRepository).save(
+      agentContext,
+      new AnonCredsCredentialDefinitionRecord({
+        credentialDefinition: credentialDefinitionState.credentialDefinition,
+        credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+      })
+    )
+
+    await agentContext.dependencyManager.resolve(AnonCredsCredentialDefinitionPrivateRepository).save(
+      agentContext,
+      new AnonCredsCredentialDefinitionPrivateRecord({
+        value: credentialDefinitionPrivate,
+        credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+      })
+    )
+
+    await agentContext.dependencyManager.resolve(AnonCredsKeyCorrectnessProofRepository).save(
+      agentContext,
+      new AnonCredsKeyCorrectnessProofRecord({
+        value: keyCorrectnessProof,
+        credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+      })
+    )
+
+    const linkSecret = await anonCredsHolderService.createLinkSecret(agentContext, { linkSecretId: 'linkSecretId' })
+    expect(linkSecret.linkSecretId).toBe('linkSecretId')
+
+    await agentContext.dependencyManager.resolve(AnonCredsLinkSecretRepository).save(
+      agentContext,
+      new AnonCredsLinkSecretRecord({
+        value: linkSecret.linkSecretValue,
+        linkSecretId: linkSecret.linkSecretId,
+      })
+    )
+
+    const holderCredentialRecord = new CredentialExchangeRecord({
+      protocolVersion: 'v1',
+      state: CredentialState.ProposalSent,
+      threadId: 'f365c1a5-2baf-4873-9432-fa87c888a0aa',
+    })
+
+    const issuerCredentialRecord = new CredentialExchangeRecord({
+      protocolVersion: 'v1',
+      state: CredentialState.ProposalReceived,
+      threadId: 'f365c1a5-2baf-4873-9432-fa87c888a0aa',
+    })
+
+    const credentialAttributes = [
+      new CredentialPreviewAttribute({
+        name: 'name',
+        value: 'John',
+      }),
+      new CredentialPreviewAttribute({
+        name: 'age',
+        value: '25',
+      }),
+    ]
+
+    // Holder creates proposal
+    holderCredentialRecord.credentialAttributes = credentialAttributes
+    const { attachment: proposalAttachment } = await anoncredsCredentialFormatService.createProposal(agentContext, {
+      credentialRecord: holderCredentialRecord,
+      credentialFormats: {
+        anoncreds: {
+          attributes: credentialAttributes,
+          credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+        },
+      },
+    })
+
+    // Issuer processes and accepts proposal
+    await anoncredsCredentialFormatService.processProposal(agentContext, {
+      credentialRecord: issuerCredentialRecord,
+      attachment: proposalAttachment,
+    })
+    // Set attributes on the credential record, this is normally done by the protocol service
+    issuerCredentialRecord.credentialAttributes = credentialAttributes
+    const { attachment: offerAttachment } = await anoncredsCredentialFormatService.acceptProposal(agentContext, {
+      credentialRecord: issuerCredentialRecord,
+      proposalAttachment: proposalAttachment,
+    })
+
+    // Holder processes and accepts offer
+    await anoncredsCredentialFormatService.processOffer(agentContext, {
+      credentialRecord: holderCredentialRecord,
+      attachment: offerAttachment,
+    })
+    const { attachment: requestAttachment } = await anoncredsCredentialFormatService.acceptOffer(agentContext, {
+      credentialRecord: holderCredentialRecord,
+      offerAttachment,
+      credentialFormats: {
+        anoncreds: {
+          linkSecretId: linkSecret.linkSecretId,
+        },
+      },
+    })
+
+    // Make sure the request contains an entropy and does not contain a prover_did field
+    expect((requestAttachment.getDataAsJson() as AnonCredsCredentialRequest).entropy).toBeDefined()
+    expect((requestAttachment.getDataAsJson() as AnonCredsCredentialRequest).prover_did).toBeUndefined()
+
+    // Issuer processes and accepts request
+    await anoncredsCredentialFormatService.processRequest(agentContext, {
+      credentialRecord: issuerCredentialRecord,
+      attachment: requestAttachment,
+    })
+    const { attachment: credentialAttachment } = await anoncredsCredentialFormatService.acceptRequest(agentContext, {
+      credentialRecord: issuerCredentialRecord,
+      requestAttachment,
+      offerAttachment,
+    })
+
+    // Holder processes and accepts credential
+    await anoncredsCredentialFormatService.processCredential(agentContext, {
+      credentialRecord: holderCredentialRecord,
+      attachment: credentialAttachment,
+      requestAttachment,
+    })
+
+    expect(holderCredentialRecord.credentials).toEqual([
+      { credentialRecordType: 'anoncreds', credentialRecordId: expect.any(String) },
+    ])
+
+    const credentialId = holderCredentialRecord.credentials[0].credentialRecordId
+    const anonCredsCredential = await anonCredsHolderService.getCredential(agentContext, {
+      credentialId,
+    })
+
+    expect(anonCredsCredential).toEqual({
+      credentialId,
+      attributes: {
+        age: '25',
+        name: 'John',
+      },
+      schemaId: schemaState.schemaId,
+      credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+      revocationRegistryId: null,
+      credentialRevocationId: undefined, // FIXME: should be null?
+    })
+
+    expect(holderCredentialRecord.metadata.data).toEqual({
+      '_anonCreds/anonCredsCredential': {
+        schemaId: schemaState.schemaId,
+        credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+      },
+      '_anonCreds/anonCredsCredentialRequest': {
+        master_secret_blinding_data: expect.any(Object),
+        master_secret_name: expect.any(String),
+        nonce: expect.any(String),
+      },
+    })
+
+    expect(issuerCredentialRecord.metadata.data).toEqual({
+      '_anonCreds/anonCredsCredential': {
+        schemaId: schemaState.schemaId,
+        credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+      },
+    })
+
+    const holderProofRecord = new ProofExchangeRecord({
+      protocolVersion: 'v1',
+      state: ProofState.ProposalSent,
+      threadId: '4f5659a4-1aea-4f42-8c22-9a9985b35e38',
+    })
+    const verifierProofRecord = new ProofExchangeRecord({
+      protocolVersion: 'v1',
+      state: ProofState.ProposalReceived,
+      threadId: '4f5659a4-1aea-4f42-8c22-9a9985b35e38',
+    })
+
+    const { attachment: proofProposalAttachment } = await anoncredsProofFormatService.createProposal(agentContext, {
+      proofFormats: {
+        anoncreds: {
+          attributes: [
+            {
+              name: 'name',
+              credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+              value: 'John',
+              referent: '1',
+            },
+          ],
+          predicates: [
+            {
+              credentialDefinitionId: credentialDefinitionState.credentialDefinitionId,
+              name: 'age',
+              predicate: '>=',
+              threshold: 18,
+            },
+          ],
+          name: 'Proof Request',
+          version: '1.0',
+        },
+      },
+      proofRecord: holderProofRecord,
+    })
+
+    await anoncredsProofFormatService.processProposal(agentContext, {
+      attachment: proofProposalAttachment,
+      proofRecord: verifierProofRecord,
+    })
+
+    const { attachment: proofRequestAttachment } = await anoncredsProofFormatService.acceptProposal(agentContext, {
+      proofRecord: verifierProofRecord,
+      proposalAttachment: proofProposalAttachment,
+    })
+
+    await anoncredsProofFormatService.processRequest(agentContext, {
+      attachment: proofRequestAttachment,
+      proofRecord: holderProofRecord,
+    })
+
+    const { attachment: proofAttachment } = await anoncredsProofFormatService.acceptRequest(agentContext, {
+      proofRecord: holderProofRecord,
+      requestAttachment: proofRequestAttachment,
+      proposalAttachment: proofProposalAttachment,
+    })
+
+    const isValid = await anoncredsProofFormatService.processPresentation(agentContext, {
+      attachment: proofAttachment,
+      proofRecord: verifierProofRecord,
+      requestAttachment: proofRequestAttachment,
+    })
+
+    expect(isValid).toBe(true)
+  })
+})

--- a/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
+++ b/packages/anoncreds/src/formats/AnonCredsCredentialFormatService.ts
@@ -1,0 +1,635 @@
+import type { AnonCredsCredentialFormat, AnonCredsCredentialProposalFormat } from './AnonCredsCredentialFormat'
+import type {
+  AnonCredsCredential,
+  AnonCredsCredentialOffer,
+  AnonCredsCredentialRequest,
+  AnonCredsCredentialRequestMetadata,
+} from '../models'
+import type { AnonCredsIssuerService, AnonCredsHolderService, GetRevocationRegistryDefinitionReturn } from '../services'
+import type { AnonCredsCredentialMetadata } from '../utils/metadata'
+import type {
+  CredentialFormatService,
+  AgentContext,
+  CredentialFormatCreateProposalOptions,
+  CredentialFormatCreateProposalReturn,
+  CredentialFormatProcessOptions,
+  CredentialFormatAcceptProposalOptions,
+  CredentialFormatCreateOfferReturn,
+  CredentialFormatCreateOfferOptions,
+  CredentialFormatAcceptOfferOptions,
+  CredentialFormatCreateReturn,
+  CredentialFormatAcceptRequestOptions,
+  CredentialFormatProcessCredentialOptions,
+  CredentialFormatAutoRespondProposalOptions,
+  CredentialFormatAutoRespondOfferOptions,
+  CredentialFormatAutoRespondRequestOptions,
+  CredentialFormatAutoRespondCredentialOptions,
+  CredentialExchangeRecord,
+  CredentialPreviewAttributeOptions,
+  LinkedAttachment,
+} from '@aries-framework/core'
+
+import {
+  ProblemReportError,
+  MessageValidator,
+  CredentialFormatSpec,
+  AriesFrameworkError,
+  Attachment,
+  JsonEncoder,
+  utils,
+  CredentialProblemReportReason,
+  JsonTransformer,
+} from '@aries-framework/core'
+
+import { AnonCredsError } from '../error'
+import { AnonCredsCredentialProposal } from '../models/AnonCredsCredentialProposal'
+import { AnonCredsIssuerServiceSymbol, AnonCredsHolderServiceSymbol } from '../services'
+import { AnonCredsRegistryService } from '../services/registry/AnonCredsRegistryService'
+import {
+  convertAttributesToCredentialValues,
+  assertCredentialValuesMatch,
+  checkCredentialValuesMatch,
+  assertAttributesMatch,
+  createAndLinkAttachmentsToPreview,
+} from '../utils/credential'
+import { AnonCredsCredentialMetadataKey, AnonCredsCredentialRequestMetadataKey } from '../utils/metadata'
+
+const ANONCREDS_CREDENTIAL_OFFER = 'anoncreds/credential-offer@v1.0'
+const ANONCREDS_CREDENTIAL_REQUEST = 'anoncreds/credential-request@v1.0'
+const ANONCREDS_CREDENTIAL_FILTER = 'anoncreds/credential-filter@v1.0'
+const ANONCREDS_CREDENTIAL = 'anoncreds/credential@v1.0'
+
+export class AnonCredsCredentialFormatService implements CredentialFormatService<AnonCredsCredentialFormat> {
+  /** formatKey is the key used when calling agent.credentials.xxx with credentialFormats.anoncreds */
+  public readonly formatKey = 'anoncreds' as const
+
+  /**
+   * credentialRecordType is the type of record that stores the credential. It is stored in the credential
+   * record binding in the credential exchange record.
+   */
+  public readonly credentialRecordType = 'anoncreds' as const
+
+  /**
+   * Create a {@link AttachmentFormats} object dependent on the message type.
+   *
+   * @param options The object containing all the options for the proposed credential
+   * @returns object containing associated attachment, format and optionally the credential preview
+   *
+   */
+  public async createProposal(
+    agentContext: AgentContext,
+    { credentialFormats, credentialRecord }: CredentialFormatCreateProposalOptions<AnonCredsCredentialFormat>
+  ): Promise<CredentialFormatCreateProposalReturn> {
+    const format = new CredentialFormatSpec({
+      format: ANONCREDS_CREDENTIAL_FILTER,
+    })
+
+    const anoncredsFormat = credentialFormats.anoncreds
+
+    if (!anoncredsFormat) {
+      throw new AriesFrameworkError('Missing anoncreds payload in createProposal')
+    }
+
+    // We want all properties except for `attributes` and `linkedAttachments` attributes.
+    // The easiest way is to destructure and use the spread operator. But that leaves the other properties unused
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { attributes, linkedAttachments, ...anoncredsCredentialProposal } = anoncredsFormat
+    const proposal = new AnonCredsCredentialProposal(anoncredsCredentialProposal)
+
+    try {
+      MessageValidator.validateSync(proposal)
+    } catch (error) {
+      throw new AriesFrameworkError(
+        `Invalid proposal supplied: ${anoncredsCredentialProposal} in AnonCredsFormatService`
+      )
+    }
+
+    const attachment = this.getFormatData(JsonTransformer.toJSON(proposal), format.attachmentId)
+
+    const { previewAttributes } = this.getCredentialLinkedAttachments(
+      anoncredsFormat.attributes,
+      anoncredsFormat.linkedAttachments
+    )
+
+    // Set the metadata
+    credentialRecord.metadata.set<AnonCredsCredentialMetadata>(AnonCredsCredentialMetadataKey, {
+      schemaId: proposal.schemaId,
+      credentialDefinitionId: proposal.credentialDefinitionId,
+    })
+
+    return { format, attachment, previewAttributes }
+  }
+
+  public async processProposal(
+    agentContext: AgentContext,
+    { attachment }: CredentialFormatProcessOptions
+  ): Promise<void> {
+    const proposalJson = attachment.getDataAsJson()
+
+    JsonTransformer.fromJSON(proposalJson, AnonCredsCredentialProposal)
+  }
+
+  public async acceptProposal(
+    agentContext: AgentContext,
+    {
+      attachmentId,
+      credentialFormats,
+      credentialRecord,
+      proposalAttachment,
+    }: CredentialFormatAcceptProposalOptions<AnonCredsCredentialFormat>
+  ): Promise<CredentialFormatCreateOfferReturn> {
+    const anoncredsFormat = credentialFormats?.anoncreds
+
+    const proposalJson = proposalAttachment.getDataAsJson<AnonCredsCredentialProposalFormat>()
+    const credentialDefinitionId = anoncredsFormat?.credentialDefinitionId ?? proposalJson.cred_def_id
+
+    const attributes = anoncredsFormat?.attributes ?? credentialRecord.credentialAttributes
+
+    if (!credentialDefinitionId) {
+      throw new AriesFrameworkError(
+        'No credential definition id in proposal or provided as input to accept proposal method.'
+      )
+    }
+
+    if (!attributes) {
+      throw new AriesFrameworkError('No attributes in proposal or provided as input to accept proposal method.')
+    }
+
+    const { format, attachment, previewAttributes } = await this.createAnonCredsOffer(agentContext, {
+      credentialRecord,
+      attachmentId,
+      attributes,
+      credentialDefinitionId,
+      linkedAttachments: anoncredsFormat?.linkedAttachments,
+    })
+
+    return { format, attachment, previewAttributes }
+  }
+
+  /**
+   * Create a credential attachment format for a credential request.
+   *
+   * @param options The object containing all the options for the credential offer
+   * @returns object containing associated attachment, formats and offersAttach elements
+   *
+   */
+  public async createOffer(
+    agentContext: AgentContext,
+    { credentialFormats, credentialRecord, attachmentId }: CredentialFormatCreateOfferOptions<AnonCredsCredentialFormat>
+  ): Promise<CredentialFormatCreateOfferReturn> {
+    const anoncredsFormat = credentialFormats.anoncreds
+
+    if (!anoncredsFormat) {
+      throw new AriesFrameworkError('Missing anoncreds credential format data')
+    }
+
+    const { format, attachment, previewAttributes } = await this.createAnonCredsOffer(agentContext, {
+      credentialRecord,
+      attachmentId,
+      attributes: anoncredsFormat.attributes,
+      credentialDefinitionId: anoncredsFormat.credentialDefinitionId,
+      linkedAttachments: anoncredsFormat.linkedAttachments,
+    })
+
+    return { format, attachment, previewAttributes }
+  }
+
+  public async processOffer(
+    agentContext: AgentContext,
+    { attachment, credentialRecord }: CredentialFormatProcessOptions
+  ) {
+    agentContext.config.logger.debug(
+      `Processing anoncreds credential offer for credential record ${credentialRecord.id}`
+    )
+
+    const credOffer = attachment.getDataAsJson<AnonCredsCredentialOffer>()
+
+    if (!credOffer.schema_id || !credOffer.cred_def_id) {
+      throw new ProblemReportError('Invalid credential offer', {
+        problemCode: CredentialProblemReportReason.IssuanceAbandoned,
+      })
+    }
+  }
+
+  public async acceptOffer(
+    agentContext: AgentContext,
+    {
+      credentialRecord,
+      attachmentId,
+      offerAttachment,
+      credentialFormats,
+    }: CredentialFormatAcceptOfferOptions<AnonCredsCredentialFormat>
+  ): Promise<CredentialFormatCreateReturn> {
+    const registryService = agentContext.dependencyManager.resolve(AnonCredsRegistryService)
+    const holderService = agentContext.dependencyManager.resolve<AnonCredsHolderService>(AnonCredsHolderServiceSymbol)
+
+    const credentialOffer = offerAttachment.getDataAsJson<AnonCredsCredentialOffer>()
+
+    // Get credential definition
+    const registry = registryService.getRegistryForIdentifier(agentContext, credentialOffer.cred_def_id)
+    const { credentialDefinition, resolutionMetadata } = await registry.getCredentialDefinition(
+      agentContext,
+      credentialOffer.cred_def_id
+    )
+
+    if (!credentialDefinition) {
+      throw new AnonCredsError(
+        `Unable to retrieve credential definition with id ${credentialOffer.cred_def_id}: ${resolutionMetadata.error} ${resolutionMetadata.message}`
+      )
+    }
+
+    const { credentialRequest, credentialRequestMetadata } = await holderService.createCredentialRequest(agentContext, {
+      credentialOffer,
+      credentialDefinition,
+      linkSecretId: credentialFormats?.anoncreds?.linkSecretId,
+    })
+
+    credentialRecord.metadata.set<AnonCredsCredentialRequestMetadata>(
+      AnonCredsCredentialRequestMetadataKey,
+      credentialRequestMetadata
+    )
+    credentialRecord.metadata.set<AnonCredsCredentialMetadata>(AnonCredsCredentialMetadataKey, {
+      credentialDefinitionId: credentialOffer.cred_def_id,
+      schemaId: credentialOffer.schema_id,
+    })
+
+    const format = new CredentialFormatSpec({
+      attachmentId,
+      format: ANONCREDS_CREDENTIAL_REQUEST,
+    })
+
+    const attachment = this.getFormatData(credentialRequest, format.attachmentId)
+    return { format, attachment }
+  }
+
+  /**
+   * Starting from a request is not supported for anoncreds credentials, this method only throws an error.
+   */
+  public async createRequest(): Promise<CredentialFormatCreateReturn> {
+    throw new AriesFrameworkError('Starting from a request is not supported for anoncreds credentials')
+  }
+
+  /**
+   * We don't have any models to validate an anoncreds request object, for now this method does nothing
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async processRequest(agentContext: AgentContext, options: CredentialFormatProcessOptions): Promise<void> {
+    // not needed for anoncreds
+  }
+
+  public async acceptRequest(
+    agentContext: AgentContext,
+    {
+      credentialRecord,
+      attachmentId,
+      offerAttachment,
+      requestAttachment,
+    }: CredentialFormatAcceptRequestOptions<AnonCredsCredentialFormat>
+  ): Promise<CredentialFormatCreateReturn> {
+    // Assert credential attributes
+    const credentialAttributes = credentialRecord.credentialAttributes
+    if (!credentialAttributes) {
+      throw new AriesFrameworkError(
+        `Missing required credential attribute values on credential record with id ${credentialRecord.id}`
+      )
+    }
+
+    const anonCredsIssuerService =
+      agentContext.dependencyManager.resolve<AnonCredsIssuerService>(AnonCredsIssuerServiceSymbol)
+
+    const credentialOffer = offerAttachment?.getDataAsJson<AnonCredsCredentialOffer>()
+    if (!credentialOffer) throw new AriesFrameworkError('Missing anoncreds credential offer in createCredential')
+
+    const credentialRequest = requestAttachment.getDataAsJson<AnonCredsCredentialRequest>()
+    if (!credentialRequest) throw new AriesFrameworkError('Missing anoncreds credential request in createCredential')
+
+    const { credential, credentialRevocationId } = await anonCredsIssuerService.createCredential(agentContext, {
+      credentialOffer,
+      credentialRequest,
+      credentialValues: convertAttributesToCredentialValues(credentialAttributes),
+    })
+
+    if (credential.rev_reg_id) {
+      credentialRecord.metadata.add<AnonCredsCredentialMetadata>(AnonCredsCredentialMetadataKey, {
+        credentialRevocationId: credentialRevocationId,
+        revocationRegistryId: credential.rev_reg_id,
+      })
+      credentialRecord.setTags({
+        anonCredsRevocationRegistryId: credential.rev_reg_id,
+        anonCredsCredentialRevocationId: credentialRevocationId,
+      })
+    }
+
+    const format = new CredentialFormatSpec({
+      attachmentId,
+      format: ANONCREDS_CREDENTIAL,
+    })
+
+    const attachment = this.getFormatData(credential, format.attachmentId)
+    return { format, attachment }
+  }
+
+  /**
+   * Processes an incoming credential - retrieve metadata, retrieve payload and store it in wallet
+   * @param options the issue credential message wrapped inside this object
+   * @param credentialRecord the credential exchange record for this credential
+   */
+  public async processCredential(
+    agentContext: AgentContext,
+    { credentialRecord, attachment }: CredentialFormatProcessCredentialOptions
+  ): Promise<void> {
+    const credentialRequestMetadata = credentialRecord.metadata.get<AnonCredsCredentialRequestMetadata>(
+      AnonCredsCredentialRequestMetadataKey
+    )
+
+    const registryService = agentContext.dependencyManager.resolve(AnonCredsRegistryService)
+    const anonCredsHolderService =
+      agentContext.dependencyManager.resolve<AnonCredsHolderService>(AnonCredsHolderServiceSymbol)
+
+    if (!credentialRequestMetadata) {
+      throw new AriesFrameworkError(
+        `Missing required request metadata for credential exchange with thread id with id ${credentialRecord.id}`
+      )
+    }
+
+    if (!credentialRecord.credentialAttributes) {
+      throw new AriesFrameworkError(
+        'Missing credential attributes on credential record. Unable to check credential attributes'
+      )
+    }
+
+    const anonCredsCredential = attachment.getDataAsJson<AnonCredsCredential>()
+
+    const credentialDefinitionResult = await registryService
+      .getRegistryForIdentifier(agentContext, anonCredsCredential.cred_def_id)
+      .getCredentialDefinition(agentContext, anonCredsCredential.cred_def_id)
+    if (!credentialDefinitionResult.credentialDefinition) {
+      throw new AriesFrameworkError(
+        `Unable to resolve credential definition ${anonCredsCredential.cred_def_id}: ${credentialDefinitionResult.resolutionMetadata.error} ${credentialDefinitionResult.resolutionMetadata.message}`
+      )
+    }
+
+    const schemaResult = await registryService
+      .getRegistryForIdentifier(agentContext, anonCredsCredential.cred_def_id)
+      .getSchema(agentContext, anonCredsCredential.schema_id)
+    if (!schemaResult.schema) {
+      throw new AriesFrameworkError(
+        `Unable to resolve schema ${anonCredsCredential.schema_id}: ${schemaResult.resolutionMetadata.error} ${schemaResult.resolutionMetadata.message}`
+      )
+    }
+
+    // Resolve revocation registry if credential is revocable
+    let revocationRegistryResult: null | GetRevocationRegistryDefinitionReturn = null
+    if (anonCredsCredential.rev_reg_id) {
+      revocationRegistryResult = await registryService
+        .getRegistryForIdentifier(agentContext, anonCredsCredential.rev_reg_id)
+        .getRevocationRegistryDefinition(agentContext, anonCredsCredential.rev_reg_id)
+
+      if (!revocationRegistryResult.revocationRegistryDefinition) {
+        throw new AriesFrameworkError(
+          `Unable to resolve revocation registry definition ${anonCredsCredential.rev_reg_id}: ${revocationRegistryResult.resolutionMetadata.error} ${revocationRegistryResult.resolutionMetadata.message}`
+        )
+      }
+    }
+
+    // assert the credential values match the offer values
+    const recordCredentialValues = convertAttributesToCredentialValues(credentialRecord.credentialAttributes)
+    assertCredentialValuesMatch(anonCredsCredential.values, recordCredentialValues)
+
+    const credentialId = await anonCredsHolderService.storeCredential(agentContext, {
+      credentialId: utils.uuid(),
+      credentialRequestMetadata,
+      credential: anonCredsCredential,
+      credentialDefinitionId: credentialDefinitionResult.credentialDefinitionId,
+      credentialDefinition: credentialDefinitionResult.credentialDefinition,
+      schema: schemaResult.schema,
+      revocationRegistry: revocationRegistryResult?.revocationRegistryDefinition
+        ? {
+            definition: revocationRegistryResult.revocationRegistryDefinition,
+            id: revocationRegistryResult.revocationRegistryDefinitionId,
+          }
+        : undefined,
+    })
+
+    // If the credential is revocable, store the revocation identifiers in the credential record
+    if (anonCredsCredential.rev_reg_id) {
+      const credential = await anonCredsHolderService.getCredential(agentContext, { credentialId })
+
+      credentialRecord.metadata.add<AnonCredsCredentialMetadata>(AnonCredsCredentialMetadataKey, {
+        credentialRevocationId: credential.credentialRevocationId,
+        revocationRegistryId: credential.revocationRegistryId,
+      })
+      credentialRecord.setTags({
+        anonCredsRevocationRegistryId: credential.revocationRegistryId,
+        anonCredsCredentialRevocationId: credential.credentialRevocationId,
+      })
+    }
+
+    credentialRecord.credentials.push({
+      credentialRecordType: this.credentialRecordType,
+      credentialRecordId: credentialId,
+    })
+  }
+
+  public supportsFormat(format: string): boolean {
+    const supportedFormats = [
+      ANONCREDS_CREDENTIAL_REQUEST,
+      ANONCREDS_CREDENTIAL_OFFER,
+      ANONCREDS_CREDENTIAL_FILTER,
+      ANONCREDS_CREDENTIAL,
+    ]
+
+    return supportedFormats.includes(format)
+  }
+
+  /**
+   * Gets the attachment object for a given attachmentId. We need to get out the correct attachmentId for
+   * anoncreds and then find the corresponding attachment (if there is one)
+   * @param formats the formats object containing the attachmentId
+   * @param messageAttachments the attachments containing the payload
+   * @returns The Attachment if found or undefined
+   *
+   */
+  public getAttachment(formats: CredentialFormatSpec[], messageAttachments: Attachment[]): Attachment | undefined {
+    const supportedAttachmentIds = formats.filter((f) => this.supportsFormat(f.format)).map((f) => f.attachmentId)
+    const supportedAttachment = messageAttachments.find((attachment) => supportedAttachmentIds.includes(attachment.id))
+
+    return supportedAttachment
+  }
+
+  public async deleteCredentialById(agentContext: AgentContext, credentialRecordId: string): Promise<void> {
+    const anonCredsHolderService =
+      agentContext.dependencyManager.resolve<AnonCredsHolderService>(AnonCredsHolderServiceSymbol)
+
+    await anonCredsHolderService.deleteCredential(agentContext, credentialRecordId)
+  }
+
+  public async shouldAutoRespondToProposal(
+    agentContext: AgentContext,
+    { offerAttachment, proposalAttachment }: CredentialFormatAutoRespondProposalOptions
+  ) {
+    const proposalJson = proposalAttachment.getDataAsJson<AnonCredsCredentialProposalFormat>()
+    const offerJson = offerAttachment.getDataAsJson<AnonCredsCredentialOffer>()
+
+    // We want to make sure the credential definition matches.
+    // TODO: If no credential definition is present on the proposal, we could check whether the other fields
+    // of the proposal match with the credential definition id.
+    return proposalJson.cred_def_id === offerJson.cred_def_id
+  }
+
+  public async shouldAutoRespondToOffer(
+    agentContext: AgentContext,
+    { offerAttachment, proposalAttachment }: CredentialFormatAutoRespondOfferOptions
+  ) {
+    const proposalJson = proposalAttachment.getDataAsJson<AnonCredsCredentialProposalFormat>()
+    const offerJson = offerAttachment.getDataAsJson<AnonCredsCredentialOffer>()
+
+    // We want to make sure the credential definition matches.
+    // TODO: If no credential definition is present on the proposal, we could check whether the other fields
+    // of the proposal match with the credential definition id.
+    return proposalJson.cred_def_id === offerJson.cred_def_id
+  }
+
+  public async shouldAutoRespondToRequest(
+    agentContext: AgentContext,
+    { offerAttachment, requestAttachment }: CredentialFormatAutoRespondRequestOptions
+  ) {
+    const credentialOfferJson = offerAttachment.getDataAsJson<AnonCredsCredentialOffer>()
+    const credentialRequestJson = requestAttachment.getDataAsJson<AnonCredsCredentialRequest>()
+
+    return credentialOfferJson.cred_def_id === credentialRequestJson.cred_def_id
+  }
+
+  public async shouldAutoRespondToCredential(
+    agentContext: AgentContext,
+    { credentialRecord, requestAttachment, credentialAttachment }: CredentialFormatAutoRespondCredentialOptions
+  ) {
+    const credentialJson = credentialAttachment.getDataAsJson<AnonCredsCredential>()
+    const credentialRequestJson = requestAttachment.getDataAsJson<AnonCredsCredentialRequest>()
+
+    // make sure the credential definition matches
+    if (credentialJson.cred_def_id !== credentialRequestJson.cred_def_id) return false
+
+    // If we don't have any attributes stored we can't compare so always return false.
+    if (!credentialRecord.credentialAttributes) return false
+    const attributeValues = convertAttributesToCredentialValues(credentialRecord.credentialAttributes)
+
+    // check whether the values match the values in the record
+    return checkCredentialValuesMatch(attributeValues, credentialJson.values)
+  }
+
+  private async createAnonCredsOffer(
+    agentContext: AgentContext,
+    {
+      credentialRecord,
+      attachmentId,
+      credentialDefinitionId,
+      attributes,
+      linkedAttachments,
+    }: {
+      credentialDefinitionId: string
+      credentialRecord: CredentialExchangeRecord
+      attachmentId?: string
+      attributes: CredentialPreviewAttributeOptions[]
+      linkedAttachments?: LinkedAttachment[]
+    }
+  ): Promise<CredentialFormatCreateOfferReturn> {
+    const anonCredsIssuerService =
+      agentContext.dependencyManager.resolve<AnonCredsIssuerService>(AnonCredsIssuerServiceSymbol)
+
+    // if the proposal has an attachment Id use that, otherwise the generated id of the formats object
+    const format = new CredentialFormatSpec({
+      attachmentId: attachmentId,
+      format: ANONCREDS_CREDENTIAL,
+    })
+
+    const offer = await anonCredsIssuerService.createCredentialOffer(agentContext, {
+      credentialDefinitionId,
+    })
+
+    const { previewAttributes } = this.getCredentialLinkedAttachments(attributes, linkedAttachments)
+    if (!previewAttributes) {
+      throw new AriesFrameworkError('Missing required preview attributes for anoncreds offer')
+    }
+
+    await this.assertPreviewAttributesMatchSchemaAttributes(agentContext, offer, previewAttributes)
+
+    credentialRecord.metadata.set<AnonCredsCredentialMetadata>(AnonCredsCredentialMetadataKey, {
+      schemaId: offer.schema_id,
+      credentialDefinitionId: offer.cred_def_id,
+    })
+
+    const attachment = this.getFormatData(offer, format.attachmentId)
+
+    return { format, attachment, previewAttributes }
+  }
+
+  private async assertPreviewAttributesMatchSchemaAttributes(
+    agentContext: AgentContext,
+    offer: AnonCredsCredentialOffer,
+    attributes: CredentialPreviewAttributeOptions[]
+  ): Promise<void> {
+    const registryService = agentContext.dependencyManager.resolve(AnonCredsRegistryService)
+    const registry = registryService.getRegistryForIdentifier(agentContext, offer.schema_id)
+
+    const schemaResult = await registry.getSchema(agentContext, offer.schema_id)
+
+    if (!schemaResult.schema) {
+      throw new AriesFrameworkError(
+        `Unable to resolve schema ${offer.schema_id} from registry: ${schemaResult.resolutionMetadata.error} ${schemaResult.resolutionMetadata.message}`
+      )
+    }
+
+    assertAttributesMatch(schemaResult.schema, attributes)
+  }
+
+  /**
+   * Get linked attachments for anoncreds format from a proposal message. This allows attachments
+   * to be copied across to old style credential records
+   *
+   * @param options ProposeCredentialOptions object containing (optionally) the linked attachments
+   * @return array of linked attachments or undefined if none present
+   */
+  private getCredentialLinkedAttachments(
+    attributes?: CredentialPreviewAttributeOptions[],
+    linkedAttachments?: LinkedAttachment[]
+  ): {
+    attachments?: Attachment[]
+    previewAttributes?: CredentialPreviewAttributeOptions[]
+  } {
+    if (!linkedAttachments && !attributes) {
+      return {}
+    }
+
+    let previewAttributes = attributes ?? []
+    let attachments: Attachment[] | undefined
+
+    if (linkedAttachments) {
+      // there are linked attachments so transform into the attribute field of the CredentialPreview object for
+      // this proposal
+      previewAttributes = createAndLinkAttachmentsToPreview(linkedAttachments, previewAttributes)
+      attachments = linkedAttachments.map((linkedAttachment) => linkedAttachment.attachment)
+    }
+
+    return { attachments, previewAttributes }
+  }
+
+  /**
+   * Returns an object of type {@link Attachment} for use in credential exchange messages.
+   * It looks up the correct format identifier and encodes the data as a base64 attachment.
+   *
+   * @param data The data to include in the attach object
+   * @param id the attach id from the formats component of the message
+   */
+  public getFormatData(data: unknown, id: string): Attachment {
+    const attachment = new Attachment({
+      id,
+      mimeType: 'application/json',
+      data: {
+        base64: JsonEncoder.toBase64(data),
+      },
+    })
+
+    return attachment
+  }
+}

--- a/packages/anoncreds/src/formats/AnonCredsProofFormatService.ts
+++ b/packages/anoncreds/src/formats/AnonCredsProofFormatService.ts
@@ -1,0 +1,796 @@
+import type {
+  AnonCredsProofFormat,
+  AnonCredsCredentialsForProofRequest,
+  AnonCredsGetCredentialsForProofRequestOptions,
+} from './AnonCredsProofFormat'
+import type {
+  AnonCredsCredentialDefinition,
+  AnonCredsCredentialInfo,
+  AnonCredsProof,
+  AnonCredsRequestedAttribute,
+  AnonCredsRequestedAttributeMatch,
+  AnonCredsRequestedPredicate,
+  AnonCredsRequestedPredicateMatch,
+  AnonCredsSchema,
+  AnonCredsSelectedCredentials,
+  AnonCredsProofRequest,
+} from '../models'
+import type {
+  AnonCredsHolderService,
+  AnonCredsVerifierService,
+  CreateProofOptions,
+  GetCredentialsForProofRequestReturn,
+  VerifyProofOptions,
+} from '../services'
+import type {
+  ProofFormatService,
+  AgentContext,
+  ProofFormatCreateReturn,
+  FormatCreateRequestOptions,
+  ProofFormatCreateProposalOptions,
+  ProofFormatProcessOptions,
+  ProofFormatAcceptProposalOptions,
+  ProofFormatAcceptRequestOptions,
+  ProofFormatProcessPresentationOptions,
+  ProofFormatGetCredentialsForRequestOptions,
+  ProofFormatGetCredentialsForRequestReturn,
+  ProofFormatSelectCredentialsForRequestOptions,
+  ProofFormatSelectCredentialsForRequestReturn,
+  ProofFormatAutoRespondProposalOptions,
+  ProofFormatAutoRespondRequestOptions,
+  ProofFormatAutoRespondPresentationOptions,
+} from '@aries-framework/core'
+
+import {
+  AriesFrameworkError,
+  Attachment,
+  AttachmentData,
+  JsonEncoder,
+  ProofFormatSpec,
+  JsonTransformer,
+} from '@aries-framework/core'
+
+import { AnonCredsProofRequest as AnonCredsProofRequestClass } from '../models/AnonCredsProofRequest'
+import { AnonCredsVerifierServiceSymbol, AnonCredsHolderServiceSymbol } from '../services'
+import { AnonCredsRegistryService } from '../services/registry/AnonCredsRegistryService'
+import {
+  sortRequestedCredentialsMatches,
+  createRequestFromPreview,
+  areAnonCredsProofRequestsEqual,
+  assertRevocationInterval,
+  downloadTailsFile,
+  checkValidCredentialValueEncoding,
+  encodeCredentialValue,
+  assertNoDuplicateGroupsNamesInProofRequest,
+} from '../utils'
+
+const ANONCREDS_PRESENTATION_PROPOSAL = 'anoncreds/proof-request@v1.0'
+const ANONCREDS_PRESENTATION_REQUEST = 'anoncreds/proof-request@v1.0'
+const ANONCREDS_PRESENTATION = 'anoncreds/proof@v1.0'
+
+export class AnonCredsProofFormatService implements ProofFormatService<AnonCredsProofFormat> {
+  public readonly formatKey = 'anoncreds' as const
+
+  public async createProposal(
+    agentContext: AgentContext,
+    { attachmentId, proofFormats }: ProofFormatCreateProposalOptions<AnonCredsProofFormat>
+  ): Promise<ProofFormatCreateReturn> {
+    const format = new ProofFormatSpec({
+      format: ANONCREDS_PRESENTATION_PROPOSAL,
+      attachmentId,
+    })
+
+    const anoncredsFormat = proofFormats.anoncreds
+    if (!anoncredsFormat) {
+      throw Error('Missing anoncreds format to create proposal attachment format')
+    }
+
+    const proofRequest = createRequestFromPreview({
+      attributes: anoncredsFormat.attributes ?? [],
+      predicates: anoncredsFormat.predicates ?? [],
+      name: anoncredsFormat.name ?? 'Proof request',
+      version: anoncredsFormat.version ?? '1.0',
+      nonce: await agentContext.wallet.generateNonce(),
+    })
+    const attachment = this.getFormatData(proofRequest, format.attachmentId)
+
+    return { attachment, format }
+  }
+
+  public async processProposal(agentContext: AgentContext, { attachment }: ProofFormatProcessOptions): Promise<void> {
+    const proposalJson = attachment.getDataAsJson<AnonCredsProofRequest>()
+
+    // fromJson also validates
+    JsonTransformer.fromJSON(proposalJson, AnonCredsProofRequestClass)
+
+    // Assert attribute and predicate (group) names do not match
+    assertNoDuplicateGroupsNamesInProofRequest(proposalJson)
+  }
+
+  public async acceptProposal(
+    agentContext: AgentContext,
+    { proposalAttachment, attachmentId }: ProofFormatAcceptProposalOptions<AnonCredsProofFormat>
+  ): Promise<ProofFormatCreateReturn> {
+    const format = new ProofFormatSpec({
+      format: ANONCREDS_PRESENTATION_REQUEST,
+      attachmentId,
+    })
+
+    const proposalJson = proposalAttachment.getDataAsJson<AnonCredsProofRequest>()
+
+    const request = {
+      ...proposalJson,
+      // We never want to reuse the nonce from the proposal, as this will allow replay attacks
+      nonce: await agentContext.wallet.generateNonce(),
+    }
+
+    const attachment = this.getFormatData(request, format.attachmentId)
+
+    return { attachment, format }
+  }
+
+  public async createRequest(
+    agentContext: AgentContext,
+    { attachmentId, proofFormats }: FormatCreateRequestOptions<AnonCredsProofFormat>
+  ): Promise<ProofFormatCreateReturn> {
+    const format = new ProofFormatSpec({
+      format: ANONCREDS_PRESENTATION_REQUEST,
+      attachmentId,
+    })
+
+    const anoncredsFormat = proofFormats.anoncreds
+    if (!anoncredsFormat) {
+      throw Error('Missing anoncreds format in create request attachment format')
+    }
+
+    const request = {
+      name: anoncredsFormat.name,
+      version: anoncredsFormat.version,
+      nonce: await agentContext.wallet.generateNonce(),
+      requested_attributes: anoncredsFormat.requested_attributes ?? {},
+      requested_predicates: anoncredsFormat.requested_predicates ?? {},
+      non_revoked: anoncredsFormat.non_revoked,
+    } satisfies AnonCredsProofRequest
+
+    // Assert attribute and predicate (group) names do not match
+    assertNoDuplicateGroupsNamesInProofRequest(request)
+
+    const attachment = this.getFormatData(request, format.attachmentId)
+
+    return { attachment, format }
+  }
+
+  public async processRequest(agentContext: AgentContext, { attachment }: ProofFormatProcessOptions): Promise<void> {
+    const requestJson = attachment.getDataAsJson<AnonCredsProofRequest>()
+
+    // fromJson also validates
+    JsonTransformer.fromJSON(requestJson, AnonCredsProofRequestClass)
+
+    // Assert attribute and predicate (group) names do not match
+    assertNoDuplicateGroupsNamesInProofRequest(requestJson)
+  }
+
+  public async acceptRequest(
+    agentContext: AgentContext,
+    { proofFormats, requestAttachment, attachmentId }: ProofFormatAcceptRequestOptions<AnonCredsProofFormat>
+  ): Promise<ProofFormatCreateReturn> {
+    const format = new ProofFormatSpec({
+      format: ANONCREDS_PRESENTATION,
+      attachmentId,
+    })
+    const requestJson = requestAttachment.getDataAsJson<AnonCredsProofRequest>()
+
+    const anoncredsFormat = proofFormats?.anoncreds
+
+    const selectedCredentials =
+      anoncredsFormat ??
+      (await this._selectCredentialsForRequest(agentContext, requestJson, {
+        filterByNonRevocationRequirements: true,
+      }))
+
+    const proof = await this.createProof(agentContext, requestJson, selectedCredentials)
+    const attachment = this.getFormatData(proof, format.attachmentId)
+
+    return {
+      attachment,
+      format,
+    }
+  }
+
+  public async processPresentation(
+    agentContext: AgentContext,
+    { requestAttachment, attachment }: ProofFormatProcessPresentationOptions
+  ): Promise<boolean> {
+    const verifierService =
+      agentContext.dependencyManager.resolve<AnonCredsVerifierService>(AnonCredsVerifierServiceSymbol)
+
+    const proofRequestJson = requestAttachment.getDataAsJson<AnonCredsProofRequest>()
+
+    // NOTE: we don't do validation here, as this is handled by the AnonCreds implementation, however
+    // this can lead to confusing error messages. We should consider doing validation here as well.
+    // Defining a class-transformer/class-validator class seems a bit overkill, and the usage of interfaces
+    // for the anoncreds package keeps things simple. Maybe we can try to use something like zod to validate
+    const proofJson = attachment.getDataAsJson<AnonCredsProof>()
+
+    for (const [referent, attribute] of Object.entries(proofJson.requested_proof.revealed_attrs)) {
+      if (!checkValidCredentialValueEncoding(attribute.raw, attribute.encoded)) {
+        throw new AriesFrameworkError(
+          `The encoded value for '${referent}' is invalid. ` +
+            `Expected '${encodeCredentialValue(attribute.raw)}'. ` +
+            `Actual '${attribute.encoded}'`
+        )
+      }
+    }
+
+    for (const [, attributeGroup] of Object.entries(proofJson.requested_proof.revealed_attr_groups ?? {})) {
+      for (const [attributeName, attribute] of Object.entries(attributeGroup.values)) {
+        if (!checkValidCredentialValueEncoding(attribute.raw, attribute.encoded)) {
+          throw new AriesFrameworkError(
+            `The encoded value for '${attributeName}' is invalid. ` +
+              `Expected '${encodeCredentialValue(attribute.raw)}'. ` +
+              `Actual '${attribute.encoded}'`
+          )
+        }
+      }
+    }
+
+    const schemas = await this.getSchemas(agentContext, new Set(proofJson.identifiers.map((i) => i.schema_id)))
+    const credentialDefinitions = await this.getCredentialDefinitions(
+      agentContext,
+      new Set(proofJson.identifiers.map((i) => i.cred_def_id))
+    )
+
+    const revocationRegistries = await this.getRevocationRegistriesForProof(agentContext, proofJson)
+
+    return await verifierService.verifyProof(agentContext, {
+      proofRequest: proofRequestJson,
+      proof: proofJson,
+      schemas,
+      credentialDefinitions,
+      revocationRegistries,
+    })
+  }
+
+  public async getCredentialsForRequest(
+    agentContext: AgentContext,
+    { requestAttachment, proofFormats }: ProofFormatGetCredentialsForRequestOptions<AnonCredsProofFormat>
+  ): Promise<ProofFormatGetCredentialsForRequestReturn<AnonCredsProofFormat>> {
+    const proofRequestJson = requestAttachment.getDataAsJson<AnonCredsProofRequest>()
+
+    // Set default values
+    const { filterByNonRevocationRequirements = true } = proofFormats?.anoncreds ?? {}
+
+    const credentialsForRequest = await this._getCredentialsForRequest(agentContext, proofRequestJson, {
+      filterByNonRevocationRequirements,
+    })
+
+    return credentialsForRequest
+  }
+
+  public async selectCredentialsForRequest(
+    agentContext: AgentContext,
+    { requestAttachment, proofFormats }: ProofFormatSelectCredentialsForRequestOptions<AnonCredsProofFormat>
+  ): Promise<ProofFormatSelectCredentialsForRequestReturn<AnonCredsProofFormat>> {
+    const proofRequestJson = requestAttachment.getDataAsJson<AnonCredsProofRequest>()
+
+    // Set default values
+    const { filterByNonRevocationRequirements = true } = proofFormats?.anoncreds ?? {}
+
+    const selectedCredentials = this._selectCredentialsForRequest(agentContext, proofRequestJson, {
+      filterByNonRevocationRequirements,
+    })
+
+    return selectedCredentials
+  }
+
+  public async shouldAutoRespondToProposal(
+    agentContext: AgentContext,
+    { proposalAttachment, requestAttachment }: ProofFormatAutoRespondProposalOptions
+  ): Promise<boolean> {
+    const proposalJson = proposalAttachment.getDataAsJson<AnonCredsProofRequest>()
+    const requestJson = requestAttachment.getDataAsJson<AnonCredsProofRequest>()
+
+    const areRequestsEqual = areAnonCredsProofRequestsEqual(proposalJson, requestJson)
+    agentContext.config.logger.debug(`AnonCreds request and proposal are are equal: ${areRequestsEqual}`, {
+      proposalJson,
+      requestJson,
+    })
+
+    return areRequestsEqual
+  }
+
+  public async shouldAutoRespondToRequest(
+    agentContext: AgentContext,
+    { proposalAttachment, requestAttachment }: ProofFormatAutoRespondRequestOptions
+  ): Promise<boolean> {
+    const proposalJson = proposalAttachment.getDataAsJson<AnonCredsProofRequest>()
+    const requestJson = requestAttachment.getDataAsJson<AnonCredsProofRequest>()
+
+    return areAnonCredsProofRequestsEqual(proposalJson, requestJson)
+  }
+
+  public async shouldAutoRespondToPresentation(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _agentContext: AgentContext,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _options: ProofFormatAutoRespondPresentationOptions
+  ): Promise<boolean> {
+    // The presentation is already verified in processPresentation, so we can just return true here.
+    // It's only an ack, so it's just that we received the presentation.
+    return true
+  }
+
+  public supportsFormat(formatIdentifier: string): boolean {
+    const supportedFormats = [ANONCREDS_PRESENTATION_PROPOSAL, ANONCREDS_PRESENTATION_REQUEST, ANONCREDS_PRESENTATION]
+    return supportedFormats.includes(formatIdentifier)
+  }
+
+  private async _getCredentialsForRequest(
+    agentContext: AgentContext,
+    proofRequest: AnonCredsProofRequest,
+    options: AnonCredsGetCredentialsForProofRequestOptions
+  ): Promise<AnonCredsCredentialsForProofRequest> {
+    const credentialsForProofRequest: AnonCredsCredentialsForProofRequest = {
+      attributes: {},
+      predicates: {},
+    }
+
+    for (const [referent, requestedAttribute] of Object.entries(proofRequest.requested_attributes)) {
+      const credentials = await this.getCredentialsForProofRequestReferent(agentContext, proofRequest, referent)
+
+      credentialsForProofRequest.attributes[referent] = sortRequestedCredentialsMatches(
+        await Promise.all(
+          credentials.map(async (credential) => {
+            const { isRevoked, timestamp } = await this.getRevocationStatus(
+              agentContext,
+              proofRequest,
+              requestedAttribute,
+              credential.credentialInfo
+            )
+
+            return {
+              credentialId: credential.credentialInfo.credentialId,
+              revealed: true,
+              credentialInfo: credential.credentialInfo,
+              timestamp,
+              revoked: isRevoked,
+            } satisfies AnonCredsRequestedAttributeMatch
+          })
+        )
+      )
+
+      // We only attach revoked state if non-revocation is requested. So if revoked is true it means
+      // the credential is not applicable to the proof request
+      if (options.filterByNonRevocationRequirements) {
+        credentialsForProofRequest.attributes[referent] = credentialsForProofRequest.attributes[referent].filter(
+          (r) => !r.revoked
+        )
+      }
+    }
+
+    for (const [referent, requestedPredicate] of Object.entries(proofRequest.requested_predicates)) {
+      const credentials = await this.getCredentialsForProofRequestReferent(agentContext, proofRequest, referent)
+
+      credentialsForProofRequest.predicates[referent] = sortRequestedCredentialsMatches(
+        await Promise.all(
+          credentials.map(async (credential) => {
+            const { isRevoked, timestamp } = await this.getRevocationStatus(
+              agentContext,
+              proofRequest,
+              requestedPredicate,
+              credential.credentialInfo
+            )
+
+            return {
+              credentialId: credential.credentialInfo.credentialId,
+              credentialInfo: credential.credentialInfo,
+              timestamp,
+              revoked: isRevoked,
+            } satisfies AnonCredsRequestedPredicateMatch
+          })
+        )
+      )
+
+      // We only attach revoked state if non-revocation is requested. So if revoked is true it means
+      // the credential is not applicable to the proof request
+      if (options.filterByNonRevocationRequirements) {
+        credentialsForProofRequest.predicates[referent] = credentialsForProofRequest.predicates[referent].filter(
+          (r) => !r.revoked
+        )
+      }
+    }
+
+    return credentialsForProofRequest
+  }
+
+  private async _selectCredentialsForRequest(
+    agentContext: AgentContext,
+    proofRequest: AnonCredsProofRequest,
+    options: AnonCredsGetCredentialsForProofRequestOptions
+  ): Promise<AnonCredsSelectedCredentials> {
+    const credentialsForRequest = await this._getCredentialsForRequest(agentContext, proofRequest, options)
+
+    const selectedCredentials: AnonCredsSelectedCredentials = {
+      attributes: {},
+      predicates: {},
+      selfAttestedAttributes: {},
+    }
+
+    Object.keys(credentialsForRequest.attributes).forEach((attributeName) => {
+      const attributeArray = credentialsForRequest.attributes[attributeName]
+
+      if (attributeArray.length === 0) {
+        throw new AriesFrameworkError('Unable to automatically select requested attributes.')
+      }
+
+      selectedCredentials.attributes[attributeName] = attributeArray[0]
+    })
+
+    Object.keys(credentialsForRequest.predicates).forEach((attributeName) => {
+      if (credentialsForRequest.predicates[attributeName].length === 0) {
+        throw new AriesFrameworkError('Unable to automatically select requested predicates.')
+      } else {
+        selectedCredentials.predicates[attributeName] = credentialsForRequest.predicates[attributeName][0]
+      }
+    })
+
+    return selectedCredentials
+  }
+
+  private async getCredentialsForProofRequestReferent(
+    agentContext: AgentContext,
+    proofRequest: AnonCredsProofRequest,
+    attributeReferent: string
+  ): Promise<GetCredentialsForProofRequestReturn> {
+    const holderService = agentContext.dependencyManager.resolve<AnonCredsHolderService>(AnonCredsHolderServiceSymbol)
+
+    const credentials = await holderService.getCredentialsForProofRequest(agentContext, {
+      proofRequest,
+      attributeReferent,
+    })
+
+    return credentials
+  }
+
+  /**
+   * Build schemas object needed to create and verify proof objects.
+   *
+   * Creates object with `{ schemaId: AnonCredsSchema }` mapping
+   *
+   * @param schemaIds List of schema ids
+   * @returns Object containing schemas for specified schema ids
+   *
+   */
+  private async getSchemas(agentContext: AgentContext, schemaIds: Set<string>) {
+    const registryService = agentContext.dependencyManager.resolve(AnonCredsRegistryService)
+
+    const schemas: { [key: string]: AnonCredsSchema } = {}
+
+    for (const schemaId of schemaIds) {
+      const schemaRegistry = registryService.getRegistryForIdentifier(agentContext, schemaId)
+      const schemaResult = await schemaRegistry.getSchema(agentContext, schemaId)
+
+      if (!schemaResult.schema) {
+        throw new AriesFrameworkError(`Schema not found for id ${schemaId}: ${schemaResult.resolutionMetadata.message}`)
+      }
+
+      schemas[schemaId] = schemaResult.schema
+    }
+
+    return schemas
+  }
+
+  /**
+   * Build credential definitions object needed to create and verify proof objects.
+   *
+   * Creates object with `{ credentialDefinitionId: AnonCredsCredentialDefinition }` mapping
+   *
+   * @param credentialDefinitionIds List of credential definition ids
+   * @returns Object containing credential definitions for specified credential definition ids
+   *
+   */
+  private async getCredentialDefinitions(agentContext: AgentContext, credentialDefinitionIds: Set<string>) {
+    const registryService = agentContext.dependencyManager.resolve(AnonCredsRegistryService)
+
+    const credentialDefinitions: { [key: string]: AnonCredsCredentialDefinition } = {}
+
+    for (const credentialDefinitionId of credentialDefinitionIds) {
+      const credentialDefinitionRegistry = registryService.getRegistryForIdentifier(
+        agentContext,
+        credentialDefinitionId
+      )
+
+      const credentialDefinitionResult = await credentialDefinitionRegistry.getCredentialDefinition(
+        agentContext,
+        credentialDefinitionId
+      )
+
+      if (!credentialDefinitionResult.credentialDefinition) {
+        throw new AriesFrameworkError(
+          `Credential definition not found for id ${credentialDefinitionId}: ${credentialDefinitionResult.resolutionMetadata.message}`
+        )
+      }
+
+      credentialDefinitions[credentialDefinitionId] = credentialDefinitionResult.credentialDefinition
+    }
+
+    return credentialDefinitions
+  }
+
+  private async getRevocationStatus(
+    agentContext: AgentContext,
+    proofRequest: AnonCredsProofRequest,
+    requestedItem: AnonCredsRequestedAttribute | AnonCredsRequestedPredicate,
+    credentialInfo: AnonCredsCredentialInfo
+  ) {
+    const requestNonRevoked = requestedItem.non_revoked ?? proofRequest.non_revoked
+    const credentialRevocationId = credentialInfo.credentialRevocationId
+    const revocationRegistryId = credentialInfo.revocationRegistryId
+
+    // If revocation interval is not present or the credential is not revocable then we
+    // don't need to fetch the revocation status
+    if (!requestNonRevoked || !credentialRevocationId || !revocationRegistryId) {
+      return { isRevoked: undefined, timestamp: undefined }
+    }
+
+    agentContext.config.logger.trace(
+      `Fetching credential revocation status for credential revocation id '${credentialRevocationId}' with revocation interval with from '${requestNonRevoked.from}' and to '${requestNonRevoked.to}'`
+    )
+
+    // Make sure the revocation interval follows best practices from Aries RFC 0441
+    assertRevocationInterval(requestNonRevoked)
+
+    const registryService = agentContext.dependencyManager.resolve(AnonCredsRegistryService)
+    const registry = registryService.getRegistryForIdentifier(agentContext, revocationRegistryId)
+
+    const revocationStatusResult = await registry.getRevocationStatusList(
+      agentContext,
+      revocationRegistryId,
+      requestNonRevoked.to ?? Date.now()
+    )
+
+    if (!revocationStatusResult.revocationStatusList) {
+      throw new AriesFrameworkError(
+        `Could not retrieve revocation status list for revocation registry ${revocationRegistryId}: ${revocationStatusResult.resolutionMetadata.message}`
+      )
+    }
+
+    // Item is revoked when the value at the index is 1
+    const isRevoked = revocationStatusResult.revocationStatusList.revocationList[parseInt(credentialRevocationId)] === 1
+
+    agentContext.config.logger.trace(
+      `Credential with credential revocation index '${credentialRevocationId}' is ${
+        isRevoked ? '' : 'not '
+      }revoked with revocation interval with to '${requestNonRevoked.to}' & from '${requestNonRevoked.from}'`
+    )
+
+    return {
+      isRevoked,
+      timestamp: revocationStatusResult.revocationStatusList.timestamp,
+    }
+  }
+
+  /**
+   * Create anoncreds proof from a given proof request and requested credential object.
+   *
+   * @param proofRequest The proof request to create the proof for
+   * @param requestedCredentials The requested credentials object specifying which credentials to use for the proof
+   * @returns anoncreds proof object
+   */
+  private async createProof(
+    agentContext: AgentContext,
+    proofRequest: AnonCredsProofRequest,
+    selectedCredentials: AnonCredsSelectedCredentials
+  ): Promise<AnonCredsProof> {
+    const holderService = agentContext.dependencyManager.resolve<AnonCredsHolderService>(AnonCredsHolderServiceSymbol)
+
+    const credentialObjects = await Promise.all(
+      [...Object.values(selectedCredentials.attributes), ...Object.values(selectedCredentials.predicates)].map(
+        async (c) => c.credentialInfo ?? holderService.getCredential(agentContext, { credentialId: c.credentialId })
+      )
+    )
+
+    const schemas = await this.getSchemas(agentContext, new Set(credentialObjects.map((c) => c.schemaId)))
+    const credentialDefinitions = await this.getCredentialDefinitions(
+      agentContext,
+      new Set(credentialObjects.map((c) => c.credentialDefinitionId))
+    )
+
+    const revocationRegistries = await this.getRevocationRegistriesForRequest(
+      agentContext,
+      proofRequest,
+      selectedCredentials
+    )
+
+    return await holderService.createProof(agentContext, {
+      proofRequest,
+      selectedCredentials,
+      schemas,
+      credentialDefinitions,
+      revocationRegistries,
+    })
+  }
+
+  private async getRevocationRegistriesForRequest(
+    agentContext: AgentContext,
+    proofRequest: AnonCredsProofRequest,
+    selectedCredentials: AnonCredsSelectedCredentials
+  ) {
+    const revocationRegistries: CreateProofOptions['revocationRegistries'] = {}
+
+    try {
+      agentContext.config.logger.debug(`Retrieving revocation registries for proof request`, {
+        proofRequest,
+        selectedCredentials,
+      })
+
+      const referentCredentials = []
+
+      // Retrieve information for referents and push to single array
+      for (const [referent, selectedCredential] of Object.entries(selectedCredentials.attributes)) {
+        referentCredentials.push({
+          referent,
+          credentialInfo: selectedCredential.credentialInfo,
+          nonRevoked: proofRequest.requested_attributes[referent].non_revoked ?? proofRequest.non_revoked,
+        })
+      }
+      for (const [referent, selectedCredential] of Object.entries(selectedCredentials.predicates)) {
+        referentCredentials.push({
+          referent,
+          credentialInfo: selectedCredential.credentialInfo,
+          nonRevoked: proofRequest.requested_predicates[referent].non_revoked ?? proofRequest.non_revoked,
+        })
+      }
+
+      for (const { referent, credentialInfo, nonRevoked } of referentCredentials) {
+        if (!credentialInfo) {
+          throw new AriesFrameworkError(
+            `Credential for referent '${referent} does not have credential info for revocation state creation`
+          )
+        }
+
+        // Prefer referent-specific revocation interval over global revocation interval
+        const credentialRevocationId = credentialInfo.credentialRevocationId
+        const revocationRegistryId = credentialInfo.revocationRegistryId
+
+        // If revocation interval is present and the credential is revocable then create revocation state
+        if (nonRevoked && credentialRevocationId && revocationRegistryId) {
+          agentContext.config.logger.trace(
+            `Presentation is requesting proof of non revocation for referent '${referent}', creating revocation state for credential`,
+            {
+              nonRevoked,
+              credentialRevocationId,
+              revocationRegistryId,
+            }
+          )
+
+          // Make sure the revocation interval follows best practices from Aries RFC 0441
+          assertRevocationInterval(nonRevoked)
+
+          const registry = agentContext.dependencyManager
+            .resolve(AnonCredsRegistryService)
+            .getRegistryForIdentifier(agentContext, revocationRegistryId)
+
+          // Fetch revocation registry definition if not in revocation registries list yet
+          if (!revocationRegistries[revocationRegistryId]) {
+            const { revocationRegistryDefinition, resolutionMetadata } = await registry.getRevocationRegistryDefinition(
+              agentContext,
+              revocationRegistryId
+            )
+            if (!revocationRegistryDefinition) {
+              throw new AriesFrameworkError(
+                `Could not retrieve revocation registry definition for revocation registry ${revocationRegistryId}: ${resolutionMetadata.message}`
+              )
+            }
+
+            const { tailsLocation, tailsHash } = revocationRegistryDefinition.value
+            const { tailsFilePath } = await downloadTailsFile(agentContext, tailsLocation, tailsHash)
+
+            revocationRegistries[revocationRegistryId] = {
+              definition: revocationRegistryDefinition,
+              tailsFilePath,
+              revocationStatusLists: {},
+            }
+          }
+
+          // TODO: can we check if the revocation status list is already fetched? We don't know which timestamp the query will return. This
+          // should probably be solved using caching
+          // Fetch the revocation status list
+          const { revocationStatusList, resolutionMetadata: statusListResolutionMetadata } =
+            await registry.getRevocationStatusList(agentContext, revocationRegistryId, nonRevoked.to ?? Date.now())
+          if (!revocationStatusList) {
+            throw new AriesFrameworkError(
+              `Could not retrieve revocation status list for revocation registry ${revocationRegistryId}: ${statusListResolutionMetadata.message}`
+            )
+          }
+
+          revocationRegistries[revocationRegistryId].revocationStatusLists[revocationStatusList.timestamp] =
+            revocationStatusList
+        }
+      }
+
+      agentContext.config.logger.debug(`Retrieved revocation registries for proof request`, {
+        revocationRegistries,
+      })
+
+      return revocationRegistries
+    } catch (error) {
+      agentContext.config.logger.error(`Error retrieving revocation registry for proof request`, {
+        error,
+        proofRequest,
+        selectedCredentials,
+      })
+
+      throw error
+    }
+  }
+
+  private async getRevocationRegistriesForProof(agentContext: AgentContext, proof: AnonCredsProof) {
+    const revocationRegistries: VerifyProofOptions['revocationRegistries'] = {}
+
+    for (const identifier of proof.identifiers) {
+      const revocationRegistryId = identifier.rev_reg_id
+      const timestamp = identifier.timestamp
+
+      // Skip if no revocation registry id is present
+      if (!revocationRegistryId || !timestamp) continue
+
+      const registry = agentContext.dependencyManager
+        .resolve(AnonCredsRegistryService)
+        .getRegistryForIdentifier(agentContext, revocationRegistryId)
+
+      // Fetch revocation registry definition if not already fetched
+      if (!revocationRegistries[revocationRegistryId]) {
+        const { revocationRegistryDefinition, resolutionMetadata } = await registry.getRevocationRegistryDefinition(
+          agentContext,
+          revocationRegistryId
+        )
+        if (!revocationRegistryDefinition) {
+          throw new AriesFrameworkError(
+            `Could not retrieve revocation registry definition for revocation registry ${revocationRegistryId}: ${resolutionMetadata.message}`
+          )
+        }
+
+        revocationRegistries[revocationRegistryId] = {
+          definition: revocationRegistryDefinition,
+          revocationStatusLists: {},
+        }
+      }
+
+      // Fetch revocation status list by timestamp if not already fetched
+      if (!revocationRegistries[revocationRegistryId].revocationStatusLists[timestamp]) {
+        const { revocationStatusList, resolutionMetadata: statusListResolutionMetadata } =
+          await registry.getRevocationStatusList(agentContext, revocationRegistryId, timestamp)
+
+        if (!revocationStatusList) {
+          throw new AriesFrameworkError(
+            `Could not retrieve revocation status list for revocation registry ${revocationRegistryId}: ${statusListResolutionMetadata.message}`
+          )
+        }
+
+        revocationRegistries[revocationRegistryId].revocationStatusLists[timestamp] = revocationStatusList
+      }
+    }
+
+    return revocationRegistries
+  }
+
+  /**
+   * Returns an object of type {@link Attachment} for use in credential exchange messages.
+   * It looks up the correct format identifier and encodes the data as a base64 attachment.
+   *
+   * @param data The data to include in the attach object
+   * @param id the attach id from the formats component of the message
+   */
+  private getFormatData(data: unknown, id: string): Attachment {
+    const attachment = new Attachment({
+      id,
+      mimeType: 'application/json',
+      data: new AttachmentData({
+        base64: JsonEncoder.toBase64(data),
+      }),
+    })
+
+    return attachment
+  }
+}

--- a/packages/anoncreds/src/formats/index.ts
+++ b/packages/anoncreds/src/formats/index.ts
@@ -1,7 +1,9 @@
 export * from './AnonCredsCredentialFormat'
 export * from './LegacyIndyCredentialFormat'
+export { AnonCredsCredentialFormatService } from './AnonCredsCredentialFormatService'
 export { LegacyIndyCredentialFormatService } from './LegacyIndyCredentialFormatService'
 
 export * from './AnonCredsProofFormat'
 export * from './LegacyIndyProofFormat'
+export { AnonCredsProofFormatService } from './AnonCredsProofFormatService'
 export { LegacyIndyProofFormatService } from './LegacyIndyProofFormatService'

--- a/packages/anoncreds/src/models/exchange.ts
+++ b/packages/anoncreds/src/models/exchange.ts
@@ -34,6 +34,7 @@ export interface AnonCredsCredentialOffer {
 export interface AnonCredsCredentialRequest {
   // prover_did is deprecated, however it is kept for backwards compatibility with legacy anoncreds implementations
   prover_did?: string
+  entropy?: string
   cred_def_id: string
   blinded_ms: Record<string, unknown>
   blinded_ms_correctness_proof: Record<string, unknown>


### PR DESCRIPTION
Add Credential and Proof format services according to [Aries RFC 0771](https://github.com/hyperledger/aries-rfcs/tree/main/features/0771-anoncreds-attachments).

Essentially the same as Legacy Indy counterparts but using the new identifiers, using entropy instead of prover_did for Credential Request and not restricting identifiers to legacy Indy format, so any AnonCreds method can be used with them.