### PR TITLE
feat: support askar profiles for multi-tenancy

### DIFF
--- a/packages/askar/src/AskarModule.ts
+++ b/packages/askar/src/AskarModule.ts
@@ -1,11 +1,13 @@
 import type { AskarModuleConfigOptions } from './AskarModuleConfig'
-import type { DependencyManager, Module } from '@aries-framework/core'
+import type { AgentContext, DependencyManager, Module } from '@aries-framework/core'
 
 import { AgentConfig, AriesFrameworkError, InjectionSymbols } from '@aries-framework/core'
+import { Store } from '@hyperledger/aries-askar-shared'
 
-import { AskarModuleConfig } from './AskarModuleConfig'
+import { AskarMultiWalletDatabaseScheme, AskarModuleConfig } from './AskarModuleConfig'
 import { AskarStorageService } from './storage'
-import { AskarWallet } from './wallet'
+import { assertAskarWallet } from './utils/assertAskarWallet'
+import { AskarProfileWallet, AskarWallet } from './wallet'
 
 export class AskarModule implements Module {
   public readonly config: AskarModuleConfig
@@ -28,12 +30,45 @@ export class AskarModule implements Module {
       throw new AriesFrameworkError('There is an instance of Wallet already registered')
     } else {
       dependencyManager.registerContextScoped(InjectionSymbols.Wallet, AskarWallet)
+
+      // If the multiWalletDatabaseScheme is set to ProfilePerWallet, we want to register the AskarProfileWallet
+      if (this.config.multiWalletDatabaseScheme === AskarMultiWalletDatabaseScheme.ProfilePerWallet) {
+        dependencyManager.registerContextScoped(AskarProfileWallet)
+      }
     }
 
     if (dependencyManager.isRegistered(InjectionSymbols.StorageService)) {
       throw new AriesFrameworkError('There is an instance of StorageService already registered')
     } else {
       dependencyManager.registerSingleton(InjectionSymbols.StorageService, AskarStorageService)
+    }
+  }
+
+  public async initialize(agentContext: AgentContext): Promise<void> {
+    // We MUST use an askar wallet here
+    assertAskarWallet(agentContext.wallet)
+
+    const wallet = agentContext.wallet
+
+    // Register the Askar store instance on the dependency manager
+    // This allows it to be re-used for tenants
+    agentContext.dependencyManager.registerInstance(Store, agentContext.wallet.store)
+
+    // If the multiWalletDatabaseScheme is set to ProfilePerWallet, we want to register the AskarProfileWallet
+    // and return that as the wallet for all tenants, but not for the main agent, that should use the AskarWallet
+    if (this.config.multiWalletDatabaseScheme === AskarMultiWalletDatabaseScheme.ProfilePerWallet) {
+      agentContext.dependencyManager.container.register(InjectionSymbols.Wallet, {
+        useFactory: (container) => {
+          // If the container is the same as the root dependency manager container
+          // it means we are in the main agent, and we should use the root wallet
+          if (container === agentContext.dependencyManager.container) {
+            return wallet
+          }
+
+          // Otherwise we want to return the AskarProfileWallet
+          return container.resolve(AskarProfileWallet)
+        },
+      })
     }
   }
 }

--- a/packages/askar/src/AskarModuleConfig.ts
+++ b/packages/askar/src/AskarModuleConfig.ts
@@ -1,5 +1,17 @@
 import type { AriesAskar } from '@hyperledger/aries-askar-shared'
 
+export enum AskarMultiWalletDatabaseScheme {
+  /**
+   * Each wallet get its own database and uses a separate store.
+   */
+  DatabasePerWallet = 'DatabasePerWallet',
+
+  /**
+   * All wallets are stored in a single database, but each wallet uses a separate profile.
+   */
+  ProfilePerWallet = 'ProfilePerWallet',
+}
+
 export interface AskarModuleConfigOptions {
   /**
    *
@@ -36,6 +48,16 @@ export interface AskarModuleConfigOptions {
    * ```
    */
   ariesAskar: AriesAskar
+
+  /**
+   * Determine the strategy for storing wallets if multiple wallets are used in a single agent.
+   * This is mostly the case in multi-tenancy, and determines whether each tenant will get a separate
+   * database, or whether all wallets will be stored in a single database, using a different profile
+   * for each wallet.
+   *
+   * @default {@link AskarMultiWalletDatabaseScheme.DatabasePerWallet} (for backwards compatibility)
+   */
+  multiWalletDatabaseScheme?: AskarMultiWalletDatabaseScheme
 }
 
 /**
@@ -48,7 +70,13 @@ export class AskarModuleConfig {
     this.options = options
   }
 
+  /** See {@link AskarModuleConfigOptions.ariesAskar} */
   public get ariesAskar() {
     return this.options.ariesAskar
+  }
+
+  /** See {@link AskarModuleConfigOptions.multiWalletDatabaseScheme} */
+  public get multiWalletDatabaseScheme() {
+    return this.options.multiWalletDatabaseScheme ?? AskarMultiWalletDatabaseScheme.DatabasePerWallet
   }
 }

--- a/packages/askar/src/index.ts
+++ b/packages/askar/src/index.ts
@@ -4,6 +4,7 @@ export {
   AskarWalletPostgresStorageConfig,
   AskarWalletPostgresConfig,
   AskarWalletPostgresCredentials,
+  AskarProfileWallet,
 } from './wallet'
 
 // Storage
@@ -11,3 +12,4 @@ export { AskarStorageService } from './storage'
 
 // Module
 export { AskarModule } from './AskarModule'
+export { AskarModuleConfigOptions, AskarMultiWalletDatabaseScheme } from './AskarModuleConfig'

