### PR TITLE
test(indy-vdr): add delay after DID creation

### DIFF
--- a/packages/indy-vdr/tests/helpers.ts
+++ b/packages/indy-vdr/tests/helpers.ts
@@ -4,6 +4,7 @@ import type { Agent } from '@aries-framework/core'
 import { DidCommV1Service, DidCommV2Service, DidDocumentService, KeyType } from '@aries-framework/core'
 import { indyVdr } from '@hyperledger/indy-vdr-nodejs'
 
+import { sleep } from '../../core/src/utils/sleep'
 import { genesisTransactions } from '../../core/tests/helpers'
 import { IndyVdrModuleConfig } from '../src/IndyVdrModuleConfig'
 
@@ -59,6 +60,9 @@ export async function createDidOnLedger(agent: Agent, submitterDid: string) {
       `Did was not created. ${createResult.didState.state === 'failed' ? createResult.didState.reason : 'Not finished'}`
     )
   }
+
+  // Wait some time pass to let ledger settle the object
+  await sleep(1000)
 
   return { did: createResult.didState.did, key }
 }

--- a/packages/indy-vdr/tests/indy-vdr-did-registrar.e2e.test.ts
+++ b/packages/indy-vdr/tests/indy-vdr-did-registrar.e2e.test.ts
@@ -153,7 +153,8 @@ describe('Indy VDR Indy Did Registrar', () => {
       },
     })
 
-    await new Promise((res) => setTimeout(res, 1000))
+    // Wait some time pass to let ledger settle the object
+    await sleep(1000)
 
     expect(JsonTransformer.toJSON(didRegistrationResult)).toMatchObject({
       didDocumentMetadata: {},

--- a/packages/indy-vdr/tests/indy-vdr-did-registrar.e2e.test.ts
+++ b/packages/indy-vdr/tests/indy-vdr-did-registrar.e2e.test.ts
@@ -14,6 +14,7 @@ import {
 import { indyVdr } from '@hyperledger/indy-vdr-nodejs'
 import { convertPublicKeyToX25519, generateKeyPairFromSeed } from '@stablelib/ed25519'
 
+import { sleep } from '../../core/src/utils/sleep'
 import { getAgentOptions, importExistingIndyDidFromPrivateKey } from '../../core/tests/helpers'
 import { IndySdkModule } from '../../indy-sdk/src'
 import { indySdk } from '../../indy-sdk/tests/setupIndySdkModule'
@@ -100,6 +101,9 @@ describe('Indy VDR Indy Did Registrar', () => {
     const did = didRegistrationResult.didState.did
     if (!did) throw Error('did not defined')
 
+    // Wait some time pass to let ledger settle the object
+    await sleep(1000)
+
     const didResolutionResult = await agent.dids.resolve(did)
     expect(JsonTransformer.toJSON(didResolutionResult)).toMatchObject({
       didDocument: {
@@ -149,6 +153,8 @@ describe('Indy VDR Indy Did Registrar', () => {
       },
     })
 
+    await new Promise((res) => setTimeout(res, 1000))
+
     expect(JsonTransformer.toJSON(didRegistrationResult)).toMatchObject({
       didDocumentMetadata: {},
       didRegistrationMetadata: {},
@@ -175,6 +181,9 @@ describe('Indy VDR Indy Did Registrar', () => {
         },
       },
     })
+
+    // Wait some time pass to let ledger settle the object
+    await sleep(1000)
 
     const didResult = await agent.dids.resolve(did)
     expect(JsonTransformer.toJSON(didResult)).toMatchObject({
@@ -312,6 +321,9 @@ describe('Indy VDR Indy Did Registrar', () => {
         didDocument: expectedDidDocument,
       },
     })
+
+    // Wait some time pass to let ledger settle the object
+    await sleep(1000)
 
     const didResult = await agent.dids.resolve(did)
     expect(JsonTransformer.toJSON(didResult)).toMatchObject({


### PR DESCRIPTION
In Indy VDR tests, after DID creation we are attempting to resolve the recently created DID immediately, which does not always work properly in CI. Here we add the 1000 ms delay that we also do in other Indy registrar tests.