### PR TITLE
fix(indy-vdr): do not force indy-vdr version

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "refresh": "rm -rf ./node_modules ./yarn.lock && yarn"
   },
   "dependencies": {
-    "@hyperledger/indy-vdr-nodejs": "0.1.0-dev.13",
+    "@hyperledger/indy-vdr-nodejs": "^0.1.0-dev.14",
     "@hyperledger/anoncreds-nodejs": "^0.1.0-dev.14",
     "@hyperledger/aries-askar-nodejs": "^0.1.0-dev.8",
     "inquirer": "^8.2.5"

--- a/packages/indy-vdr/package.json
+++ b/packages/indy-vdr/package.json
@@ -26,10 +26,10 @@
   "dependencies": {
     "@aries-framework/anoncreds": "0.3.3",
     "@aries-framework/core": "0.3.3",
-    "@hyperledger/indy-vdr-shared": "0.1.0-dev.13"
+    "@hyperledger/indy-vdr-shared": "^0.1.0-dev.14"
   },
   "devDependencies": {
-    "@hyperledger/indy-vdr-nodejs": "0.1.0-dev.13",
+    "@hyperledger/indy-vdr-nodejs": "^0.1.0-dev.14",
     "@stablelib/ed25519": "^1.0.2",
     "rimraf": "^4.4.0",
     "rxjs": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,12 +1072,12 @@
   dependencies:
     fast-text-encoding "^1.0.3"
 
-"@hyperledger/indy-vdr-nodejs@0.1.0-dev.13":
-  version "0.1.0-dev.13"
-  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-nodejs/-/indy-vdr-nodejs-0.1.0-dev.13.tgz#1630d7e00366160d3ef6ae0237528faa749ca831"
-  integrity sha512-r5s5GuKjTP1ALkW4sG6oGdSGPX407nCEHB0lTapVuDF7aUHRsYQkcGUkyMESH2LmCSoxAvwM05RVKJOHYnK7zg==
+"@hyperledger/indy-vdr-nodejs@^0.1.0-dev.14":
+  version "0.1.0-dev.14"
+  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-nodejs/-/indy-vdr-nodejs-0.1.0-dev.14.tgz#d21590d5464341fb701b654c132c75c96e1cba8f"
+  integrity sha512-iuR4At4Vs2tQhctZH84KlWKFL1JI6BXa+2dnBauQXhMEQj8q2l5kTH8TjJeXPD1PyOnbLB9ry4tfx+/a0A2AKg==
   dependencies:
-    "@hyperledger/indy-vdr-shared" "0.1.0-dev.13"
+    "@hyperledger/indy-vdr-shared" "0.1.0-dev.14"
     "@mapbox/node-pre-gyp" "^1.0.10"
     "@types/ref-array-di" "^1.2.5"
     ffi-napi "^4.0.3"
@@ -1085,10 +1085,10 @@
     ref-napi "^3.0.3"
     ref-struct-di "^1.1.1"
 
-"@hyperledger/indy-vdr-shared@0.1.0-dev.13":
-  version "0.1.0-dev.13"
-  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-shared/-/indy-vdr-shared-0.1.0-dev.13.tgz#ccecd11b706253e61be16c1e8098ba045a5a42d1"
-  integrity sha512-MxSlxZSy9lpfFB6/APHclxOqFwWbyEGJtg+8u9CgAVtyHA8AqdM5MQc7A485VzUFYqV95f1FmE+8W5qpPSLTZw==
+"@hyperledger/indy-vdr-shared@0.1.0-dev.14", "@hyperledger/indy-vdr-shared@^0.1.0-dev.14":
+  version "0.1.0-dev.14"
+  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-shared/-/indy-vdr-shared-0.1.0-dev.14.tgz#7dc3d61f997c1bcf737b23133ed0d08fec2a901d"
+  integrity sha512-CsZUcqybgtvVEVD1uHHgCGY3tddYcePJKjkEar14pss4w2IxbhRYnzkfp0+lWYUQnAY7rGX8A0MxRxwd7K1Yhw==
 
 "@isaacs/string-locale-compare@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION
I'm not sure if @hyperledger/indy-vdr-shared and @hyperledger/indy-vdr-nodejs versions are fixed to a particular version on purpose, but tests seem to work fine on the latest 0.1.0-dev.14.

This is mainly to fix https://github.com/hyperledger/aries-agent-test-harness/issues/669. If the version should be fixed to dev.13, another possibility is to fix it in the AATH backchannel.