--- a/packages/askar/src/storage/AskarStorageService.ts
+++ b/packages/askar/src/storage/AskarStorageService.ts
@@ -140,15 +140,16 @@ export class AskarStorageService<T extends BaseRecord> implements StorageService
     recordClass: BaseRecordConstructor<T>,
     query: Query<T>
   ): Promise<T[]> {
-    assertAskarWallet(agentContext.wallet)
-    const store = agentContext.wallet.store
+    const wallet = agentContext.wallet
+    assertAskarWallet(wallet)
 
     const askarQuery = askarQueryFromSearchQuery(query)
 
     const scan = new Scan({
       category: recordClass.type,
-      store,
+      store: wallet.store,
       tagFilter: askarQuery,
+      profile: wallet.profile,
     })
 
     const instances = []

--- a/packages/askar/src/utils/assertAskarWallet.ts
+++ b/packages/askar/src/utils/assertAskarWallet.ts
@@ -2,12 +2,14 @@ import type { Wallet } from '@aries-framework/core'
 
 import { AriesFrameworkError } from '@aries-framework/core'
 
-import { AskarWallet } from '../wallet/AskarWallet'
+import { AskarWallet, AskarProfileWallet } from '../wallet'
 
-export function assertAskarWallet(wallet: Wallet): asserts wallet is AskarWallet {
-  if (!(wallet instanceof AskarWallet)) {
+export function assertAskarWallet(wallet: Wallet): asserts wallet is AskarProfileWallet | AskarWallet {
+  if (!(wallet instanceof AskarProfileWallet) && !(wallet instanceof AskarWallet)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const walletClassName = (wallet as any).constructor?.name ?? 'unknown'
-    throw new AriesFrameworkError(`Expected wallet to be instance of AskarWallet, found ${walletClassName}`)
+    throw new AriesFrameworkError(
+      `Expected wallet to be instance of AskarProfileWallet or AskarWallet, found ${walletClassName}`
+    )
   }
 }

--- a/packages/askar/src/wallet/AskarBaseWallet.ts
+++ b/packages/askar/src/wallet/AskarBaseWallet.ts
@@ -445,9 +445,9 @@ export abstract class AskarBaseWallet implements Wallet {
     try {
       cek = AskarKey.fromSecretBytes({ algorithm: KeyAlgs.Chacha20C20P, secretKey: payloadKey })
       const message = cek.aeadDecrypt({
-        ciphertext: TypedArrayEncoder.fromBase64(messagePackage.ciphertext as any),
-        nonce: TypedArrayEncoder.fromBase64(messagePackage.iv as any),
-        tag: TypedArrayEncoder.fromBase64(messagePackage.tag as any),
+        ciphertext: TypedArrayEncoder.fromBase64(messagePackage.ciphertext),
+        nonce: TypedArrayEncoder.fromBase64(messagePackage.iv),
+        tag: TypedArrayEncoder.fromBase64(messagePackage.tag),
         aad: TypedArrayEncoder.fromString(messagePackage.protected),
       })
       return {

--- a/packages/askar/src/wallet/AskarBaseWallet.ts
+++ b/packages/askar/src/wallet/AskarBaseWallet.ts
@@ -1,0 +1,515 @@
+import type {
+  EncryptedMessage,
+  WalletConfig,
+  WalletCreateKeyOptions,
+  WalletSignOptions,
+  UnpackedMessageContext,
+  WalletVerifyOptions,
+  Wallet,
+  WalletConfigRekey,
+  KeyPair,
+  WalletExportImportConfig,
+  Logger,
+  SigningProviderRegistry,
+} from '@aries-framework/core'
+import type { KeyEntryObject, Session } from '@hyperledger/aries-askar-shared'
+
+import {
+  WalletKeyExistsError,
+  isValidSeed,
+  isValidPrivateKey,
+  JsonTransformer,
+  JsonEncoder,
+  KeyType,
+  Buffer,
+  AriesFrameworkError,
+  WalletError,
+  Key,
+  TypedArrayEncoder,
+} from '@aries-framework/core'
+import { KeyAlgs, CryptoBox, Store, Key as AskarKey, keyAlgFromString } from '@hyperledger/aries-askar-shared'
+// eslint-disable-next-line import/order
+import BigNumber from 'bn.js'
+
+const isError = (error: unknown): error is Error => error instanceof Error
+
+import { AskarErrorCode, isAskarError, isKeyTypeSupportedByAskar, keyTypesSupportedByAskar } from '../utils'
+
+import { JweEnvelope, JweRecipient } from './JweEnvelope'
+
+export abstract class AskarBaseWallet implements Wallet {
+  protected _session?: Session
+
+  protected logger: Logger
+  protected signingKeyProviderRegistry: SigningProviderRegistry
+
+  public constructor(logger: Logger, signingKeyProviderRegistry: SigningProviderRegistry) {
+    this.logger = logger
+    this.signingKeyProviderRegistry = signingKeyProviderRegistry
+  }
+
+  /**
+   * Abstract methods that need to be implemented by subclasses
+   */
+  public abstract isInitialized: boolean
+  public abstract isProvisioned: boolean
+  public abstract create(walletConfig: WalletConfig): Promise<void>
+  public abstract createAndOpen(walletConfig: WalletConfig): Promise<void>
+  public abstract open(walletConfig: WalletConfig): Promise<void>
+  public abstract rotateKey(walletConfig: WalletConfigRekey): Promise<void>
+  public abstract close(): Promise<void>
+  public abstract delete(): Promise<void>
+  public abstract export(exportConfig: WalletExportImportConfig): Promise<void>
+  public abstract import(walletConfig: WalletConfig, importConfig: WalletExportImportConfig): Promise<void>
+  public abstract dispose(): void | Promise<void>
+  public abstract profile: string
+
+  public get session() {
+    if (!this._session) {
+      throw new AriesFrameworkError('No Wallet Session is opened')
+    }
+
+    return this._session
+  }
+
+  public get supportedKeyTypes() {
+    const signingKeyProviderSupportedKeyTypes = this.signingKeyProviderRegistry.supportedKeyTypes
+
+    return Array.from(new Set([...keyTypesSupportedByAskar, ...signingKeyProviderSupportedKeyTypes]))
+  }
+
+  /**
+   * Create a key with an optional seed and keyType.
+   * The keypair is also automatically stored in the wallet afterwards
+   */
+  public async createKey({ seed, privateKey, keyType }: WalletCreateKeyOptions): Promise<Key> {
+    try {
+      if (seed && privateKey) {
+        throw new WalletError('Only one of seed and privateKey can be set')
+      }
+
+      if (seed && !isValidSeed(seed, keyType)) {
+        throw new WalletError('Invalid seed provided')
+      }
+
+      if (privateKey && !isValidPrivateKey(privateKey, keyType)) {
+        throw new WalletError('Invalid private key provided')
+      }
+
+      if (isKeyTypeSupportedByAskar(keyType)) {
+        const algorithm = keyAlgFromString(keyType)
+
+        // Create key
+        let key: AskarKey | undefined
+        try {
+          const key = privateKey
+            ? AskarKey.fromSecretBytes({ secretKey: privateKey, algorithm })
+            : seed
+            ? AskarKey.fromSeed({ seed, algorithm })
+            : AskarKey.generate(algorithm)
+
+          const keyPublicBytes = key.publicBytes
+          // Store key
+          await this.session.insertKey({ key, name: TypedArrayEncoder.toBase58(keyPublicBytes) })
+          key.handle.free()
+          return Key.fromPublicKey(keyPublicBytes, keyType)
+        } catch (error) {
+          key?.handle.free()
+          // Handle case where key already exists
+          if (isAskarError(error, AskarErrorCode.Duplicate)) {
+            throw new WalletKeyExistsError('Key already exists')
+          }
+
+          // Otherwise re-throw error
+          throw error
+        }
+      } else {
+        // Check if there is a signing key provider for the specified key type.
+        if (this.signingKeyProviderRegistry.hasProviderForKeyType(keyType)) {
+          const signingKeyProvider = this.signingKeyProviderRegistry.getProviderForKeyType(keyType)
+
+          const keyPair = await signingKeyProvider.createKeyPair({ seed, privateKey })
+          await this.storeKeyPair(keyPair)
+          return Key.fromPublicKeyBase58(keyPair.publicKeyBase58, keyType)
+        }
+        throw new WalletError(`Unsupported key type: '${keyType}'`)
+      }
+    } catch (error) {
+      // If already instance of `WalletError`, re-throw
+      if (error instanceof WalletError) throw error
+
+      if (!isError(error)) {
+        throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })
+      }
+      throw new WalletError(`Error creating key with key type '${keyType}': ${error.message}`, { cause: error })
+    }
+  }
+
+  /**
+   * sign a Buffer with an instance of a Key class
+   *
+   * @param data Buffer The data that needs to be signed
+   * @param key Key The key that is used to sign the data
+   *
+   * @returns A signature for the data
+   */
+  public async sign({ data, key }: WalletSignOptions): Promise<Buffer> {
+    let keyEntry: KeyEntryObject | null | undefined
+    try {
+      if (isKeyTypeSupportedByAskar(key.keyType)) {
+        if (!TypedArrayEncoder.isTypedArray(data)) {
+          throw new WalletError(`Currently not supporting signing of multiple messages`)
+        }
+        keyEntry = await this.session.fetchKey({ name: key.publicKeyBase58 })
+
+        if (!keyEntry) {
+          throw new WalletError('Key entry not found')
+        }
+
+        const signed = keyEntry.key.signMessage({ message: data as Buffer })
+
+        keyEntry.key.handle.free()
+
+        return Buffer.from(signed)
+      } else {
+        // Check if there is a signing key provider for the specified key type.
+        if (this.signingKeyProviderRegistry.hasProviderForKeyType(key.keyType)) {
+          const signingKeyProvider = this.signingKeyProviderRegistry.getProviderForKeyType(key.keyType)
+
+          const keyPair = await this.retrieveKeyPair(key.publicKeyBase58)
+          const signed = await signingKeyProvider.sign({
+            data,
+            privateKeyBase58: keyPair.privateKeyBase58,
+            publicKeyBase58: key.publicKeyBase58,
+          })
+
+          return signed
+        }
+        throw new WalletError(`Unsupported keyType: ${key.keyType}`)
+      }
+    } catch (error) {
+      keyEntry?.key.handle.free()
+      if (!isError(error)) {
+        throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })
+      }
+      throw new WalletError(`Error signing data with verkey ${key.publicKeyBase58}. ${error.message}`, { cause: error })
+    }
+  }
+
+  /**
+   * Verify the signature with the data and the used key
+   *
+   * @param data Buffer The data that has to be confirmed to be signed
+   * @param key Key The key that was used in the signing process
+   * @param signature Buffer The signature that was created by the signing process
+   *
+   * @returns A boolean whether the signature was created with the supplied data and key
+   *
+   * @throws {WalletError} When it could not do the verification
+   * @throws {WalletError} When an unsupported keytype is used
+   */
+  public async verify({ data, key, signature }: WalletVerifyOptions): Promise<boolean> {
+    let askarKey: AskarKey | undefined
+    try {
+      if (isKeyTypeSupportedByAskar(key.keyType)) {
+        if (!TypedArrayEncoder.isTypedArray(data)) {
+          throw new WalletError(`Currently not supporting verification of multiple messages`)
+        }
+
+        const askarKey = AskarKey.fromPublicBytes({
+          algorithm: keyAlgFromString(key.keyType),
+          publicKey: key.publicKey,
+        })
+        const verified = askarKey.verifySignature({ message: data as Buffer, signature })
+        askarKey.handle.free()
+        return verified
+      } else {
+        // Check if there is a signing key provider for the specified key type.
+        if (this.signingKeyProviderRegistry.hasProviderForKeyType(key.keyType)) {
+          const signingKeyProvider = this.signingKeyProviderRegistry.getProviderForKeyType(key.keyType)
+
+          const signed = await signingKeyProvider.verify({
+            data,
+            signature,
+            publicKeyBase58: key.publicKeyBase58,
+          })
+
+          return signed
+        }
+        throw new WalletError(`Unsupported keyType: ${key.keyType}`)
+      }
+    } catch (error) {
+      askarKey?.handle.free()
+      if (!isError(error)) {
+        throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })
+      }
+      throw new WalletError(`Error verifying signature of data signed with verkey ${key.publicKeyBase58}`, {
+        cause: error,
+      })
+    }
+  }
+
+  /**
+   * Pack a message using DIDComm V1 algorithm
+   *
+   * @param payload message to send
+   * @param recipientKeys array containing recipient keys in base58
+   * @param senderVerkey sender key in base58
+   * @returns JWE Envelope to send
+   */
+  public async pack(
+    payload: Record<string, unknown>,
+    recipientKeys: string[],
+    senderVerkey?: string // in base58
+  ): Promise<EncryptedMessage> {
+    let cek: AskarKey | undefined
+    let senderKey: KeyEntryObject | null | undefined
+    let senderExchangeKey: AskarKey | undefined
+
+    try {
+      cek = AskarKey.generate(KeyAlgs.Chacha20C20P)
+
+      senderKey = senderVerkey ? await this.session.fetchKey({ name: senderVerkey }) : undefined
+      if (senderVerkey && !senderKey) {
+        throw new WalletError(`Unable to pack message. Sender key ${senderVerkey} not found in wallet.`)
+      }
+
+      senderExchangeKey = senderKey ? senderKey.key.convertkey({ algorithm: KeyAlgs.X25519 }) : undefined
+
+      const recipients: JweRecipient[] = []
+
+      for (const recipientKey of recipientKeys) {
+        let targetExchangeKey: AskarKey | undefined
+        try {
+          targetExchangeKey = AskarKey.fromPublicBytes({
+            publicKey: Key.fromPublicKeyBase58(recipientKey, KeyType.Ed25519).publicKey,
+            algorithm: KeyAlgs.Ed25519,
+          }).convertkey({ algorithm: KeyAlgs.X25519 })
+
+          if (senderVerkey && senderExchangeKey) {
+            const encryptedSender = CryptoBox.seal({
+              recipientKey: targetExchangeKey,
+              message: Buffer.from(senderVerkey),
+            })
+            const nonce = CryptoBox.randomNonce()
+            const encryptedCek = CryptoBox.cryptoBox({
+              recipientKey: targetExchangeKey,
+              senderKey: senderExchangeKey,
+              message: cek.secretBytes,
+              nonce,
+            })
+
+            recipients.push(
+              new JweRecipient({
+                encryptedKey: encryptedCek,
+                header: {
+                  kid: recipientKey,
+                  sender: TypedArrayEncoder.toBase64URL(encryptedSender),
+                  iv: TypedArrayEncoder.toBase64URL(nonce),
+                },
+              })
+            )
+          } else {
+            const encryptedCek = CryptoBox.seal({
+              recipientKey: targetExchangeKey,
+              message: cek.secretBytes,
+            })
+            recipients.push(
+              new JweRecipient({
+                encryptedKey: encryptedCek,
+                header: {
+                  kid: recipientKey,
+                },
+              })
+            )
+          }
+        } finally {
+          targetExchangeKey?.handle.free()
+        }
+      }
+
+      const protectedJson = {
+        enc: 'xchacha20poly1305_ietf',
+        typ: 'JWM/1.0',
+        alg: senderVerkey ? 'Authcrypt' : 'Anoncrypt',
+        recipients: recipients.map((item) => JsonTransformer.toJSON(item)),
+      }
+
+      const { ciphertext, tag, nonce } = cek.aeadEncrypt({
+        message: Buffer.from(JSON.stringify(payload)),
+        aad: Buffer.from(JsonEncoder.toBase64URL(protectedJson)),
+      }).parts
+
+      const envelope = new JweEnvelope({
+        ciphertext: TypedArrayEncoder.toBase64URL(ciphertext),
+        iv: TypedArrayEncoder.toBase64URL(nonce),
+        protected: JsonEncoder.toBase64URL(protectedJson),
+        tag: TypedArrayEncoder.toBase64URL(tag),
+      }).toJson()
+
+      return envelope as EncryptedMessage
+    } finally {
+      cek?.handle.free()
+      senderKey?.key.handle.free()
+      senderExchangeKey?.handle.free()
+    }
+  }
+
+  /**
+   * Unpacks a JWE Envelope coded using DIDComm V1 algorithm
+   *
+   * @param messagePackage JWE Envelope
+   * @returns UnpackedMessageContext with plain text message, sender key and recipient key
+   */
+  public async unpack(messagePackage: EncryptedMessage): Promise<UnpackedMessageContext> {
+    const protectedJson = JsonEncoder.fromBase64(messagePackage.protected)
+
+    const alg = protectedJson.alg
+    if (!['Anoncrypt', 'Authcrypt'].includes(alg)) {
+      throw new WalletError(`Unsupported pack algorithm: ${alg}`)
+    }
+
+    const recipients = []
+
+    for (const recip of protectedJson.recipients) {
+      const kid = recip.header.kid
+      if (!kid) {
+        throw new WalletError('Blank recipient key')
+      }
+      const sender = recip.header.sender ? TypedArrayEncoder.fromBase64(recip.header.sender) : undefined
+      const iv = recip.header.iv ? TypedArrayEncoder.fromBase64(recip.header.iv) : undefined
+      if (sender && !iv) {
+        throw new WalletError('Missing IV')
+      } else if (!sender && iv) {
+        throw new WalletError('Unexpected IV')
+      }
+      recipients.push({
+        kid,
+        sender,
+        iv,
+        encrypted_key: TypedArrayEncoder.fromBase64(recip.encrypted_key),
+      })
+    }
+
+    let payloadKey, senderKey, recipientKey
+
+    for (const recipient of recipients) {
+      let recipientKeyEntry: KeyEntryObject | null | undefined
+      let sender_x: AskarKey | undefined
+      let recip_x: AskarKey | undefined
+
+      try {
+        recipientKeyEntry = await this.session.fetchKey({ name: recipient.kid })
+        if (recipientKeyEntry) {
+          const recip_x = recipientKeyEntry.key.convertkey({ algorithm: KeyAlgs.X25519 })
+          recipientKey = recipient.kid
+
+          if (recipient.sender && recipient.iv) {
+            senderKey = TypedArrayEncoder.toUtf8String(
+              CryptoBox.sealOpen({
+                recipientKey: recip_x,
+                ciphertext: recipient.sender,
+              })
+            )
+            const sender_x = AskarKey.fromPublicBytes({
+              algorithm: KeyAlgs.Ed25519,
+              publicKey: TypedArrayEncoder.fromBase58(senderKey),
+            }).convertkey({ algorithm: KeyAlgs.X25519 })
+
+            payloadKey = CryptoBox.open({
+              recipientKey: recip_x,
+              senderKey: sender_x,
+              message: recipient.encrypted_key,
+              nonce: recipient.iv,
+            })
+          } else {
+            payloadKey = CryptoBox.sealOpen({ ciphertext: recipient.encrypted_key, recipientKey: recip_x })
+          }
+          break
+        }
+      } finally {
+        recipientKeyEntry?.key.handle.free()
+        sender_x?.handle.free()
+        recip_x?.handle.free()
+      }
+    }
+    if (!payloadKey) {
+      throw new WalletError('No corresponding recipient key found')
+    }
+
+    if (!senderKey && alg === 'Authcrypt') {
+      throw new WalletError('Sender public key not provided for Authcrypt')
+    }
+
+    let cek: AskarKey | undefined
+    try {
+      cek = AskarKey.fromSecretBytes({ algorithm: KeyAlgs.Chacha20C20P, secretKey: payloadKey })
+      const message = cek.aeadDecrypt({
+        ciphertext: TypedArrayEncoder.fromBase64(messagePackage.ciphertext as any),
+        nonce: TypedArrayEncoder.fromBase64(messagePackage.iv as any),
+        tag: TypedArrayEncoder.fromBase64(messagePackage.tag as any),
+        aad: TypedArrayEncoder.fromString(messagePackage.protected),
+      })
+      return {
+        plaintextMessage: JsonEncoder.fromBuffer(message),
+        senderKey,
+        recipientKey,
+      }
+    } finally {
+      cek?.handle.free()
+    }
+  }
+
+  public async generateNonce(): Promise<string> {
+    try {
+      // generate an 80-bit nonce suitable for AnonCreds proofs
+      const nonce = CryptoBox.randomNonce().slice(0, 10)
+      return new BigNumber(nonce).toString()
+    } catch (error) {
+      if (!isError(error)) {
+        throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })
+      }
+      throw new WalletError('Error generating nonce', { cause: error })
+    }
+  }
+
+  public async generateWalletKey() {
+    try {
+      return Store.generateRawKey()
+    } catch (error) {
+      throw new WalletError('Error generating wallet key', { cause: error })
+    }
+  }
+
+  private async retrieveKeyPair(publicKeyBase58: string): Promise<KeyPair> {
+    try {
+      const entryObject = await this.session.fetch({ category: 'KeyPairRecord', name: `key-${publicKeyBase58}` })
+
+      if (entryObject?.value) {
+        return JsonEncoder.fromString(entryObject?.value as string) as KeyPair
+      } else {
+        throw new WalletError(`No content found for record with public key: ${publicKeyBase58}`)
+      }
+    } catch (error) {
+      throw new WalletError('Error retrieving KeyPair record', { cause: error })
+    }
+  }
+
+  private async storeKeyPair(keyPair: KeyPair): Promise<void> {
+    try {
+      await this.session.insert({
+        category: 'KeyPairRecord',
+        name: `key-${keyPair.publicKeyBase58}`,
+        value: JSON.stringify(keyPair),
+        tags: {
+          keyType: keyPair.keyType,
+        },
+      })
+    } catch (error) {
+      if (isAskarError(error, AskarErrorCode.Duplicate)) {
+        throw new WalletKeyExistsError('Key already exists')
+      }
+      throw new WalletError('Error saving KeyPair record', { cause: error })
+    }
+  }
+}

