### PR TITLE
refactor(cache)!: change default cache to in memory

### DIFF
--- a/packages/core/src/modules/cache/CacheModule.ts
+++ b/packages/core/src/modules/cache/CacheModule.ts
@@ -3,6 +3,7 @@ import type { DependencyManager, Module } from '../../plugins'
 import type { Optional } from '../../utils'
 
 import { CacheModuleConfig } from './CacheModuleConfig'
+import { InMemoryLruCache } from './InMemoryLruCache'
 import { SingleContextLruCacheRepository } from './singleContextLruCache/SingleContextLruCacheRepository'
 import { SingleContextStorageLruCache } from './singleContextLruCache/SingleContextStorageLruCache'
 
@@ -17,7 +18,7 @@ export class CacheModule implements Module {
       ...config,
       cache:
         config?.cache ??
-        new SingleContextStorageLruCache({
+        new InMemoryLruCache({
           limit: 500,
         }),
     })


### PR DESCRIPTION
Changes default cache implementation to an in memory cache. This simplifies the caching, and makes sure it works for all cases (nodejs/react-native, but also mulit-tenancy).

BREAKING CHANGE:
The default cache implementation has been changed from `SingleContextStorageLruCache` to `InMemoryLruCache`. In React Native environments it is still recommended to use the `SingleContextStorageLruCache` cache implementation, but due to it's dependence on the wallet storage, it is not recommend for server side or multi-tenancy deployments. A custom caching interface can be implemented in those cases.