### PR TITLE
feat: openid4vci draft 11 support

### DIFF
--- a/packages/openid4vc-client/package.json
+++ b/packages/openid4vc-client/package.json
@@ -3,9 +3,7 @@
   "main": "build/index",
   "types": "build/index",
   "version": "0.3.3",
-  "files": [
-    "build"
-  ],
+  "files": ["build"],
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
@@ -25,7 +23,8 @@
   },
   "dependencies": {
     "@aries-framework/core": "0.3.3",
-    "@sphereon/openid4vci-client": "^0.4.0",
+    "@sphereon/oid4vci-client": "file:../../../OID4VCI/packages/client",
+    "@sphereon/oid4vci-common": "file:../../../OID4VCI/packages/common",
     "@stablelib/random": "^1.0.2"
   },
   "devDependencies": {

--- a/packages/openid4vc-client/tests/fixtures.ts
+++ b/packages/openid4vc-client/tests/fixtures.ts
@@ -1,5 +1,13 @@
-export const getMetadataResponse = {
+export const PRE_AUTHORIZED_OPENID_CREDENTIAL_OFFER =
+  'openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Flaunchpad.vii.electron.mattrlabs.io%22%2C%22credentials%22%3A%5B%7B%22credentialDefinition%22%3A%7B%22%40context%22%3A%5B%22some_context%22%5D%2C%22types%22%3A%5B%22type_one%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Apre-authorized_code%22%3A%7B%22pre-authorized_code%22%3A%22ABC%22%7D%7D%7D'
+
+export const AUTHORIZED_OPENID_CREDENTIAL_OFFER =
+  'openid-credential-offer://?credential_offer=%7B%22credential_issuer%22%3A%22https%3A%2F%2Flaunchpad.vii.electron.mattrlabs.io%22%2C%22credentials%22%3A%5B%7B%22credentialDefinition%22%3A%7B%22%40context%22%3A%5B%22some_context%22%5D%2C%22types%22%3A%5B%22type_one%22%5D%7D%7D%5D%2C%22grants%22%3A%7B%22authorization-code%22%3A%7B%7D%7D%7D'
+
+export const CREDENTIAL_ISSUER_METADATA = {
+  credential_issuer: 'https://launchpad.vii.electron.mattrlabs.io',
   authorization_endpoint: 'https://launchpad.vii.electron.mattrlabs.io/oidc/v1/auth/authorize',
+  credential_endpoint: 'https://launchpad.vii.electron.mattrlabs.io/credential',
   token_endpoint: 'https://launchpad.vii.electron.mattrlabs.io/oidc/v1/auth/token',
   jwks_uri: 'https://launchpad.vii.electron.mattrlabs.io/oidc/v1/auth/jwks',
   token_endpoint_auth_methods_supported: [
@@ -15,63 +23,50 @@ export const getMetadataResponse = {
   response_types_supported: ['code id_token', 'code', 'id_token', 'none'],
   scopes_supported: ['OpenBadgeCredential', 'AcademicAward', 'LearnerProfile', 'PermanentResidentCard'],
   token_endpoint_auth_signing_alg_values_supported: ['HS256', 'RS256', 'PS256', 'ES256', 'EdDSA'],
-  credential_endpoint: 'https://launchpad.vii.electron.mattrlabs.io/oidc/v1/auth/credential',
-  credentials_supported: {
-    OpenBadgeCredential: {
-      formats: {
-        ldp_vc: {
-          name: 'JFF x vc-edu PlugFest 2',
-          description: "MATTR's submission for JFF Plugfest 2",
-          types: ['OpenBadgeCredential'],
-          binding_methods_supported: ['did'],
-          cryptographic_suites_supported: ['Ed25519Signature2018'],
-        },
-      },
+  credentials_supported: [
+    {
+      format: 'ldp_vc',
+      id: 'OpenBadgeCredential',
+      name: 'JFF x vc-edu PlugFest 2',
+      types: ['OpenBadgeCredential'],
+      cryptographic_binding_methods_supported: ['did:key', 'did:web', 'did:jwk'],
+      cryptographic_suites_supported: ['Ed25519Signature2018'],
     },
-    AcademicAward: {
-      formats: {
-        ldp_vc: {
-          name: 'Example Academic Award',
-          description: 'Microcredential from the MyCreds Network.',
-          types: ['AcademicAward'],
-          binding_methods_supported: ['did'],
-          cryptographic_suites_supported: ['Ed25519Signature2018'],
-        },
-      },
+    {
+      format: 'ldp_vc',
+      id: 'AcademicAward',
+      name: 'Example Academic Award',
+      types: ['AcademicAward'],
+      cryptographic_binding_methods_supported: ['did:key', 'did:web', 'did:jwk'],
+      cryptographic_suites_supported: ['Ed25519Signature2018'],
     },
-    LearnerProfile: {
-      formats: {
-        ldp_vc: {
-          name: 'Digitary Learner Profile',
-          description: 'Example',
-          types: ['LearnerProfile'],
-          binding_methods_supported: ['did'],
-          cryptographic_suites_supported: ['Ed25519Signature2018'],
-        },
-      },
+    {
+      format: 'ldp_vc',
+      id: 'LearnerProfile',
+      name: 'Digitary Learner Profile',
+      types: ['LearnerProfile'],
+      cryptographic_binding_methods_supported: ['did:key', 'did:web', 'did:jwk'],
+      cryptographic_suites_supported: ['Ed25519Signature2018'],
     },
-    PermanentResidentCard: {
-      formats: {
-        ldp_vc: {
-          name: 'Permanent Resident Card',
-          description: 'Government of Kakapo',
-          types: ['PermanentResidentCard'],
-          binding_methods_supported: ['did'],
-          cryptographic_suites_supported: ['Ed25519Signature2018'],
-        },
-      },
+    {
+      format: 'ldp_vc',
+      id: 'PermanentResidentCard',
+      name: 'Permanent Resident Card',
+      types: ['PermanentResidentCard'],
+      cryptographic_binding_methods_supported: ['did:key', 'did:web', 'did:jwk'],
+      cryptographic_suites_supported: ['Ed25519Signature2018'],
     },
-  },
+  ],
 }
 
-export const acquireAccessTokenResponse = {
+export const ACCESS_TOKEN_RESPONSE = {
   access_token: '7nikUotMQefxn7oRX56R7MDNE7KJTGfwGjOkHzGaUIG',
   expires_in: 3600,
   scope: 'OpenBadgeCredential',
   token_type: 'Bearer',
 }
 
-export const credentialRequestResponse = {
+export const CREDENTIAL_REQUEST_RESPONSE = {
   format: 'w3cvc-jsonld',
   credential: {
     type: ['VerifiableCredential', 'VerifiableCredentialExtension', 'OpenBadgeCredential'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2334,15 +2334,30 @@
   resolved "https://registry.yarnpkg.com/@sovpro/delimited-stream/-/delimited-stream-1.1.0.tgz#4334bba7ee241036e580fdd99c019377630d26b4"
   integrity sha512-kQpk267uxB19X3X2T1mvNMjyvIEonpNSHrMlK5ZaBU6aZxw7wPbpgKJOjHN3+/GPVpXgAV9soVT2oyHpLkLtyw==
 
-"@sphereon/openid4vci-client@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@sphereon/openid4vci-client/-/openid4vci-client-0.4.0.tgz#f48c2bb42041b9eab13669de23ba917785c83b24"
-  integrity sha512-N9ytyV3DHAjBjd67jMowmBMmD9/4Sxkehsrpd1I9Hxg5TO1K+puUPsPXj8Zh4heIWSzT5xBsGTSqXdF0LlrDwQ==
+"@sphereon/oid4vci-client@file:../OID4VCI/packages/client":
+  version "0.5.0"
   dependencies:
+    "@sphereon/oid4vci-common" "workspace:*"
     "@sphereon/ssi-types" "^0.9.0"
     cross-fetch "^3.1.5"
     debug "^4.3.4"
     uint8arrays "^3.1.1"
+
+"@sphereon/oid4vci-common@file:../OID4VCI/packages/common":
+  version "0.5.0"
+  dependencies:
+    "@sphereon/ssi-types" "^0.9.0"
+    cross-fetch "^3.1.6"
+    jwt-decode "^3.1.2"
+
+"@sphereon/oid4vci-common@workspace:*":
+  version "0.4.1-unstable.253"
+  resolved "https://registry.yarnpkg.com/@sphereon/oid4vci-common/-/oid4vci-common-0.4.1-unstable.253.tgz#66a8aff00dc7ff9c37f7a8b089e1f12a33299f19"
+  integrity sha512-16S/is08A/mo6kgKBtY9h5Uu/mCz07b3qygWjM6gxc5qpn/X2DMGrl73lFiQc2zS/pPJjBWAHEAg+J4MoXWTvw==
+  dependencies:
+    "@sphereon/ssi-types" "^0.9.0"
+    cross-fetch "^3.1.6"
+    jwt-decode "^3.1.2"
 
 "@sphereon/ssi-types@^0.9.0":
   version "0.9.0"
@@ -4528,6 +4543,13 @@ cross-fetch@^3.1.5:
   integrity sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==
   dependencies:
     node-fetch "2.6.7"
+
+cross-fetch@^3.1.6:
+  version "3.1.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.6.tgz#bae05aa31a4da760969756318feeee6e70f15d6c"
+  integrity sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==
+  dependencies:
+    node-fetch "^2.6.11"
 
 cross-spawn@^6.0.0:
   version "6.0.5"
@@ -8881,6 +8903,13 @@ node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.11:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.11.tgz#cde7fc71deef3131ef80a738919f999e6edfff25"
+  integrity sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==
   dependencies:
     whatwg-url "^5.0.0"
 


### PR DESCRIPTION
draft PR to update the openid4vci-client implementation to support Draft 11 of the openid4vci specification.

Currently there are some issues with the authorized code flow. Mainly the query parameters are not formatted correctly which should be fixed in the library we are using.

edit: fix for the authorization parameter issue: https://github.com/Sphereon-Opensource/OID4VCI/pull/50

Everything passes now (with my local build of the OIDC4VC library) so we just have to wait for an alpha release or stable.