--- a/packages/askar/src/wallet/AskarProfileWallet.ts
+++ b/packages/askar/src/wallet/AskarProfileWallet.ts
@@ -1,0 +1,196 @@
+import type { WalletConfig } from '@aries-framework/core'
+
+import {
+  WalletDuplicateError,
+  WalletNotFoundError,
+  InjectionSymbols,
+  Logger,
+  SigningProviderRegistry,
+  WalletError,
+} from '@aries-framework/core'
+import { Store } from '@hyperledger/aries-askar-shared'
+import { inject, injectable } from 'tsyringe'
+
+import { AskarErrorCode, isAskarError } from '../utils'
+
+import { AskarBaseWallet } from './AskarBaseWallet'
+
+@injectable()
+export class AskarProfileWallet extends AskarBaseWallet {
+  private walletConfig?: WalletConfig
+  public readonly store: Store
+
+  public constructor(
+    store: Store,
+    @inject(InjectionSymbols.Logger) logger: Logger,
+    signingKeyProviderRegistry: SigningProviderRegistry
+  ) {
+    super(logger, signingKeyProviderRegistry)
+
+    this.store = store
+  }
+
+  public get isInitialized() {
+    return this._session !== undefined
+  }
+
+  public get isProvisioned() {
+    return this.walletConfig !== undefined
+  }
+
+  public get profile() {
+    if (!this.walletConfig) {
+      throw new WalletError('No profile configured.')
+    }
+
+    return this.walletConfig.id
+  }
+
+  /**
+   * Dispose method is called when an agent context is disposed.
+   */
+  public async dispose() {
+    if (this.isInitialized) {
+      await this.close()
+    }
+  }
+
+  public async create(walletConfig: WalletConfig): Promise<void> {
+    this.logger.debug(`Creating wallet for profile '${walletConfig.id}'`)
+
+    try {
+      await this.store.createProfile(walletConfig.id)
+    } catch (error) {
+      if (isAskarError(error, AskarErrorCode.Duplicate)) {
+        const errorMessage = `Wallet for profile '${walletConfig.id}' already exists`
+        this.logger.debug(errorMessage)
+
+        throw new WalletDuplicateError(errorMessage, {
+          walletType: 'AskarProfileWallet',
+          cause: error,
+        })
+      }
+
+      const errorMessage = `Error creating wallet for profile '${walletConfig.id}'`
+      this.logger.error(errorMessage, {
+        error,
+        errorMessage: error.message,
+      })
+
+      throw new WalletError(errorMessage, { cause: error })
+    }
+
+    this.logger.debug(`Successfully created wallet for profile '${walletConfig.id}'`)
+  }
+
+  public async open(walletConfig: WalletConfig): Promise<void> {
+    this.logger.debug(`Opening wallet for profile '${walletConfig.id}'`)
+
+    try {
+      this.walletConfig = walletConfig
+
+      this._session = await this.store.session(walletConfig.id).open()
+
+      // FIXME: opening a session for a profile that does not exist, will not throw an error until
+      // the session is actually used. We can check if the profile exists by doing something with
+      // the session, which will throw a not found error if the profile does not exists,
+      // but that is not very efficient as it needs to be done on every open.
+      // See: https://github.com/hyperledger/aries-askar/issues/163
+      await this._session.fetch({
+        category: 'fetch-to-see-if-profile-exists',
+        name: 'fetch-to-see-if-profile-exists',
+        forUpdate: false,
+        isJson: false,
+      })
+    } catch (error) {
+      // Profile does not exist
+      if (isAskarError(error, AskarErrorCode.NotFound)) {
+        const errorMessage = `Wallet for profile '${walletConfig.id}' not found`
+        this.logger.debug(errorMessage)
+
+        throw new WalletNotFoundError(errorMessage, {
+          walletType: 'AskarProfileWallet',
+          cause: error,
+        })
+      }
+
+      const errorMessage = `Error opening wallet for profile '${walletConfig.id}'`
+      this.logger.error(errorMessage, {
+        error,
+        errorMessage: error.message,
+      })
+
+      throw new WalletError(errorMessage, { cause: error })
+    }
+
+    this.logger.debug(`Successfully opened wallet for profile '${walletConfig.id}'`)
+  }
+
+  public async createAndOpen(walletConfig: WalletConfig): Promise<void> {
+    await this.create(walletConfig)
+    await this.open(walletConfig)
+  }
+
+  public async delete() {
+    if (!this.walletConfig) {
+      throw new WalletError(
+        'Can not delete wallet that does not have wallet config set. Make sure to call create wallet before deleting the wallet'
+      )
+    }
+
+    this.logger.info(`Deleting profile '${this.walletConfig.id}'`)
+
+    if (this._session) {
+      await this.close()
+    }
+
+    try {
+      await this.store.removeProfile(this.walletConfig.id)
+    } catch (error) {
+      const errorMessage = `Error deleting wallet for profile '${this.walletConfig.id}': ${error.message}`
+      this.logger.error(errorMessage, {
+        error,
+        errorMessage: error.message,
+      })
+
+      throw new WalletError(errorMessage, { cause: error })
+    }
+  }
+
+  public async export() {
+    // This PR should help with this: https://github.com/hyperledger/aries-askar/pull/159
+    throw new WalletError('Exporting a profile is not supported.')
+  }
+
+  public async import() {
+    // This PR should help with this: https://github.com/hyperledger/aries-askar/pull/159
+    throw new WalletError('Importing a profile is not supported.')
+  }
+
+  public async rotateKey(): Promise<void> {
+    throw new WalletError(
+      'Rotating a key is not supported for a profile. You can rotate the key on the main askar wallet.'
+    )
+  }
+
+  public async close() {
+    this.logger.debug(`Closing wallet for profile ${this.walletConfig?.id}`)
+
+    if (!this._session) {
+      throw new WalletError('Wallet is in invalid state, you are trying to close wallet that has no handle.')
+    }
+
+    try {
+      await this.session.close()
+      this._session = undefined
+    } catch (error) {
+      const errorMessage = `Error closing wallet for profile ${this.walletConfig?.id}: ${error.message}`
+      this.logger.error(errorMessage, {
+        error,
+        errorMessage: error.message,
+      })
+
+      throw new WalletError(errorMessage, { cause: error })
+    }
+  }
+}

