### PR TITLE
fix(askar): in memory wallet creation

### DIFF
--- a/packages/askar/src/wallet/AskarWallet.ts
+++ b/packages/askar/src/wallet/AskarWallet.ts
@@ -240,7 +240,11 @@ export class AskarWallet implements Wallet {
 
       this.walletConfig = walletConfig
     } catch (error) {
-      if (isAskarError(error) && error.code === AskarErrorCode.NotFound) {
+      if (
+        isAskarError(error) &&
+        (error.code === AskarErrorCode.NotFound ||
+          (error.code === AskarErrorCode.Backend && walletConfig.storage?.inMemory))
+      ) {
         const errorMessage = `Wallet '${walletConfig.id}' not found`
         this.logger.debug(errorMessage)
 

--- a/packages/askar/tests/askar-inmemory.e2e.test.ts
+++ b/packages/askar/tests/askar-inmemory.e2e.test.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import type { SubjectMessage } from '../../../tests/transport/SubjectInboundTransport'
-import type { AskarWalletPostgresStorageConfig } from '../src/wallet'
 
 import { Agent } from '@aries-framework/core'
 import { Subject } from 'rxjs'
@@ -9,28 +8,25 @@ import { describeRunInNodeVersion } from '../../../tests/runInVersion'
 import { SubjectInboundTransport } from '../../../tests/transport/SubjectInboundTransport'
 import { SubjectOutboundTransport } from '../../../tests/transport/SubjectOutboundTransport'
 
-import { e2eTest, getPostgresAgentOptions } from './helpers'
+import { e2eTest, getSqliteAgentOptions } from './helpers'
 
-const storageConfig: AskarWalletPostgresStorageConfig = {
-  type: 'postgres',
-  config: {
-    host: 'localhost:5432',
+const aliceInMemoryAgentOptions = getSqliteAgentOptions(
+  'AgentsAlice',
+  {
+    endpoints: ['rxjs:alice'],
   },
-  credentials: {
-    account: 'postgres',
-    password: 'postgres',
+  true
+)
+const bobInMemoryAgentOptions = getSqliteAgentOptions(
+  'AgentsBob',
+  {
+    endpoints: ['rxjs:bob'],
   },
-}
-
-const alicePostgresAgentOptions = getPostgresAgentOptions('AgentsAlice', storageConfig, {
-  endpoints: ['rxjs:alice'],
-})
-const bobPostgresAgentOptions = getPostgresAgentOptions('AgentsBob', storageConfig, {
-  endpoints: ['rxjs:bob'],
-})
+  true
+)
 
 // FIXME: Re-include in tests when Askar NodeJS wrapper performance is improved
-describeRunInNodeVersion([18], 'Askar Postgres agents', () => {
+describeRunInNodeVersion([18], 'Askar In Memory agents', () => {
   let aliceAgent: Agent
   let bobAgent: Agent
 
@@ -46,7 +42,7 @@ describeRunInNodeVersion([18], 'Askar Postgres agents', () => {
     }
   })
 
-  test('Postgres Askar wallets E2E test', async () => {
+  test('In memory Askar wallets E2E test', async () => {
     const aliceMessages = new Subject<SubjectMessage>()
     const bobMessages = new Subject<SubjectMessage>()
 
@@ -55,12 +51,12 @@ describeRunInNodeVersion([18], 'Askar Postgres agents', () => {
       'rxjs:bob': bobMessages,
     }
 
-    aliceAgent = new Agent(alicePostgresAgentOptions)
+    aliceAgent = new Agent(aliceInMemoryAgentOptions)
     aliceAgent.registerInboundTransport(new SubjectInboundTransport(aliceMessages))
     aliceAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
     await aliceAgent.initialize()
 
-    bobAgent = new Agent(bobPostgresAgentOptions)
+    bobAgent = new Agent(bobInMemoryAgentOptions)
     bobAgent.registerInboundTransport(new SubjectInboundTransport(bobMessages))
     bobAgent.registerOutboundTransport(new SubjectOutboundTransport(subjectMap))
     await bobAgent.initialize()

--- a/packages/askar/tests/helpers.ts
+++ b/packages/askar/tests/helpers.ts
@@ -1,11 +1,12 @@
 import type { AskarWalletPostgresStorageConfig } from '../src/wallet'
-import type { InitConfig } from '@aries-framework/core'
+import type { Agent, InitConfig } from '@aries-framework/core'
 
-import { ConnectionsModule, LogLevel, utils } from '@aries-framework/core'
+import { ConnectionsModule, HandshakeProtocol, LogLevel, utils } from '@aries-framework/core'
 import { ariesAskar } from '@hyperledger/aries-askar-nodejs'
 import { registerAriesAskar } from '@hyperledger/aries-askar-shared'
 import path from 'path'
 
+import { waitForBasicMessage } from '../../core/tests/helpers'
 import { TestLogger } from '../../core/tests/logger'
 import { agentDependencies } from '../../node/src'
 import { AskarModule } from '../src/AskarModule'
@@ -54,14 +55,14 @@ export function getPostgresAgentOptions(
   } as const
 }
 
-export function getSqliteAgentOptions(name: string, extraConfig: Partial<InitConfig> = {}) {
+export function getSqliteAgentOptions(name: string, extraConfig: Partial<InitConfig> = {}, inMemory?: boolean) {
   const random = utils.uuid().slice(0, 4)
   const config: InitConfig = {
     label: `SQLiteAgent: ${name} - ${random}`,
     walletConfig: {
       id: `SQLiteWallet${name} - ${random}`,
       key: `Key${name}`,
-      storage: { type: 'sqlite' },
+      storage: { type: 'sqlite', inMemory },
     },
     autoUpdateStorageOnStartup: false,
     logger: new TestLogger(LogLevel.off, name),
@@ -77,4 +78,42 @@ export function getSqliteAgentOptions(name: string, extraConfig: Partial<InitCon
       }),
     },
   } as const
+}
+
+/**
+ * Basic E2E test: connect two agents, send a basic message and verify it they can be re initialized
+ * @param senderAgent
+ * @param receiverAgent
+ */
+export async function e2eTest(senderAgent: Agent, receiverAgent: Agent) {
+  const senderReceiverOutOfBandRecord = await senderAgent.oob.createInvitation({
+    handshakeProtocols: [HandshakeProtocol.Connections],
+  })
+
+  const { connectionRecord: bobConnectionAtReceiversender } = await receiverAgent.oob.receiveInvitation(
+    senderReceiverOutOfBandRecord.outOfBandInvitation
+  )
+  if (!bobConnectionAtReceiversender) throw new Error('Connection not created')
+
+  await receiverAgent.connections.returnWhenIsConnected(bobConnectionAtReceiversender.id)
+
+  const [senderConnectionAtReceiver] = await senderAgent.connections.findAllByOutOfBandId(
+    senderReceiverOutOfBandRecord.id
+  )
+  const senderConnection = await senderAgent.connections.returnWhenIsConnected(senderConnectionAtReceiver.id)
+
+  const message = 'hello, world'
+  await senderAgent.basicMessages.sendMessage(senderConnection.id, message)
+
+  const basicMessage = await waitForBasicMessage(receiverAgent, {
+    content: message,
+  })
+
+  expect(basicMessage.content).toBe(message)
+
+  expect(senderAgent.isInitialized).toBe(true)
+  await senderAgent.shutdown()
+  expect(senderAgent.isInitialized).toBe(false)
+  await senderAgent.initialize()
+  expect(senderAgent.isInitialized).toBe(true)
 }


### PR DESCRIPTION
Quick fix to allow the creation of an in-memory wallet (for test purposes). Previously, the parameter was supported but, due to a particular error thrown by `@hyperledger/askar-shared` it was not working.