### PR TITLE
fix(samples): mediator wallet and http transport

### DIFF
--- a/packages/node/src/transport/HttpInboundTransport.ts
+++ b/packages/node/src/transport/HttpInboundTransport.ts
@@ -24,18 +24,6 @@ export class HttpInboundTransport implements InboundTransport {
     this.app = app ?? express()
     this.path = path ?? '/'
 
-    this.app.use((req, res, next) => {
-      const contentType = req.headers['content-type']
-
-      if (!contentType || !supportedContentTypes.includes(contentType)) {
-        return res
-          .status(415)
-          .send('Unsupported content-type. Supported content-types are: ' + supportedContentTypes.join(', '))
-      }
-
-      return next()
-    })
-
     this.app.use(text({ type: supportedContentTypes, limit: '5mb' }))
   }
 
@@ -48,6 +36,14 @@ export class HttpInboundTransport implements InboundTransport {
     })
 
     this.app.post(this.path, async (req, res) => {
+      const contentType = req.headers['content-type']
+
+      if (!contentType || !supportedContentTypes.includes(contentType)) {
+        return res
+          .status(415)
+          .send('Unsupported content-type. Supported content-types are: ' + supportedContentTypes.join(', '))
+      }
+
       const session = new HttpTransportSession(utils.uuid(), req, res)
       try {
         const message = req.body

--- a/samples/mediator.ts
+++ b/samples/mediator.ts
@@ -16,6 +16,7 @@ import type { InitConfig } from '@aries-framework/core'
 import type { Socket } from 'net'
 
 import express from 'express'
+import * as indySdk from 'indy-sdk'
 import { Server } from 'ws'
 
 import { TestLogger } from '../packages/core/tests/logger'
@@ -29,6 +30,7 @@ import {
   LogLevel,
   WsOutboundTransport,
 } from '@aries-framework/core'
+import { IndySdkModule } from '@aries-framework/indy-sdk'
 import { HttpInboundTransport, agentDependencies, WsInboundTransport } from '@aries-framework/node'
 
 const port = process.env.AGENT_PORT ? Number(process.env.AGENT_PORT) : 3001
@@ -58,6 +60,7 @@ const agent = new Agent({
   config: agentConfig,
   dependencies: agentDependencies,
   modules: {
+    indySdk: new IndySdkModule({ indySdk }),
     mediator: new MediatorModule({
       autoAcceptMediationRequests: true,
     }),


### PR DESCRIPTION
Adds `IndySdkModule` to `Agent` modules in order to allow it to have a default Wallet and Storage implementation (it could be Askar once we solve the performance issue for node <18 and/or drop support for it).

In `HttpInboundTransport`, It also moves content-type validation to the specific endpoint rather than the whole HTTP server. This is needed to allow using an invitation endpoint.