--- a/packages/askar/src/wallet/AskarWallet.ts
+++ b/packages/askar/src/wallet/AskarWallet.ts
@@ -1,78 +1,45 @@
-import type {
-  EncryptedMessage,
-  WalletConfig,
-  WalletCreateKeyOptions,
-  WalletSignOptions,
-  UnpackedMessageContext,
-  WalletVerifyOptions,
-  Wallet,
-  WalletConfigRekey,
-  KeyPair,
-  WalletExportImportConfig,
-} from '@aries-framework/core'
-import type { KeyEntryObject, Session } from '@hyperledger/aries-askar-shared'
+import type { WalletConfig, WalletConfigRekey, WalletExportImportConfig } from '@aries-framework/core'
 
 import {
   WalletExportPathExistsError,
-  WalletKeyExistsError,
-  isValidSeed,
-  isValidPrivateKey,
-  JsonTransformer,
   WalletInvalidKeyError,
   WalletDuplicateError,
-  JsonEncoder,
-  KeyType,
-  Buffer,
   AriesFrameworkError,
   Logger,
   WalletError,
   InjectionSymbols,
-  Key,
   SigningProviderRegistry,
-  TypedArrayEncoder,
   FileSystem,
   WalletNotFoundError,
   KeyDerivationMethod,
 } from '@aries-framework/core'
