### PR TITLE
fix(connections): store imageUrl when using DIDExchange

### DIFF
--- a/packages/core/src/modules/connections/DidExchangeProtocol.ts
+++ b/packages/core/src/modules/connections/DidExchangeProtocol.ts
@@ -98,6 +98,7 @@ export class DidExchangeProtocol {
       autoAcceptConnection: outOfBandRecord.autoAcceptConnection,
       outOfBandId: outOfBandRecord.id,
       invitationDid,
+      imageUrl: outOfBandInvitation.imageUrl,
     })
 
     DidExchangeStateMachine.assertCreateMessageState(DidExchangeRequestMessage.type, connectionRecord)

--- a/packages/core/tests/oob.test.ts
+++ b/packages/core/tests/oob.test.ts
@@ -50,6 +50,7 @@ describe('out of band', () => {
     goalCode: 'p2p-messaging',
     label: 'Faber College',
     alias: `Faber's connection with Alice`,
+    imageUrl: 'http://faber.image.url',
   }
 
   const issueCredentialConfig = {
@@ -186,6 +187,7 @@ describe('out of band', () => {
       expect(outOfBandRecord.outOfBandInvitation.goal).toBe(makeConnectionConfig.goal)
       expect(outOfBandRecord.outOfBandInvitation.goalCode).toBe(makeConnectionConfig.goalCode)
       expect(outOfBandRecord.outOfBandInvitation.label).toBe(makeConnectionConfig.label)
+      expect(outOfBandRecord.outOfBandInvitation.imageUrl).toBe(makeConnectionConfig.imageUrl)
     })
 
     test('create OOB message only with handshake', async () => {
@@ -316,6 +318,7 @@ describe('out of band', () => {
       expect(faberAliceConnection?.state).toBe(DidExchangeState.Completed)
 
       expect(aliceFaberConnection).toBeConnectedWith(faberAliceConnection!)
+      expect(aliceFaberConnection.imageUrl).toBe(makeConnectionConfig.imageUrl)
       expect(faberAliceConnection).toBeConnectedWith(aliceFaberConnection)
       expect(faberAliceConnection.alias).toBe(makeConnectionConfig.alias)
     })


### PR DESCRIPTION
It was already fixed for Connection protocol in https://github.com/hyperledger/aries-framework-javascript/pull/896 but missing for DID Exchange.