### PR TITLE
fix: encode tails url

### DIFF
--- a/packages/react-native/src/ReactNativeFileSystem.ts
+++ b/packages/react-native/src/ReactNativeFileSystem.ts
@@ -66,8 +66,11 @@ export class ReactNativeFileSystem implements FileSystem {
     // Make sure parent directories exist
     await RNFS.mkdir(getDirFromFilePath(path))
 
+    // Some characters in the URL might be invalid for
+    // the native os to handle. We need to encode the URL.
+    const encodedFromUrl = encodeURI(url)
     const { promise } = RNFS.downloadFile({
-      fromUrl: url,
+      fromUrl: encodedFromUrl,
       toFile: path,
     })
 


### PR DESCRIPTION
Some schema names can have characters that are not supported by URL loaders without being encoded. This PR fixes this issue by url encoding before passing the URL off to the loading mechanics. I tested this change agains the issue that reports the problem and it does fix the problem.

Fixes #1478