-import { KeyAlgs, CryptoBox, Store, Key as AskarKey, keyAlgFromString } from '@hyperledger/aries-askar-shared'
 // eslint-disable-next-line import/order
-import BigNumber from 'bn.js'
-
-const isError = (error: unknown): error is Error => error instanceof Error
+import { Store } from '@hyperledger/aries-askar-shared'
 
 import { inject, injectable } from 'tsyringe'
 
-import {
-  AskarErrorCode,
-  isAskarError,
-  keyDerivationMethodToStoreKeyMethod,
-  isKeyTypeSupportedByAskar,
-  uriFromWalletConfig,
-  keyTypesSupportedByAskar,
-} from '../utils'
+import { AskarErrorCode, isAskarError, keyDerivationMethodToStoreKeyMethod, uriFromWalletConfig } from '../utils'
 
-import { JweEnvelope, JweRecipient } from './JweEnvelope'
+import { AskarBaseWallet } from './AskarBaseWallet'
+import { AskarProfileWallet } from './AskarProfileWallet'
 
+/**
+ * @todo: rename after 0.5.0, as we now have multiple types of AskarWallet
+ */
 @injectable()
-export class AskarWallet implements Wallet {
-  private walletConfig?: WalletConfig
-  private _session?: Session
-
-  private _store?: Store
-
-  private logger: Logger
+export class AskarWallet extends AskarBaseWallet {
   private fileSystem: FileSystem
 
-  private signingKeyProviderRegistry: SigningProviderRegistry
+  private walletConfig?: WalletConfig
+  private _store?: Store
 
   public constructor(
     @inject(InjectionSymbols.Logger) logger: Logger,
     @inject(InjectionSymbols.FileSystem) fileSystem: FileSystem,
     signingKeyProviderRegistry: SigningProviderRegistry
   ) {
-    this.logger = logger
+    super(logger, signingKeyProviderRegistry)
     this.fileSystem = fileSystem
-    this.signingKeyProviderRegistry = signingKeyProviderRegistry
   }
 
   public get isProvisioned() {
@@ -93,18 +60,12 @@ export class AskarWallet implements Wallet {
     return this._store
   }
 
-  public get session() {
-    if (!this._session) {
-      throw new AriesFrameworkError('No Wallet Session is opened')
+  public get profile() {
+    if (!this.walletConfig) {
+      throw new WalletError('No profile configured.')
     }
 
-    return this._session
-  }
-
-  public get supportedKeyTypes() {
-    const signingKeyProviderSupportedKeyTypes = this.signingKeyProviderRegistry.supportedKeyTypes
-
-    return Array.from(new Set([...keyTypesSupportedByAskar, ...signingKeyProviderSupportedKeyTypes]))
+    return this.walletConfig.id
   }
 
   /**
@@ -123,6 +84,14 @@ export class AskarWallet implements Wallet {
   public async create(walletConfig: WalletConfig): Promise<void> {
     await this.createAndOpen(walletConfig)
     await this.close()
+  }
+
+  /**
+   * TODO: we can add this method, and add custom logic in the tenants module
+   * or we can try to register the store on the agent context
+   */
+  public async getProfileWallet() {
+    return new AskarProfileWallet(this.store, this.logger, this.signingKeyProviderRegistry)
   }
 
   /**
@@ -415,409 +384,6 @@ export class AskarWallet implements Wallet {
     }
   }
 
-  /**
-   * Create a key with an optional seed and keyType.
-   * The keypair is also automatically stored in the wallet afterwards
-   */
-  public async createKey({ seed, privateKey, keyType }: WalletCreateKeyOptions): Promise<Key> {
-    try {
-      if (seed && privateKey) {
-        throw new WalletError('Only one of seed and privateKey can be set')
-      }
-
-      if (seed && !isValidSeed(seed, keyType)) {
-        throw new WalletError('Invalid seed provided')
-      }
-
-      if (privateKey && !isValidPrivateKey(privateKey, keyType)) {
-        throw new WalletError('Invalid private key provided')
-      }
-
-      if (isKeyTypeSupportedByAskar(keyType)) {
-        const algorithm = keyAlgFromString(keyType)
-
-        // Create key
-        let key: AskarKey | undefined
-        try {
-          const key = privateKey
-            ? AskarKey.fromSecretBytes({ secretKey: privateKey, algorithm })
-            : seed
-            ? AskarKey.fromSeed({ seed, algorithm })
-            : AskarKey.generate(algorithm)
-
-          const keyPublicBytes = key.publicBytes
-          // Store key
-          await this.session.insertKey({ key, name: TypedArrayEncoder.toBase58(keyPublicBytes) })
-          key.handle.free()
-          return Key.fromPublicKey(keyPublicBytes, keyType)
-        } catch (error) {
-          key?.handle.free()
-          // Handle case where key already exists
-          if (isAskarError(error, AskarErrorCode.Duplicate)) {
-            throw new WalletKeyExistsError('Key already exists')
-          }
-
-          // Otherwise re-throw error
-          throw error
-        }
-      } else {
-        // Check if there is a signing key provider for the specified key type.
-        if (this.signingKeyProviderRegistry.hasProviderForKeyType(keyType)) {
-          const signingKeyProvider = this.signingKeyProviderRegistry.getProviderForKeyType(keyType)
-
-          const keyPair = await signingKeyProvider.createKeyPair({ seed, privateKey })
-          await this.storeKeyPair(keyPair)
-          return Key.fromPublicKeyBase58(keyPair.publicKeyBase58, keyType)
-        }
-        throw new WalletError(`Unsupported key type: '${keyType}'`)
-      }
-    } catch (error) {
-      // If already instance of `WalletError`, re-throw
-      if (error instanceof WalletError) throw error
-
-      if (!isError(error)) {
-        throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })
-      }
-      throw new WalletError(`Error creating key with key type '${keyType}': ${error.message}`, { cause: error })
-    }
-  }
-
-  /**
-   * sign a Buffer with an instance of a Key class
-   *
-   * @param data Buffer The data that needs to be signed
-   * @param key Key The key that is used to sign the data
-   *
-   * @returns A signature for the data
-   */
-  public async sign({ data, key }: WalletSignOptions): Promise<Buffer> {
-    let keyEntry: KeyEntryObject | null | undefined
-    try {
-      if (isKeyTypeSupportedByAskar(key.keyType)) {
-        if (!TypedArrayEncoder.isTypedArray(data)) {
-          throw new WalletError(`Currently not supporting signing of multiple messages`)
-        }
-        keyEntry = await this.session.fetchKey({ name: key.publicKeyBase58 })
-
-        if (!keyEntry) {
-          throw new WalletError('Key entry not found')
-        }
-
-        const signed = keyEntry.key.signMessage({ message: data as Buffer })
-
-        keyEntry.key.handle.free()
-
-        return Buffer.from(signed)
-      } else {
-        // Check if there is a signing key provider for the specified key type.
-        if (this.signingKeyProviderRegistry.hasProviderForKeyType(key.keyType)) {
-          const signingKeyProvider = this.signingKeyProviderRegistry.getProviderForKeyType(key.keyType)
-
-          const keyPair = await this.retrieveKeyPair(key.publicKeyBase58)
-          const signed = await signingKeyProvider.sign({
-            data,
-            privateKeyBase58: keyPair.privateKeyBase58,
-            publicKeyBase58: key.publicKeyBase58,
-          })
-
-          return signed
-        }
-        throw new WalletError(`Unsupported keyType: ${key.keyType}`)
-      }
-    } catch (error) {
-      keyEntry?.key.handle.free()
-      if (!isError(error)) {
-        throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })
-      }
-      throw new WalletError(`Error signing data with verkey ${key.publicKeyBase58}. ${error.message}`, { cause: error })
-    }
-  }
-
-  /**
-   * Verify the signature with the data and the used key
-   *
-   * @param data Buffer The data that has to be confirmed to be signed
-   * @param key Key The key that was used in the signing process
-   * @param signature Buffer The signature that was created by the signing process
-   *
-   * @returns A boolean whether the signature was created with the supplied data and key
-   *
-   * @throws {WalletError} When it could not do the verification
-   * @throws {WalletError} When an unsupported keytype is used
-   */
-  public async verify({ data, key, signature }: WalletVerifyOptions): Promise<boolean> {
-    let askarKey: AskarKey | undefined
-    try {
-      if (isKeyTypeSupportedByAskar(key.keyType)) {
-        if (!TypedArrayEncoder.isTypedArray(data)) {
-          throw new WalletError(`Currently not supporting verification of multiple messages`)
-        }
-
-        const askarKey = AskarKey.fromPublicBytes({
-          algorithm: keyAlgFromString(key.keyType),
-          publicKey: key.publicKey,
-        })
-        const verified = askarKey.verifySignature({ message: data as Buffer, signature })
-        askarKey.handle.free()
-        return verified
-      } else {
-        // Check if there is a signing key provider for the specified key type.
-        if (this.signingKeyProviderRegistry.hasProviderForKeyType(key.keyType)) {
-          const signingKeyProvider = this.signingKeyProviderRegistry.getProviderForKeyType(key.keyType)
-
-          const signed = await signingKeyProvider.verify({
-            data,
-            signature,
-            publicKeyBase58: key.publicKeyBase58,
-          })
-
-          return signed
-        }
-        throw new WalletError(`Unsupported keyType: ${key.keyType}`)
-      }
-    } catch (error) {
-      askarKey?.handle.free()
-      if (!isError(error)) {
-        throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })
-      }
-      throw new WalletError(`Error verifying signature of data signed with verkey ${key.publicKeyBase58}`, {
-        cause: error,
-      })
-    }
-  }
-
-  /**
-   * Pack a message using DIDComm V1 algorithm
-   *
-   * @param payload message to send
-   * @param recipientKeys array containing recipient keys in base58
-   * @param senderVerkey sender key in base58
-   * @returns JWE Envelope to send
-   */
-  public async pack(
-    payload: Record<string, unknown>,
-    recipientKeys: string[],
-    senderVerkey?: string // in base58
-  ): Promise<EncryptedMessage> {
-    let cek: AskarKey | undefined
-    let senderKey: KeyEntryObject | null | undefined
-    let senderExchangeKey: AskarKey | undefined
-
-    try {
-      cek = AskarKey.generate(KeyAlgs.Chacha20C20P)
-
-      senderKey = senderVerkey ? await this.session.fetchKey({ name: senderVerkey }) : undefined
-      if (senderVerkey && !senderKey) {
-        throw new WalletError(`Unable to pack message. Sender key ${senderVerkey} not found in wallet.`)
-      }
-
-      senderExchangeKey = senderKey ? senderKey.key.convertkey({ algorithm: KeyAlgs.X25519 }) : undefined
-
-      const recipients: JweRecipient[] = []
-
-      for (const recipientKey of recipientKeys) {
-        let targetExchangeKey: AskarKey | undefined
-        try {
-          targetExchangeKey = AskarKey.fromPublicBytes({
-            publicKey: Key.fromPublicKeyBase58(recipientKey, KeyType.Ed25519).publicKey,
-            algorithm: KeyAlgs.Ed25519,
-          }).convertkey({ algorithm: KeyAlgs.X25519 })
-
-          if (senderVerkey && senderExchangeKey) {
-            const encryptedSender = CryptoBox.seal({
-              recipientKey: targetExchangeKey,
-              message: Buffer.from(senderVerkey),
-            })
-            const nonce = CryptoBox.randomNonce()
-            const encryptedCek = CryptoBox.cryptoBox({
-              recipientKey: targetExchangeKey,
-              senderKey: senderExchangeKey,
-              message: cek.secretBytes,
-              nonce,
-            })
-
-            recipients.push(
-              new JweRecipient({
-                encryptedKey: encryptedCek,
-                header: {
-                  kid: recipientKey,
-                  sender: TypedArrayEncoder.toBase64URL(encryptedSender),
-                  iv: TypedArrayEncoder.toBase64URL(nonce),
-                },
-              })
-            )
-          } else {
-            const encryptedCek = CryptoBox.seal({
-              recipientKey: targetExchangeKey,
-              message: cek.secretBytes,
-            })
-            recipients.push(
-              new JweRecipient({
-                encryptedKey: encryptedCek,
-                header: {
-                  kid: recipientKey,
-                },
-              })
-            )
-          }
-        } finally {
-          targetExchangeKey?.handle.free()
-        }
-      }
-
-      const protectedJson = {
-        enc: 'xchacha20poly1305_ietf',
-        typ: 'JWM/1.0',
-        alg: senderVerkey ? 'Authcrypt' : 'Anoncrypt',
-        recipients: recipients.map((item) => JsonTransformer.toJSON(item)),
-      }
-
-      const { ciphertext, tag, nonce } = cek.aeadEncrypt({
-        message: Buffer.from(JSON.stringify(payload)),
-        aad: Buffer.from(JsonEncoder.toBase64URL(protectedJson)),
-      }).parts
-
-      const envelope = new JweEnvelope({
-        ciphertext: TypedArrayEncoder.toBase64URL(ciphertext),
-        iv: TypedArrayEncoder.toBase64URL(nonce),
-        protected: JsonEncoder.toBase64URL(protectedJson),
-        tag: TypedArrayEncoder.toBase64URL(tag),
-      }).toJson()
-
-      return envelope as EncryptedMessage
-    } finally {
-      cek?.handle.free()
-      senderKey?.key.handle.free()
-      senderExchangeKey?.handle.free()
-    }
-  }
-
-  /**
-   * Unpacks a JWE Envelope coded using DIDComm V1 algorithm
-   *
-   * @param messagePackage JWE Envelope
-   * @returns UnpackedMessageContext with plain text message, sender key and recipient key
-   */
-  public async unpack(messagePackage: EncryptedMessage): Promise<UnpackedMessageContext> {
-    const protectedJson = JsonEncoder.fromBase64(messagePackage.protected)
-
-    const alg = protectedJson.alg
-    if (!['Anoncrypt', 'Authcrypt'].includes(alg)) {
-      throw new WalletError(`Unsupported pack algorithm: ${alg}`)
-    }
-
-    const recipients = []
-
-    for (const recip of protectedJson.recipients) {
-      const kid = recip.header.kid
-      if (!kid) {
-        throw new WalletError('Blank recipient key')
-      }
-      const sender = recip.header.sender ? TypedArrayEncoder.fromBase64(recip.header.sender) : undefined
-      const iv = recip.header.iv ? TypedArrayEncoder.fromBase64(recip.header.iv) : undefined
-      if (sender && !iv) {
-        throw new WalletError('Missing IV')
-      } else if (!sender && iv) {
-        throw new WalletError('Unexpected IV')
-      }
-      recipients.push({
-        kid,
-        sender,
-        iv,
-        encrypted_key: TypedArrayEncoder.fromBase64(recip.encrypted_key),
-      })
-    }
-
-    let payloadKey, senderKey, recipientKey
-
-    for (const recipient of recipients) {
-      let recipientKeyEntry: KeyEntryObject | null | undefined
-      let sender_x: AskarKey | undefined
-      let recip_x: AskarKey | undefined
-
-      try {
-        recipientKeyEntry = await this.session.fetchKey({ name: recipient.kid })
-        if (recipientKeyEntry) {
-          const recip_x = recipientKeyEntry.key.convertkey({ algorithm: KeyAlgs.X25519 })
-          recipientKey = recipient.kid
-
-          if (recipient.sender && recipient.iv) {
-            senderKey = TypedArrayEncoder.toUtf8String(
-              CryptoBox.sealOpen({
-                recipientKey: recip_x,
-                ciphertext: recipient.sender,
-              })
-            )
-            const sender_x = AskarKey.fromPublicBytes({
-              algorithm: KeyAlgs.Ed25519,
-              publicKey: TypedArrayEncoder.fromBase58(senderKey),
-            }).convertkey({ algorithm: KeyAlgs.X25519 })
-
-            payloadKey = CryptoBox.open({
-              recipientKey: recip_x,
-              senderKey: sender_x,
-              message: recipient.encrypted_key,
-              nonce: recipient.iv,
-            })
-          } else {
-            payloadKey = CryptoBox.sealOpen({ ciphertext: recipient.encrypted_key, recipientKey: recip_x })
-          }
-          break
-        }
-      } finally {
-        recipientKeyEntry?.key.handle.free()
-        sender_x?.handle.free()
-        recip_x?.handle.free()
-      }
-    }
-    if (!payloadKey) {
-      throw new WalletError('No corresponding recipient key found')
-    }
-
-    if (!senderKey && alg === 'Authcrypt') {
-      throw new WalletError('Sender public key not provided for Authcrypt')
-    }
-
-    let cek: AskarKey | undefined
-    try {
-      cek = AskarKey.fromSecretBytes({ algorithm: KeyAlgs.Chacha20C20P, secretKey: payloadKey })
-      const message = cek.aeadDecrypt({
-        ciphertext: TypedArrayEncoder.fromBase64(messagePackage.ciphertext as any),
-        nonce: TypedArrayEncoder.fromBase64(messagePackage.iv as any),
-        tag: TypedArrayEncoder.fromBase64(messagePackage.tag as any),
-        aad: TypedArrayEncoder.fromString(messagePackage.protected),
-      })
-      return {
-        plaintextMessage: JsonEncoder.fromBuffer(message),
-        senderKey,
-        recipientKey,
-      }
-    } finally {
-      cek?.handle.free()
-    }
-  }
-
-  public async generateNonce(): Promise<string> {
-    try {
-      // generate an 80-bit nonce suitable for AnonCreds proofs
-      const nonce = CryptoBox.randomNonce().slice(0, 10)
-      return new BigNumber(nonce).toString()
-    } catch (error) {
-      if (!isError(error)) {
-        throw new AriesFrameworkError('Attempted to throw error, but it was not of type Error', { cause: error })
-      }
-      throw new WalletError('Error generating nonce', { cause: error })
-    }
-  }
-
-  public async generateWalletKey() {
-    try {
-      return Store.generateRawKey()
-    } catch (error) {
-      throw new WalletError('Error generating wallet key', { cause: error })
-    }
-  }
-
   private async getAskarWalletConfig(walletConfig: WalletConfig) {
     const { uri, path } = uriFromWalletConfig(walletConfig, this.fileSystem.dataPath)
 
@@ -834,38 +400,6 @@ export class AskarWallet implements Wallet {
         walletConfig.keyDerivationMethod ?? KeyDerivationMethod.Argon2IMod
       ),
       passKey: walletConfig.key,
-    }
-  }
-
-  private async retrieveKeyPair(publicKeyBase58: string): Promise<KeyPair> {
-    try {
-      const entryObject = await this.session.fetch({ category: 'KeyPairRecord', name: `key-${publicKeyBase58}` })
-
-      if (entryObject?.value) {
-        return JsonEncoder.fromString(entryObject?.value as string) as KeyPair
-      } else {
-        throw new WalletError(`No content found for record with public key: ${publicKeyBase58}`)
-      }
-    } catch (error) {
-      throw new WalletError('Error retrieving KeyPair record', { cause: error })
-    }
-  }
-
-  private async storeKeyPair(keyPair: KeyPair): Promise<void> {
-    try {
-      await this.session.insert({
-        category: 'KeyPairRecord',
-        name: `key-${keyPair.publicKeyBase58}`,
-        value: JSON.stringify(keyPair),
-        tags: {
-          keyType: keyPair.keyType,
-        },
-      })
-    } catch (error) {
-      if (isAskarError(error, AskarErrorCode.Duplicate)) {
-        throw new WalletKeyExistsError('Key already exists')
-      }
-      throw new WalletError('Error saving KeyPair record', { cause: error })
     }
   }
 }

