### PR TITLE
fix: check if URL already encoded

### DIFF
--- a/packages/react-native/src/ReactNativeFileSystem.ts
+++ b/packages/react-native/src/ReactNativeFileSystem.ts
@@ -66,12 +66,7 @@ export class ReactNativeFileSystem implements FileSystem {
     // Make sure parent directories exist
     await RNFS.mkdir(getDirFromFilePath(path))
 
-    // Some characters in the URL might be invalid for
-    // the native os to handle. Only encode if necessary.
-    let fromUrl = url
-    if (url === decodeURI(url)) {
-      fromUrl = encodeURI(url)
-    }
+    const fromUrl = this.encodeUriIfRequired(url)
 
     const { promise } = RNFS.downloadFile({
       fromUrl,
@@ -95,5 +90,11 @@ export class ReactNativeFileSystem implements FileSystem {
         )
       }
     }
+  }
+
+  private encodeUriIfRequired(uri: string) {
+    // Some characters in the URL might be invalid for
+    // the native os to handle. Only encode if necessary.
+    return uri === decodeURI(uri) ? encodeURI(uri) : uri
   }
 }

--- a/packages/react-native/src/ReactNativeFileSystem.ts
+++ b/packages/react-native/src/ReactNativeFileSystem.ts
@@ -67,10 +67,14 @@ export class ReactNativeFileSystem implements FileSystem {
     await RNFS.mkdir(getDirFromFilePath(path))
 
     // Some characters in the URL might be invalid for
-    // the native os to handle. We need to encode the URL.
-    const encodedFromUrl = encodeURI(url)
+    // the native os to handle. Only encode if necessary.
+    let fromUrl = url
+    if (url === decodeURI(url)) {
+      fromUrl = encodeURI(url)
+    }
+
     const { promise } = RNFS.downloadFile({
-      fromUrl: encodedFromUrl,
+      fromUrl,
       toFile: path,
     })
 


### PR DESCRIPTION
Check to make sure an URL is not already encoded before encoding it. If this happens it will create an erronious URL.

Fixes #1484
