### PR TITLE
fix: Emit RoutingCreated event for mediator routing record

### DIFF
--- a/packages/core/src/modules/routing/services/MediatorService.ts
+++ b/packages/core/src/modules/routing/services/MediatorService.ts
@@ -212,6 +212,17 @@ export class MediatorService {
 
     await this.mediatorRoutingRepository.save(agentContext, routingRecord)
 
+    this.eventEmitter.emit(agentContext, {
+      type: RoutingEventTypes.RoutingCreatedEvent,
+      payload: {
+        routing: {
+          endpoints: agentContext.config.endpoints,
+          routingKeys: [],
+          recipientKey: routingKey,
+        },
+      },
+    })
+
     return routingRecord
   }
 


### PR DESCRIPTION
Added `RoutingCreatedEvent` emit after creation of mediator routing record in `MediatorService`.

This change is required to enable mediator functionality for tenant agents as `registerRecipientKeyForTenant` will not be called for mediator routing key otherwise (done in `RoutingCreatedEvent` listener).