--- a/packages/askar/src/wallet/__tests__/AskarProfileWallet.test.ts
+++ b/packages/askar/src/wallet/__tests__/AskarProfileWallet.test.ts
@@ -1,0 +1,64 @@
+import type { WalletConfig } from '@aries-framework/core'
+
+import {
+  SigningProviderRegistry,
+  WalletDuplicateError,
+  WalletNotFoundError,
+  KeyDerivationMethod,
+} from '@aries-framework/core'
+
+import { describeRunInNodeVersion } from '../../../../../tests/runInVersion'
+import { testLogger, agentDependencies } from '../../../../core/tests'
+import { AskarProfileWallet } from '../AskarProfileWallet'
+import { AskarWallet } from '../AskarWallet'
+
+// use raw key derivation method to speed up wallet creating / opening / closing between tests
+const rootWalletConfig: WalletConfig = {
+  id: 'Wallet: AskarProfileWalletTest',
+  // generated using indy.generateWalletKey
+  key: 'CwNJroKHTSSj3XvE7ZAnuKiTn2C4QkFvxEqfm5rzhNrb',
+  keyDerivationMethod: KeyDerivationMethod.Raw,
+}
+
+describeRunInNodeVersion([18], 'AskarWallet management', () => {
+  let rootAskarWallet: AskarWallet
+  let profileAskarWallet: AskarProfileWallet
+
+  afterEach(async () => {
+    if (profileAskarWallet) {
+      await profileAskarWallet.delete()
+    }
+
+    if (rootAskarWallet) {
+      await rootAskarWallet.delete()
+    }
+  })
+
+  test('Create, open, close, delete', async () => {
+    const signingProviderRegistry = new SigningProviderRegistry([])
+    rootAskarWallet = new AskarWallet(testLogger, new agentDependencies.FileSystem(), signingProviderRegistry)
+
+    // Create and open wallet
+    await rootAskarWallet.createAndOpen(rootWalletConfig)
+
+    profileAskarWallet = new AskarProfileWallet(rootAskarWallet.store, testLogger, signingProviderRegistry)
+
+    // Create, open and close profile
+    await profileAskarWallet.create({ ...rootWalletConfig, id: 'profile-id' })
+    await profileAskarWallet.open({ ...rootWalletConfig, id: 'profile-id' })
+    await profileAskarWallet.close()
+
+    // try to re-create it
+    await expect(profileAskarWallet.createAndOpen({ ...rootWalletConfig, id: 'profile-id' })).rejects.toThrowError(
+      WalletDuplicateError
+    )
+
+    // Re-open profile
+    await profileAskarWallet.open({ ...rootWalletConfig, id: 'profile-id' })
+
+    // try to open non-existent wallet
+    await expect(profileAskarWallet.open({ ...rootWalletConfig, id: 'non-existent-profile-id' })).rejects.toThrowError(
+      WalletNotFoundError
+    )
+  })
+})

