### PR TITLE
fix: remove scope check from response

### DIFF
--- a/packages/openid4vc-client/src/OpenId4VcClientService.ts
+++ b/packages/openid4vc-client/src/OpenId4VcClientService.ts
@@ -33,7 +33,6 @@ export interface PreAuthCodeFlowOptions {
   issuerUri: string
   kid: string
   verifyRevocationState: boolean
-  scope?: string[]
 }
 
 export interface AuthCodeFlowOptions extends PreAuthCodeFlowOptions {

--- a/packages/openid4vc-client/src/OpenId4VcClientService.ts
+++ b/packages/openid4vc-client/src/OpenId4VcClientService.ts
@@ -258,21 +258,10 @@ export class OpenId4VcClientService {
 
     this.logger.debug('Full server metadata', serverMetadata)
 
-    let scope: string
-
     if (accessToken.scope) {
-      scope = accessToken.scope
-    } else {
-      if (!options.scope || options.scope.length === 0) {
-        throw new AriesFrameworkError(
-          'The access_token response does not include a scope and no scope was provided in the request. Unable to determine the credential type.'
-        )
+      for (const credentialType of accessToken.scope.split(' ')) {
+        this.assertCredentialHasFormat(credentialFormat, credentialType, serverMetadata)
       }
-      scope = options.scope.join(' ')
-    }
-
-    for (const credentialType of scope.split(' ')) {
-      this.assertCredentialHasFormat(credentialFormat, credentialType, serverMetadata)
     }
 
     // proof of possession
@@ -298,7 +287,7 @@ export class OpenId4VcClientService {
 
     const credentialResponse = await credentialRequestClient.acquireCredentialsUsingProof({
       proofInput,
-      credentialType: scope,
+      credentialType: accessToken.scope,
       format: credentialFormat,
     })
 


### PR DESCRIPTION
Previously the `requestCredential` method would throw an error if the `scope` parameter was not present in the `access_token` response. This `scope` value was used to indicate the desired credential type when requesting the credential. However, this was incorrect, as this value is optional according to the [specification](https://www.rfc-editor.org/rfc/rfc6749.html#section-4.2.2).

This PR removes the requirement for the `scope` to be present on the `access_token` response. If the `scope` is present, it will be used to check if the server metadata indicates the requested credential format is supported for the requested credential type (indicated by the `scope`). If not, this validation is skipped.

When the `access_token` response does not contain a `scope`, the `credentialType` value that is passed to the underlying Sphereon library will be undefined. When this happens, the Sphereon library will use the `credentialType` value from the issuance initiation request instead (relevant code [here](https://github.com/Sphereon-Opensource/OID4VCI/blob/56b16a33fe8826043906f1d82616f0a9a0873d75/lib/CredentialRequestClient.ts#L66)), which should always be present according to the [spec](https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0-09.html#section-e.1.1.3).

@TimoGlastra, @blu3beri, could one of you please verify these changes are in line with the specs? 

Related to #1322 

Signed-off-by: Karim Stekelenburg <karim@animo.id>
