### PR TITLE
test: tests for DidComm V2 message packing

### DIFF
--- a/packages/askar/src/wallet/AskarWallet.ts
+++ b/packages/askar/src/wallet/AskarWallet.ts
@@ -1424,7 +1424,9 @@ export class AskarWallet implements Wallet {
   }
 
   private findCommonSupportedEncryptionKeys(recipientDidDocuments: DidDocument[], senderDidDocument?: DidDocument) {
-    const recipients = recipientDidDocuments.map((recipientDidDocument) => recipientDidDocument.agreementKeys)
+    const recipients = recipientDidDocuments.map(
+      (recipientDidDocument) => recipientDidDocument.dereferencedKeyAgreement
+    )
 
     if (!senderDidDocument) {
       return {
@@ -1433,7 +1435,7 @@ export class AskarWallet implements Wallet {
       }
     }
 
-    const senderAgreementKeys = senderDidDocument.agreementKeys
+    const senderAgreementKeys = senderDidDocument.dereferencedKeyAgreement
 
     let senderVerificationMethod: VerificationMethod | undefined
     const recipientsVerificationMethods: VerificationMethod[] = []

--- a/packages/askar/src/wallet/AskarWallet.ts
+++ b/packages/askar/src/wallet/AskarWallet.ts
@@ -1296,7 +1296,7 @@ export class AskarWallet implements Wallet {
     throw new AriesFrameworkError('Unable to open jwe: recipient key not found in the wallet')
   }
 
-  public async resolveRecipientKey({
+  private async resolveRecipientKey({
     kid,
     recipientDidDocuments,
   }: {
@@ -1317,7 +1317,7 @@ export class AskarWallet implements Wallet {
     }
   }
 
-  public resolveSenderKeys({
+  private resolveSenderKeys({
     skid,
     didDocument,
     apu,

--- a/packages/askar/src/wallet/__tests__/packing.test.ts
+++ b/packages/askar/src/wallet/__tests__/packing.test.ts
@@ -7,12 +7,27 @@ import {
   KeyDerivationMethod,
   KeyProviderRegistry,
   KeyType,
+  Buffer,
+  Key,
+  AriesFrameworkError,
 } from '@aries-framework/core'
+import { Jwk, Key as AskarKey } from '@hyperledger/aries-askar-shared'
 
 import { describeRunInNodeVersion } from '../../../../../tests/runInVersion'
+import { TrustPingMessage } from '../../../../core/src/modules/connections/protocols/trust-ping/v2'
 import { agentDependencies } from '../../../../core/tests/helpers'
 import testLogger from '../../../../core/tests/logger'
 import { AskarWallet } from '../AskarWallet'
+
+import {
+  aliceX25519Secret1,
+  bobX25519Secret1,
+  bobX25519Secret2,
+  bobX25519Secret3,
+  jweEcdh1PuA256CbcHs512_1,
+  jweEcdhEsX25519Xc20P_1,
+  message,
+} from './testVectors'
 
 // use raw key derivation method to speed up wallet creating / opening / closing between tests
 const walletConfig: WalletConfig = {
@@ -21,8 +36,6 @@ const walletConfig: WalletConfig = {
   key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
   keyDerivationMethod: KeyDerivationMethod.Raw,
 }
-
-const message = new BasicMessage({ content: 'hello' })
 
 describeRunInNodeVersion([18], 'askarWallet packing', () => {
   let askarWallet: AskarWallet
@@ -37,6 +50,8 @@ describeRunInNodeVersion([18], 'askarWallet packing', () => {
   })
 
   describe('DIDComm V1 packing and unpacking', () => {
+    const message = new BasicMessage({ content: 'hello' })
+
     test('Authcrypt', async () => {
       // Create both sender and recipient keys
       const senderKey = await askarWallet.createKey({ keyType: KeyType.Ed25519 })
@@ -70,7 +85,13 @@ describeRunInNodeVersion([18], 'askarWallet packing', () => {
   })
 
   describe('DIDComm V2 packing and unpacking', () => {
-    test('Authcrypt', async () => {
+    const message = new TrustPingMessage({
+      body: {
+        responseRequested: false,
+      },
+    })
+
+    test('Authcrypt pack/unpack works', async () => {
       // Create both sender and recipient keys
       const senderKey = await askarWallet.createKey({ keyType: KeyType.X25519 })
       const recipientKey = await askarWallet.createKey({ keyType: KeyType.X25519 })
@@ -83,10 +104,10 @@ describeRunInNodeVersion([18], 'askarWallet packing', () => {
 
       const encryptedMessage = await askarWallet.pack(message.toJSON(), params)
       const plainTextMessage = await askarWallet.unpack(encryptedMessage)
-      expect(JsonTransformer.fromJSON(plainTextMessage.plaintextMessage, BasicMessage)).toEqual(message)
+      expect(JsonTransformer.fromJSON(plainTextMessage.plaintextMessage, TrustPingMessage)).toEqual(message)
     })
 
-    test('Anoncrypt', async () => {
+    test('Anoncrypt pack/unpack works', async () => {
       // Create recipient keys only
       const recipientKey = await askarWallet.createKey({ keyType: KeyType.X25519 })
 
@@ -98,7 +119,101 @@ describeRunInNodeVersion([18], 'askarWallet packing', () => {
 
       const encryptedMessage = await askarWallet.pack(message.toJSON(), params)
       const plainTextMessage = await askarWallet.unpack(encryptedMessage)
-      expect(JsonTransformer.fromJSON(plainTextMessage.plaintextMessage, BasicMessage)).toEqual(message)
+      expect(JsonTransformer.fromJSON(plainTextMessage.plaintextMessage, TrustPingMessage)).toEqual(message)
+    })
+  })
+
+  describe('DIDComm V2 test vectors', () => {
+    function mockRecipientKey(key: { kid: string; value: any }) {
+      const recipientKeys = {
+        recipientAskarKey: AskarKey.fromJwk({ jwk: Jwk.fromJson(key.value) }),
+        recipientKey: Key.fromJwk(key.value),
+      }
+      jest.spyOn(askarWallet, 'resolveRecipientKey').mockImplementation((kid) => {
+        if (kid === key.kid) {
+          return Promise.resolve(recipientKeys)
+        } else {
+          return Promise.resolve({ recipientAskarKey: undefined, recipientKey: undefined })
+        }
+      })
+    }
+
+    function resetRecipientKeyMock() {
+      jest.spyOn(askarWallet, 'resolveRecipientKey').mockReset()
+    }
+
+    function mockSenderKey(key: { kid: string; value: any }) {
+      const senderKeys = {
+        senderAskarKey: AskarKey.fromJwk({ jwk: Jwk.fromJson(key.value) }),
+        senderKey: Key.fromJwk(key.value),
+      }
+      jest.spyOn(askarWallet, 'resolveSenderKeys').mockImplementation((kid) => {
+        if (kid === key.kid) {
+          return senderKeys
+        } else {
+          return { senderAskarKey: undefined, senderKey: undefined }
+        }
+      })
+    }
+
+    function resetSenderKeyMock() {
+      jest.spyOn(askarWallet, 'resolveSenderKeys').mockReset()
+    }
+
+    describe('Anocrypt', () => {
+      test.each([bobX25519Secret1, bobX25519Secret2, bobX25519Secret3])(
+        'Unpack anoncrypted EcdhEsX25519Xc20P test vector works',
+        async (bobX25519Secret) => {
+          const key = AskarKey.fromJwk({ jwk: Jwk.fromJson(bobX25519Secret.value) })
+          await askarWallet.createKey({
+            privateKey: Buffer.from(key.secretBytes),
+            keyType: KeyType.X25519,
+          })
+
+          mockRecipientKey(bobX25519Secret)
+
+          const unpackedMessage = await askarWallet.unpack(jweEcdhEsX25519Xc20P_1)
+          expect(unpackedMessage.plaintextMessage).toEqual(message)
+
+          resetRecipientKeyMock()
+        }
+      )
+
+      test('Unpack fails when there is not recipient key in the wallet', async () => {
+        return expect(() => askarWallet.unpack(jweEcdhEsX25519Xc20P_1)).rejects.toThrowError(AriesFrameworkError)
+      })
+    })
+
+    describe('Authcrypt', () => {
+      test.each([bobX25519Secret1, bobX25519Secret2, bobX25519Secret3])(
+        'Unpack authcrypted Ecdh1PuA256CbcHs512 test vector works',
+        async (bobX25519Secret) => {
+          const key = AskarKey.fromJwk({ jwk: Jwk.fromJson(bobX25519Secret.value) })
+          await askarWallet.createKey({
+            privateKey: Buffer.from(key.secretBytes),
+            keyType: KeyType.X25519,
+          })
+
+          mockSenderKey(aliceX25519Secret1)
+          mockRecipientKey(bobX25519Secret)
+
+          const unpackedMessage = await askarWallet.unpack(jweEcdh1PuA256CbcHs512_1)
+          expect(unpackedMessage.plaintextMessage).toEqual(message)
+
+          resetRecipientKeyMock()
+          resetSenderKeyMock()
+        }
+      )
+
+      test('Unpack fails when there is not recipient key in the wallet', async () => {
+        mockSenderKey(aliceX25519Secret1)
+        await expect(() => askarWallet.unpack(jweEcdh1PuA256CbcHs512_1)).rejects.toThrowError(AriesFrameworkError)
+        resetSenderKeyMock()
+      })
+
+      test('Unpack fails when unable to resolve sender', async () => {
+        await expect(() => askarWallet.unpack(jweEcdh1PuA256CbcHs512_1)).rejects.toThrowError(AriesFrameworkError)
+      })
     })
   })
 })

--- a/packages/askar/src/wallet/__tests__/testVectors.ts
+++ b/packages/askar/src/wallet/__tests__/testVectors.ts
@@ -108,3 +108,179 @@ export const message = {
   expires_time: 1516385931,
   body: { messagespecificattribute: 'and its value' },
 }
+
+export const aliceDidDocument = {
+  '@context': ['https://www.w3.org/ns/did/v1', 'https://w3id.org/security/suites/jws-2020/v1'],
+  id: 'did:example:alice',
+  authentication: [
+    {
+      id: 'did:example:alice#key-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:alice',
+      publicKeyJwk: {
+        kty: 'OKP',
+        crv: 'Ed25519',
+        x: 'G-boxFB6vOZBu-wXkm-9Lh79I8nf9Z50cILaOgKKGww',
+      },
+    },
+    {
+      id: 'did:example:alice#key-2',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:alice',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-256',
+        x: '2syLh57B-dGpa0F8p1JrO6JU7UUSF6j7qL-vfk1eOoY',
+        y: 'BgsGtI7UPsObMRjdElxLOrgAO9JggNMjOcfzEPox18w',
+      },
+    },
+    {
+      id: 'did:example:alice#key-3',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:alice',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'secp256k1',
+        x: 'aToW5EaTq5mlAf8C5ECYDSkqsJycrW-e1SQ6_GJcAOk',
+        y: 'JAGX94caA21WKreXwYUaOCYTBMrqaX4KWIlsQZTHWCk',
+      },
+    },
+  ],
+  keyAgreement: [
+    {
+      id: 'did:example:alice#key-x25519-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:alice',
+      publicKeyJwk: {
+        kty: 'OKP',
+        crv: 'X25519',
+        x: 'avH0O2Y4tqLAq8y9zpianr8ajii5m4F_mICrzNlatXs',
+      },
+    },
+    {
+      id: 'did:example:alice#key-p256-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:alice',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-256',
+        x: 'L0crjMN1g0Ih4sYAJ_nGoHUck2cloltUpUVQDhF2nHE',
+        y: 'SxYgE7CmEJYi7IDhgK5jI4ZiajO8jPRZDldVhqFpYoo',
+      },
+    },
+    {
+      id: 'did:example:alice#key-p521-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:alice',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-521',
+        x: 'AHBEVPRhAv-WHDEvxVM9S0px9WxxwHL641Pemgk9sDdxvli9VpKCBdra5gg_4kupBDhz__AlaBgKOC_15J2Byptz',
+        y: 'AciGcHJCD_yMikQvlmqpkBbVqqbg93mMVcgvXBYAQPP-u9AF7adybwZrNfHWCKAQwGF9ugd0Zhg7mLMEszIONFRk',
+      },
+    },
+  ],
+}
+
+export const bobDidDocument = {
+  '@context': ['https://www.w3.org/ns/did/v2'],
+  id: 'did:example:bob',
+  keyAgreement: [
+    {
+      id: 'did:example:bob#key-x25519-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'OKP',
+        crv: 'X25519',
+        x: 'GDTrI66K0pFfO54tlCSvfjjNapIs44dzpneBgyx0S3E',
+      },
+    },
+    {
+      id: 'did:example:bob#key-x25519-2',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'OKP',
+        crv: 'X25519',
+        x: 'UT9S3F5ep16KSNBBShU2wh3qSfqYjlasZimn0mB8_VM',
+      },
+    },
+    {
+      id: 'did:example:bob#key-x25519-3',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'OKP',
+        crv: 'X25519',
+        x: '82k2BTUiywKv49fKLZa-WwDi8RBf0tB0M8bvSAUQ3yY',
+      },
+    },
+    {
+      id: 'did:example:bob#key-p256-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-256',
+        x: 'FQVaTOksf-XsCUrt4J1L2UGvtWaDwpboVlqbKBY2AIo',
+        y: '6XFB9PYo7dyC5ViJSO9uXNYkxTJWn0d_mqJ__ZYhcNY',
+      },
+    },
+    {
+      id: 'did:example:bob#key-p256-2',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-256',
+        x: 'n0yBsGrwGZup9ywKhzD4KoORGicilzIUyfcXb1CSwe0',
+        y: 'ov0buZJ8GHzV128jmCw1CaFbajZoFFmiJDbMrceCXIw',
+      },
+    },
+    {
+      id: 'did:example:bob#key-p384-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-384',
+        x: 'MvnE_OwKoTcJVfHyTX-DLSRhhNwlu5LNoQ5UWD9Jmgtdxp_kpjsMuTTBnxg5RF_Y',
+        y: 'X_3HJBcKFQEG35PZbEOBn8u9_z8V1F9V1Kv-Vh0aSzmH-y9aOuDJUE3D4Hvmi5l7',
+      },
+    },
+    {
+      id: 'did:example:bob#key-p384-2',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-384',
+        x: '2x3HOTvR8e-Tu6U4UqMd1wUWsNXMD0RgIunZTMcZsS-zWOwDgsrhYVHmv3k_DjV3',
+        y: 'W9LLaBjlWYcXUxOf6ECSfcXKaC3-K9z4hCoP0PS87Q_4ExMgIwxVCXUEB6nf0GDd',
+      },
+    },
+    {
+      id: 'did:example:bob#key-p521-1',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-521',
+        x: 'Af9O5THFENlqQbh2Ehipt1Yf4gAd9RCa3QzPktfcgUIFADMc4kAaYVViTaDOuvVS2vMS1KZe0D5kXedSXPQ3QbHi',
+        y: 'ATZVigRQ7UdGsQ9j-omyff6JIeeUv3CBWYsZ0l6x3C_SYqhqVV7dEG-TafCCNiIxs8qeUiXQ8cHWVclqkH4Lo1qH',
+      },
+    },
+    {
+      id: 'did:example:bob#key-p521-2',
+      type: 'JsonWebKey2020',
+      controller: 'did:example:bob',
+      publicKeyJwk: {
+        kty: 'EC',
+        crv: 'P-521',
+        x: 'ATp_WxCfIK_SriBoStmA0QrJc2pUR1djpen0VdpmogtnKxJbitiPq-HJXYXDKriXfVnkrl2i952MsIOMfD2j0Ots',
+        y: 'AEJipR0Dc-aBZYDqN51SKHYSWs9hM58SmRY1MxgXANgZrPaq1EeGMGOjkbLMEJtBThdjXhkS5VlXMkF0cYhZELiH',
+      },
+    },
+  ],
+}

--- a/packages/askar/src/wallet/__tests__/testVectors.ts
+++ b/packages/askar/src/wallet/__tests__/testVectors.ts
@@ -1,0 +1,110 @@
+/*
+ * Test vectors from https://identity.foundation/didcomm-messaging/spec/#appendix
+ * */
+export const jweEcdhEsX25519Xc20P_1 = {
+  ciphertext:
+    'KWS7gJU7TbyJlcT9dPkCw-ohNigGaHSukR9MUqFM0THbCTCNkY-g5tahBFyszlKIKXs7qOtqzYyWbPou2q77XlAeYs93IhF6NvaIjyNqYklvj-OtJt9W2Pj5CLOMdsR0C30wchGoXd6wEQZY4ttbzpxYznqPmJ0b9KW6ZP-l4_DSRYe9B-1oSWMNmqMPwluKbtguC-riy356Xbu2C9ShfWmpmjz1HyJWQhZfczuwkWWlE63g26FMskIZZd_jGpEhPFHKUXCFwbuiw_Iy3R0BIzmXXdK_w7PZMMPbaxssl2UeJmLQgCAP8j8TukxV96EKa6rGgULvlo7qibjJqsS5j03bnbxkuxwbfyu3OxwgVzFWlyHbUH6p',
+  protected:
+    'eyJlcGsiOnsia3R5IjoiT0tQIiwiY3J2IjoiWDI1NTE5IiwieCI6IkpIanNtSVJaQWFCMHpSR193TlhMVjJyUGdnRjAwaGRIYlc1cmo4ZzBJMjQifSwiYXB2IjoiTmNzdUFuclJmUEs2OUEtcmtaMEw5WFdVRzRqTXZOQzNaZzc0QlB6NTNQQSIsInR5cCI6ImFwcGxpY2F0aW9uL2RpZGNvbW0tZW5jcnlwdGVkK2pzb24iLCJlbmMiOiJYQzIwUCIsImFsZyI6IkVDREgtRVMrQTI1NktXIn0',
+  recipients: [
+    {
+      encrypted_key: '3n1olyBR3nY7ZGAprOx-b7wYAKza6cvOYjNwVg3miTnbLwPP_FmE1A',
+      header: {
+        kid: 'did:example:bob#key-x25519-1',
+      },
+    },
+    {
+      encrypted_key: 'j5eSzn3kCrIkhQAWPnEwrFPMW6hG0zF_y37gUvvc5gvlzsuNX4hXrQ',
+      header: {
+        kid: 'did:example:bob#key-x25519-2',
+      },
+    },
+    {
+      encrypted_key: 'TEWlqlq-ao7Lbynf0oZYhxs7ZB39SUWBCK4qjqQqfeItfwmNyDm73A',
+      header: {
+        kid: 'did:example:bob#key-x25519-3',
+      },
+    },
+  ],
+  tag: '6ylC_iAs4JvDQzXeY6MuYQ',
+  iv: 'ESpmcyGiZpRjc5urDela21TOOTW8Wqd1',
+}
+
+export const jweEcdh1PuA256CbcHs512_1 = {
+  ciphertext:
+    'MJezmxJ8DzUB01rMjiW6JViSaUhsZBhMvYtezkhmwts1qXWtDB63i4-FHZP6cJSyCI7eU-gqH8lBXO_UVuviWIqnIUrTRLaumanZ4q1dNKAnxNL-dHmb3coOqSvy3ZZn6W17lsVudjw7hUUpMbeMbQ5W8GokK9ZCGaaWnqAzd1ZcuGXDuemWeA8BerQsfQw_IQm-aUKancldedHSGrOjVWgozVL97MH966j3i9CJc3k9jS9xDuE0owoWVZa7SxTmhl1PDetmzLnYIIIt-peJtNYGdpd-FcYxIFycQNRUoFEr77h4GBTLbC-vqbQHJC1vW4O2LEKhnhOAVlGyDYkNbA4DSL-LMwKxenQXRARsKSIMn7z-ZIqTE-VCNj9vbtgR',
+  protected:
+    'eyJlcGsiOnsia3R5IjoiT0tQIiwiY3J2IjoiWDI1NTE5IiwieCI6IkdGY01vcEpsamY0cExaZmNoNGFfR2hUTV9ZQWY2aU5JMWRXREd5VkNhdzAifSwiYXB2IjoiTmNzdUFuclJmUEs2OUEtcmtaMEw5WFdVRzRqTXZOQzNaZzc0QlB6NTNQQSIsInNraWQiOiJkaWQ6ZXhhbXBsZTphbGljZSNrZXkteDI1NTE5LTEiLCJhcHUiOiJaR2xrT21WNFlXMXdiR1U2WVd4cFkyVWphMlY1TFhneU5UVXhPUzB4IiwidHlwIjoiYXBwbGljYXRpb24vZGlkY29tbS1lbmNyeXB0ZWQranNvbiIsImVuYyI6IkEyNTZDQkMtSFM1MTIiLCJhbGciOiJFQ0RILTFQVStBMjU2S1cifQ',
+  recipients: [
+    {
+      encrypted_key: 'o0FJASHkQKhnFo_rTMHTI9qTm_m2mkJp-wv96mKyT5TP7QjBDuiQ0AMKaPI_RLLB7jpyE-Q80Mwos7CvwbMJDhIEBnk2qHVB',
+      header: {
+        kid: 'did:example:bob#key-x25519-1',
+      },
+    },
+    {
+      encrypted_key: 'rYlafW0XkNd8kaXCqVbtGJ9GhwBC3lZ9AihHK4B6J6V2kT7vjbSYuIpr1IlAjvxYQOw08yqEJNIwrPpB0ouDzKqk98FVN7rK',
+      header: {
+        kid: 'did:example:bob#key-x25519-2',
+      },
+    },
+    {
+      encrypted_key: 'aqfxMY2sV-njsVo-_9Ke9QbOf6hxhGrUVh_m-h_Aq530w3e_4IokChfKWG1tVJvXYv_AffY7vxj0k5aIfKZUxiNmBwC_QsNo',
+      header: {
+        kid: 'did:example:bob#key-x25519-3',
+      },
+    },
+  ],
+  tag: 'uYeo7IsZjN7AnvBjUZE5lNryNENbf6_zew_VC-d4b3U',
+  iv: 'o02OXDQ6_-sKz2PX_6oyJg',
+}
+
+export const aliceX25519Secret1 = {
+  kid: 'did:example:alice#key-x25519-1',
+  value: {
+    kty: 'OKP',
+    crv: 'X25519',
+    x: 'avH0O2Y4tqLAq8y9zpianr8ajii5m4F_mICrzNlatXs',
+  },
+}
+
+export const bobX25519Secret1 = {
+  kid: 'did:example:bob#key-x25519-1',
+  value: {
+    kty: 'OKP',
+    d: 'b9NnuOCB0hm7YGNvaE9DMhwH_wjZA1-gWD6dA0JWdL0',
+    crv: 'X25519',
+    x: 'GDTrI66K0pFfO54tlCSvfjjNapIs44dzpneBgyx0S3E',
+  },
+}
+
+export const bobX25519Secret2 = {
+  kid: 'did:example:bob#key-x25519-2',
+  value: {
+    kty: 'OKP',
+    d: 'p-vteoF1gopny1HXywt76xz_uC83UUmrgszsI-ThBKk',
+    crv: 'X25519',
+    x: 'UT9S3F5ep16KSNBBShU2wh3qSfqYjlasZimn0mB8_VM',
+  },
+}
+
+export const bobX25519Secret3 = {
+  kid: 'did:example:bob#key-x25519-3',
+  value: {
+    kty: 'OKP',
+    d: 'f9WJeuQXEItkGM8shN4dqFr5fLQLBasHnWZ-8dPaSo0',
+    crv: 'X25519',
+    x: '82k2BTUiywKv49fKLZa-WwDi8RBf0tB0M8bvSAUQ3yY',
+  },
+}
+
+export const message = {
+  id: '1234567890',
+  typ: 'application/didcomm-plain+json',
+  type: 'http://example.com/protocols/lets_do_lunch/1.0/proposal',
+  from: 'did:example:alice',
+  to: ['did:example:bob'],
+  created_time: 1516269022,
+  expires_time: 1516385931,
+  body: { messagespecificattribute: 'and its value' },
+}

--- a/packages/core/src/crypto/Key.ts
+++ b/packages/core/src/crypto/Key.ts
@@ -25,12 +25,6 @@ export class Key {
     return Key.fromPublicKey(publicKeyBytes, keyType)
   }
 
-  public static fromPublicKeyId(kid: string) {
-    const key = kid.split('#')[1] ?? kid
-    const multibaseKey = key.startsWith('z') ? key : `z${key}`
-    return Key.fromFingerprint(multibaseKey)
-  }
-
   public static fromFingerprint(fingerprint: string) {
     const { data } = MultiBaseEncoder.decode(fingerprint)
     const [code, byteLength] = VarintEncoder.decode(data)

--- a/packages/core/src/didcomm/JweEnvelope.ts
+++ b/packages/core/src/didcomm/JweEnvelope.ts
@@ -22,7 +22,7 @@ export interface ProtectedOptions {
   enc: string
   alg: string
   skid?: string
-  epk?: string
+  epk?: Record<string, unknown>
   apu?: string
   apv?: string
 }
@@ -32,7 +32,7 @@ export class Protected {
   public enc!: string
   public alg!: string
   public skid?: string
-  public epk?: string
+  public epk?: Record<string, unknown>
   public apu?: string
   public apv?: string
 
@@ -153,7 +153,7 @@ export class JweEnvelopeBuilder {
     return this
   }
 
-  public setEpk(epk: string): JweEnvelopeBuilder {
+  public setEpk(epk: Record<string, unknown>): JweEnvelopeBuilder {
     this.protected.epk = epk
     return this
   }
@@ -169,11 +169,11 @@ export class JweEnvelopeBuilder {
   }
 
   public apv(): Uint8Array {
-    return this.protected.apv ? Uint8Array.from(Buffer.from(this.protected.apv)) : Uint8Array.from([])
+    return this.protected.apv ? TypedArrayEncoder.fromBase64(this.protected.apv) : Uint8Array.from([])
   }
 
   public apu(): Uint8Array {
-    return this.protected.apu ? Uint8Array.from(Buffer.from(this.protected.apu)) : Uint8Array.from([])
+    return this.protected.apu ? TypedArrayEncoder.fromBase64(this.protected.apu) : Uint8Array.from([])
   }
 
   public alg(): Uint8Array {

--- a/packages/core/src/didcomm/versions/v2/index.ts
+++ b/packages/core/src/didcomm/versions/v2/index.ts
@@ -10,4 +10,13 @@ export interface DidCommV2PackMessageParams {
 }
 
 export { isPlaintextMessageV2, isDidCommV2Message } from './helpers'
-export { PlaintextDidCommV2Message, DidCommV2Types, DidCommV2EncryptionAlgs, DidCommV2KeyProtectionAlgs } from './types'
+export {
+  PlaintextDidCommV2Message,
+  DidCommV2Types,
+  DidCommV2EncryptionAlgs,
+  DidCommV2KeyProtectionAlgs,
+  AnoncrypDidCommV2EncryptionAlgs,
+  AuthcryptDidCommV2EncryptionAlgs,
+  AnoncrypDidCommV2KeyWrapAlgs,
+  AuthcryptDidCommV2KeyWrapAlgs,
+} from './types'

--- a/packages/core/src/didcomm/versions/v2/types.ts
+++ b/packages/core/src/didcomm/versions/v2/types.ts
@@ -14,6 +14,7 @@ export enum DidCommV2Types {
 export enum DidCommV2EncryptionAlgs {
   XC20P = 'XC20P',
   A256CbcHs512 = 'A256CBC-HS512',
+  A256Gcm = 'A256GCM',
 }
 
 export enum DidCommV2KeyProtectionAlgs {
@@ -22,3 +23,19 @@ export enum DidCommV2KeyProtectionAlgs {
   Ecdh1PuA128Kw = 'ECDH-1PU+A128KW',
   Ecdh1PuA256Kw = 'ECDH-1PU+A256KW',
 }
+
+export const AnoncrypDidCommV2EncryptionAlgs = [
+  DidCommV2EncryptionAlgs.A256Gcm,
+  DidCommV2EncryptionAlgs.XC20P,
+  DidCommV2EncryptionAlgs.A256CbcHs512,
+]
+export const AuthcryptDidCommV2EncryptionAlgs = [DidCommV2EncryptionAlgs.A256CbcHs512]
+
+export const AnoncrypDidCommV2KeyWrapAlgs = [
+  DidCommV2KeyProtectionAlgs.EcdhEsA128Kw,
+  DidCommV2KeyProtectionAlgs.EcdhEsA256Kw,
+]
+export const AuthcryptDidCommV2KeyWrapAlgs = [
+  DidCommV2KeyProtectionAlgs.Ecdh1PuA128Kw,
+  DidCommV2KeyProtectionAlgs.Ecdh1PuA256Kw,
+]

--- a/packages/core/src/modules/dids/domain/DidDocument.ts
+++ b/packages/core/src/modules/dids/domain/DidDocument.ts
@@ -264,10 +264,6 @@ export function getAuthenticationKeys(didDocument: DidDocument) {
   )
 }
 
-export function getAgreementKeys(didDocument: DidDocument) {
-  return didDocument.keyAgreement?.map((keyAgreement) => getKeyFromDidDocumentKeyEntry(keyAgreement, didDocument)) ?? []
-}
-
 function getKeyFromDidDocumentKeyEntry(key: string | VerificationMethod, didDocument: DidDocument): Key {
   const verificationMethod = typeof key === 'string' ? didDocument.dereferenceVerificationMethod(key) : key
   return getKeyFromVerificationMethod(verificationMethod)

--- a/packages/core/src/modules/dids/domain/DidDocument.ts
+++ b/packages/core/src/modules/dids/domain/DidDocument.ts
@@ -226,23 +226,23 @@ export class DidDocument {
     return recipientKeys
   }
 
-  public get agreementKeys(): Array<VerificationMethod> {
+  public get dereferencedKeyAgreement(): Array<VerificationMethod> {
     return this.dereferenceVerificationMethods(['keyAgreement'])
   }
 
-  public get authentications(): Array<VerificationMethod> {
+  public get dereferencedAuthentication(): Array<VerificationMethod> {
     return this.dereferenceVerificationMethods(['authentication'])
   }
 
-  public get assertionMethods(): Array<VerificationMethod> {
+  public get dereferencedAssertionMethod(): Array<VerificationMethod> {
     return this.dereferenceVerificationMethods(['assertionMethod'])
   }
 
-  public get capabilityInvocations(): Array<VerificationMethod> {
+  public get dereferencedCapabilityInvocation(): Array<VerificationMethod> {
     return this.dereferenceVerificationMethods(['capabilityInvocation'])
   }
 
-  public get capabilityDelegations(): Array<VerificationMethod> {
+  public get dereferencedCapabilityDelegation(): Array<VerificationMethod> {
     return this.dereferenceVerificationMethods(['capabilityDelegation'])
   }
 

--- a/packages/indy-sdk/src/wallet/IndySdkWallet.ts
+++ b/packages/indy-sdk/src/wallet/IndySdkWallet.ts
@@ -10,6 +10,7 @@ import type {
   WalletCreateKeyOptions,
   WalletExportImportConfig,
   WalletPackOptions,
+  WalletPackV1Options,
   WalletSignOptions,
   WalletVerifyOptions,
 } from '@aries-framework/core'
@@ -548,7 +549,7 @@ export class IndySdkWallet implements Wallet {
 
   public async pack(payload: Record<string, unknown>, params: WalletPackOptions): Promise<EncryptedMessage> {
     if (params.didCommVersion === DidCommMessageVersion.V1) {
-      return this.packDidCommV1(payload, params)
+      return this.packDidCommV1(payload, params as WalletPackV1Options)
     }
     if (params.didCommVersion === DidCommMessageVersion.V2) {
       throw new AriesFrameworkError(`DidComm V2 message encryption is not supported for Indy wallet`)
@@ -556,7 +557,10 @@ export class IndySdkWallet implements Wallet {
     throw new AriesFrameworkError(`Unsupported DidComm version: ${params.didCommVersion}`)
   }
 
-  private async packDidCommV1(payload: Record<string, unknown>, params: WalletPackOptions): Promise<EncryptedMessage> {
+  private async packDidCommV1(
+    payload: Record<string, unknown>,
+    params: WalletPackV1Options
+  ): Promise<EncryptedMessage> {
     try {
       const messageRaw = JsonEncoder.toBuffer(payload)
       const recipientKeys = params.recipientKeys.map((recipientKey) => recipientKey.publicKeyBase58)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10371,16 +10371,6 @@ ref-napi@3.0.3, "ref-napi@^2.0.1 || ^3.0.2", ref-napi@^3.0.3:
     node-addon-api "^3.0.0"
     node-gyp-build "^4.2.1"
 
-"ref-napi@npm:@2060.io/ref-napi@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@2060.io/ref-napi/-/ref-napi-3.0.4.tgz#6a78093b36e8f4ffeb750f706433869382e73eb1"
-  integrity sha512-Aqf699E+DKs2xANx8bSkuzXyG9gcZ2iFkAk1kUTA8KbV5BSPQtIcBJexzohSRi9QWDhP4X54NLm7xwGA0UNCdQ==
-  dependencies:
-    debug "^4.1.1"
-    get-symbol-from-current-process-h "^1.0.2"
-    node-addon-api "^3.0.0"
-    node-gyp-build "^4.2.1"
-
 ref-struct-di@1.1.1, ref-struct-di@^1.1.0, ref-struct-di@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ref-struct-di/-/ref-struct-di-1.1.1.tgz#5827b1d3b32372058f177547093db1fe1602dc10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10371,6 +10371,16 @@ ref-napi@3.0.3, "ref-napi@^2.0.1 || ^3.0.2", ref-napi@^3.0.3:
     node-addon-api "^3.0.0"
     node-gyp-build "^4.2.1"
 
+"ref-napi@npm:@2060.io/ref-napi@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@2060.io/ref-napi/-/ref-napi-3.0.4.tgz#6a78093b36e8f4ffeb750f706433869382e73eb1"
+  integrity sha512-Aqf699E+DKs2xANx8bSkuzXyG9gcZ2iFkAk1kUTA8KbV5BSPQtIcBJexzohSRi9QWDhP4X54NLm7xwGA0UNCdQ==
+  dependencies:
+    debug "^4.1.1"
+    get-symbol-from-current-process-h "^1.0.2"
+    node-addon-api "^3.0.0"
+    node-gyp-build "^4.2.1"
+
 ref-struct-di@1.1.1, ref-struct-di@^1.1.0, ref-struct-di@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ref-struct-di/-/ref-struct-di-1.1.1.tgz#5827b1d3b32372058f177547093db1fe1602dc10"


### PR DESCRIPTION
- Added tests for DidComm V2 message packing
- Fixed issue to pass test vectors from the spec:  https://identity.foundation/didcomm-messaging/spec/#appendix

**Issue with the current implementation**: we need to use DID Resolver to unpack messages properly:
- resolve sender key from `skid`
- resolve recipient key from `kid`