--- a/packages/askar/src/wallet/index.ts
+++ b/packages/askar/src/wallet/index.ts
@@ -1,2 +1,3 @@
 export { AskarWallet } from './AskarWallet'
+export { AskarProfileWallet } from './AskarProfileWallet'
 export * from './AskarWalletPostgresStorageConfig'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,10 +35,33 @@ export interface WalletExportImportConfig {
 }
 
 export type EncryptedMessage = {
+  /**
+   * The "protected" member MUST be present and contain the value
+   * BASE64URL(UTF8(JWE Protected Header)) when the JWE Protected
+   * Header value is non-empty; otherwise, it MUST be absent.  These
+   * Header Parameter values are integrity protected.
+   */
   protected: string
-  iv: unknown
-  ciphertext: unknown
-  tag: unknown
+
+  /**
+   * The "iv" member MUST be present and contain the value
+   * BASE64URL(JWE Initialization Vector) when the JWE Initialization
+   * Vector value is non-empty; otherwise, it MUST be absent.
+   */
+  iv: string
+
+  /**
+   * The "ciphertext" member MUST be present and contain the value
+   * BASE64URL(JWE Ciphertext).
+   */
+  ciphertext: string
+
+  /**
+   * The "tag" member MUST be present and contain the value
+   * BASE64URL(JWE Authentication Tag) when the JWE Authentication Tag
+   * value is non-empty; otherwise, it MUST be absent.
+   */
+  tag: string
 }
 
 export enum DidCommMimeType {

--- a/packages/tenants/tests/tenants-askar-profiles.e2e.test.ts
+++ b/packages/tenants/tests/tenants-askar-profiles.e2e.test.ts
@@ -1,0 +1,128 @@
+import type { InitConfig } from '@aries-framework/core'
+
+import { Agent } from '@aries-framework/core'
+import { agentDependencies } from '@aries-framework/node'
+
+import { describeRunInNodeVersion } from '../../../tests/runInVersion'
+import { AskarModule, AskarMultiWalletDatabaseScheme, AskarProfileWallet, AskarWallet } from '../../askar/src'
+import { askarModuleConfig } from '../../askar/tests/helpers'
+import { testLogger } from '../../core/tests'
+
+import { TenantsModule } from '@aries-framework/tenants'
+
+// FIXME: Re-include in tests when Askar NodeJS wrapper performance is improved
+describeRunInNodeVersion([18], 'Tenants Askar database schemes E2E', () => {
+  test('uses AskarWallet for all wallets and tenants when database schema is DatabasePerWallet', async () => {
+    const agentConfig: InitConfig = {
+      label: 'Tenant Agent 1',
+      walletConfig: {
+        id: 'Wallet: askar tenants without profiles e2e agent 1',
+        key: 'Wallet: askar tenants without profiles e2e agent 1',
+      },
+      logger: testLogger,
+    }
+
+    // Create multi-tenant agent
+    const agent = new Agent({
+      config: agentConfig,
+      modules: {
+        tenants: new TenantsModule(),
+        askar: new AskarModule({
+          ariesAskar: askarModuleConfig.ariesAskar,
+          // Database per wallet
+          multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.DatabasePerWallet,
+        }),
+      },
+      dependencies: agentDependencies,
+    })
+
+    await agent.initialize()
+
+    // main wallet should use AskarWallet
+    expect(agent.context.wallet).toBeInstanceOf(AskarWallet)
+    const mainWallet = agent.context.wallet as AskarWallet
+
+    // Create tenant
+    const tenantRecord = await agent.modules.tenants.createTenant({
+      config: {
+        label: 'Tenant 1',
+      },
+    })
+
+    // Get tenant agent
+    const tenantAgent = await agent.modules.tenants.getTenantAgent({
+      tenantId: tenantRecord.id,
+    })
+
+    expect(tenantAgent.context.wallet).toBeInstanceOf(AskarWallet)
+    const tenantWallet = tenantAgent.context.wallet as AskarWallet
+
+    // By default, profile is the same as the wallet id
+    expect(tenantWallet.profile).toEqual(`tenant-${tenantRecord.id}`)
+    // But the store should be different
+    expect(tenantWallet.store).not.toBe(mainWallet.store)
+
+    // Insert and end
+    await tenantAgent.genericRecords.save({ content: { name: 'hello' }, id: 'hello' })
+    await tenantAgent.endSession()
+
+    const tenantAgent2 = await agent.modules.tenants.getTenantAgent({ tenantId: tenantRecord.id })
+    expect(await tenantAgent2.genericRecords.findById('hello')).not.toBeNull()
+
+    await agent.wallet.delete()
+    await agent.shutdown()
+  })
+
+  test('uses AskarWallet for main agent, and ProfileAskarWallet for tenants', async () => {
+    const agentConfig: InitConfig = {
+      label: 'Tenant Agent 1',
+      walletConfig: {
+        id: 'Wallet: askar tenants with profiles e2e agent 1',
+        key: 'Wallet: askar tenants with profiles e2e agent 1',
+      },
+      logger: testLogger,
+    }
+
+    // Create multi-tenant agent
+    const agent = new Agent({
+      config: agentConfig,
+      modules: {
+        tenants: new TenantsModule(),
+        askar: new AskarModule({
+          ariesAskar: askarModuleConfig.ariesAskar,
+          // Profile per wallet
+          multiWalletDatabaseScheme: AskarMultiWalletDatabaseScheme.ProfilePerWallet,
+        }),
+      },
+      dependencies: agentDependencies,
+    })
+
+    await agent.initialize()
+
+    // main wallet should use AskarWallet
+    expect(agent.context.wallet).toBeInstanceOf(AskarWallet)
+    const mainWallet = agent.context.wallet as AskarWallet
+
+    // Create tenant
+    const tenantRecord = await agent.modules.tenants.createTenant({
+      config: {
+        label: 'Tenant 1',
+      },
+    })
+
+    // Get tenant agent
+    const tenantAgent = await agent.modules.tenants.getTenantAgent({
+      tenantId: tenantRecord.id,
+    })
+
+    expect(tenantAgent.context.wallet).toBeInstanceOf(AskarProfileWallet)
+    const tenantWallet = tenantAgent.context.wallet as AskarProfileWallet
+
+    expect(tenantWallet.profile).toEqual(`tenant-${tenantRecord.id}`)
+    // When using profile, the wallets should share the same store
+    expect(tenantWallet.store).toBe(mainWallet.store)
+
+    await agent.wallet.delete()
+    await agent.shutdown()
+  })
+})


### PR DESCRIPTION
Adds support for using askar profiles in multi-tenancy, so you don't have to create a new database for each tenant.

As commented on #1486, I've made some 'hacks' to make it work with the currrent API. I think extracting the wallet management from the wallet implementation can clean some things up, as well as having a more sophisticated wallet provider that is a bit more aware of having possible multilple wallets active at the same time within an agent.


The askar module now has a new `multiWalletDatabaseScheme` with two options: `ProfilePerWallet` or `DatabasePerWallet`. the database per wallet is the default to not make breaking changes, and profiel per wallet will reuse the same store for all wallets.

This is the only thing you have to do to benefit from this new feature. I've used the `initialize` method from the askar module to set everything up and register the askar `Store` from the root wallet to be used by the profile wallets. Not the cleanest, but I'm quite happy that it was at least possible to do this without significant changes.

The `AskarBaseWallet` exposes all wallet functionalitiy (such as signin, packing etc..) that is then extended by the `AskarWallet` (root / main wallet that also handles the connection to the database using a store) and `AskarProfileWallet` (uses an existing store and just creates / opens a session for a specific profile)

There's one issue I've discovered with profiles and sessions that requires a 'hack', maybe it can be fixed in Askar: https://github.com/hyperledger/aries-askar/issues/163