### PR TITLE
fix: reference to indyLedgers in IndyXXXNotConfiguredError

### DIFF
--- a/packages/indy-sdk/src/ledger/IndySdkPoolService.ts
+++ b/packages/indy-sdk/src/ledger/IndySdkPoolService.ts
@@ -93,7 +93,7 @@ export class IndySdkPoolService {
 
     if (pools.length === 0) {
       throw new IndySdkPoolNotConfiguredError(
-        "No indy ledgers configured. Provide at least one pool configuration in the 'indyLedgers' agent configuration"
+        'No indy ledgers configured. Provide at least one pool configuration in IndySdkModuleConfigOptions.networks'
       )
     }
 
@@ -129,7 +129,7 @@ export class IndySdkPoolService {
 
     // If there are self certified DIDs we always prefer it over non self certified DIDs
     // We take the first self certifying DID as we take the order in the
-    // indyLedgers config as the order of preference of ledgers
+    // IndySdkModuleConfigOptions.networks config as the order of preference of ledgers
     let value = successful.find((response) =>
       isLegacySelfCertifiedDid(response.value.did.did, response.value.did.verkey)
     )?.value
@@ -142,8 +142,8 @@ export class IndySdkPoolService {
       const nonProduction = successful.filter((s) => !s.value.pool.config.isProduction)
       const productionOrNonProduction = production.length >= 1 ? production : nonProduction
 
-      // We take the first value as we take the order in the indyLedgers config as
-      // the order of preference of ledgers
+      // We take the first value as we take the order in the IndySdkModuleConfigOptions.networks 
+      // config as the order of preference of ledgers
       value = productionOrNonProduction[0].value
     }
 
@@ -176,7 +176,7 @@ export class IndySdkPoolService {
   public getPoolForNamespace(indyNamespace?: string) {
     if (this.pools.length === 0) {
       throw new IndySdkPoolNotConfiguredError(
-        "No indy ledgers configured. Provide at least one pool configuration in the 'indyLedgers' agent configuration"
+        'No indy ledgers configured. Provide at least one pool configuration in IndySdkModuleConfigOptions.networks'
       )
     }
 

--- a/packages/indy-vdr/src/pool/IndyVdrPoolService.ts
+++ b/packages/indy-vdr/src/pool/IndyVdrPoolService.ts
@@ -69,7 +69,7 @@ export class IndyVdrPoolService {
 
     if (pools.length === 0) {
       throw new IndyVdrNotConfiguredError(
-        "No indy ledgers configured. Provide at least one pool configuration in the 'indyLedgers' agent configuration"
+        'No indy ledgers configured. Provide at least one pool configuration in IndyVdrModuleConfigOptions.networks'
       )
     }
 
@@ -105,7 +105,7 @@ export class IndyVdrPoolService {
 
     // If there are self certified DIDs we always prefer it over non self certified DIDs
     // We take the first self certifying DID as we take the order in the
-    // indyLedgers config as the order of preference of ledgers
+    // IndyVdrModuleConfigOptions.networks config as the order of preference of ledgers
     let value = successful.find((response) =>
       isSelfCertifiedDid(response.value.did.nymResponse.did, response.value.did.nymResponse.verkey)
     )?.value
@@ -118,8 +118,8 @@ export class IndyVdrPoolService {
       const nonProduction = successful.filter((s) => !s.value.pool.config.isProduction)
       const productionOrNonProduction = production.length >= 1 ? production : nonProduction
 
-      // We take the first value as we take the order in the indyLedgers config as
-      // the order of preference of ledgers
+      // We take the first value as we take the order in the IndyVdrModuleConfigOptions.networks
+      // config as the order of preference of ledgers
       value = productionOrNonProduction[0].value
     }
 
@@ -154,7 +154,7 @@ export class IndyVdrPoolService {
   public getPoolForNamespace(indyNamespace: string) {
     if (this.pools.length === 0) {
       throw new IndyVdrNotConfiguredError(
-        "No indy ledgers configured. Provide at least one pool configuration in the 'indyLedgers' agent configuration"
+        'No indy ledgers configured. Provide at least one pool configuration in IndyVdrModuleConfigOptions.networks'
       )
     }
 


### PR DESCRIPTION
Errors in indy-vdr and indy-sdk were still referencing to former AgentConfig's `indyLedgers` array, which was misleading because now they are set up in module config's networks array.