### PR TITLE
feat(anoncreds): allow automatic create link secret

### DIFF
--- a/packages/anoncreds/src/AnonCredsModule.ts
+++ b/packages/anoncreds/src/AnonCredsModule.ts
@@ -1,5 +1,5 @@
 import type { AnonCredsModuleConfigOptions } from './AnonCredsModuleConfig'
-import type { DependencyManager, Module, Update } from '@aries-framework/core'
+import type { DependencyManager, AgentContext, Module, Update } from '@aries-framework/core'
 
 import { AnonCredsApi } from './AnonCredsApi'
 import { AnonCredsModuleConfig } from './AnonCredsModuleConfig'
@@ -36,6 +36,20 @@ export class AnonCredsModule implements Module {
     dependencyManager.registerSingleton(AnonCredsCredentialDefinitionPrivateRepository)
     dependencyManager.registerSingleton(AnonCredsKeyCorrectnessProofRepository)
     dependencyManager.registerSingleton(AnonCredsLinkSecretRepository)
+  }
+
+  public async initalize(agentContext: AgentContext) {
+    if (this.config.createDefaultLinkSecret === false) {
+      return
+    }
+
+    const api = agentContext.dependencyManager.resolve(AnonCredsApi)
+    const linkSecretIds = await api.getLinkSecretIds()
+    if (linkSecretIds.length === 0) {
+      await api.createLinkSecret({
+        setAsDefault: true,
+      })
+    }
   }
 
   public updates = [

--- a/packages/anoncreds/src/AnonCredsModule.ts
+++ b/packages/anoncreds/src/AnonCredsModule.ts
@@ -39,9 +39,7 @@ export class AnonCredsModule implements Module {
   }
 
   public async initialize(agentContext: AgentContext): Promise<void> {
-    if (this.config.autoCreateLinkSecret === false) {
-      return
-    }
+    if (!this.config.autoCreateLinkSecret) return
 
     const anoncredsApi = agentContext.dependencyManager.resolve(AnonCredsApi)
     const linkSecretIds = await anoncredsApi.getLinkSecretIds()

--- a/packages/anoncreds/src/AnonCredsModule.ts
+++ b/packages/anoncreds/src/AnonCredsModule.ts
@@ -39,7 +39,7 @@ export class AnonCredsModule implements Module {
   }
 
   public async initalize(agentContext: AgentContext) {
-    if (this.config.createDefaultLinkSecret === false) {
+    if (this.config.autoCreateLinkSecret === false) {
       return
     }
 

--- a/packages/anoncreds/src/AnonCredsModule.ts
+++ b/packages/anoncreds/src/AnonCredsModule.ts
@@ -38,15 +38,15 @@ export class AnonCredsModule implements Module {
     dependencyManager.registerSingleton(AnonCredsLinkSecretRepository)
   }
 
-  public async initalize(agentContext: AgentContext) {
+  public async initialize(agentContext: AgentContext): Promise<void> {
     if (this.config.autoCreateLinkSecret === false) {
       return
     }
 
-    const api = agentContext.dependencyManager.resolve(AnonCredsApi)
-    const linkSecretIds = await api.getLinkSecretIds()
+    const anoncredsApi = agentContext.dependencyManager.resolve(AnonCredsApi)
+    const linkSecretIds = await anoncredsApi.getLinkSecretIds()
     if (linkSecretIds.length === 0) {
-      await api.createLinkSecret({
+      await anoncredsApi.createLinkSecret({
         setAsDefault: true,
       })
     }

--- a/packages/anoncreds/src/AnonCredsModuleConfig.ts
+++ b/packages/anoncreds/src/AnonCredsModuleConfig.ts
@@ -9,6 +9,12 @@ export interface AnonCredsModuleConfigOptions {
    * A list of AnonCreds registries to make available to the AnonCreds module.
    */
   registries: [AnonCredsRegistry, ...AnonCredsRegistry[]]
+
+  /**
+   * Create a default link secret on module initialization.
+   * @defaultValue true
+   */
+  createDefaultLinkSecret?: boolean
 }
 
 /**
@@ -24,5 +30,9 @@ export class AnonCredsModuleConfig {
   /** See {@link AnonCredsModuleConfigOptions.registries} */
   public get registries() {
     return this.options.registries
+  }
+
+  public get createDefaultLinkSecret() {
+    return this.options.createDefaultLinkSecret ?? true
   }
 }

--- a/packages/anoncreds/src/AnonCredsModuleConfig.ts
+++ b/packages/anoncreds/src/AnonCredsModuleConfig.ts
@@ -32,6 +32,7 @@ export class AnonCredsModuleConfig {
     return this.options.registries
   }
 
+  /** See {@link AnonCredsModuleConfigOptions.autoCreateLinkSecret} */
   public get autoCreateLinkSecret() {
     return this.options.autoCreateLinkSecret ?? true
   }

--- a/packages/anoncreds/src/AnonCredsModuleConfig.ts
+++ b/packages/anoncreds/src/AnonCredsModuleConfig.ts
@@ -14,7 +14,7 @@ export interface AnonCredsModuleConfigOptions {
    * Create a default link secret on module initialization.
    * @defaultValue true
    */
-  createDefaultLinkSecret?: boolean
+  autoCreateLinkSecret?: boolean
 }
 
 /**
@@ -32,7 +32,7 @@ export class AnonCredsModuleConfig {
     return this.options.registries
   }
 
-  public get createDefaultLinkSecret() {
-    return this.options.createDefaultLinkSecret ?? true
+  public get autoCreateLinkSecret() {
+    return this.options.autoCreateLinkSecret ?? true
   }
 }


### PR DESCRIPTION
Automatically create a default link secret for AnonCreds to make it more intuitive how setup and Agent to receive credential offers.

I don't know how to write a test for this so I created [a script](https://gist.github.com/jleach/8a956605216ee197ed9b1dbb1fd8d85a) that can be run to validate it creates a link secret and calls initialize. 

Fixed #1490
