### PR TITLE
fix: add OOB id to auto-created connection

### DIFF
--- a/demo/src/Faber.ts
+++ b/demo/src/Faber.ts
@@ -271,6 +271,11 @@ export class Faber extends BaseAgent {
     )
   }
 
+  public async ping() {
+    const connectionRecord = await this.getConnectionRecord()
+    await this.agent.connections.sendPing(connectionRecord.id, {})
+  }
+
   public async sendMessage(message: string) {
     const connectionRecord = await this.getConnectionRecord()
     await this.agent.basicMessages.sendMessage(connectionRecord.id, message)

--- a/demo/src/FaberInquirer.ts
+++ b/demo/src/FaberInquirer.ts
@@ -18,6 +18,7 @@ enum PromptOptions {
   CreateConnection = 'Create connection invitation',
   OfferCredential = 'Offer credential',
   RequestProof = 'Request proof',
+  Ping = 'Ping other party',
   SendMessage = 'Send message',
   ListConnections = 'List connections',
   Exit = 'Exit',
@@ -69,6 +70,9 @@ export class FaberInquirer extends BaseInquirer {
       case PromptOptions.RequestProof:
         await this.proof()
         return
+      case PromptOptions.Ping:
+        await this.ping()
+        break
       case PromptOptions.SendMessage:
         await this.message()
         break
@@ -112,6 +116,10 @@ export class FaberInquirer extends BaseInquirer {
     await this.faber.sendProofRequest()
     const title = 'Is the proof request accepted?'
     await this.listener.newAcceptedPrompt(title, this)
+  }
+
+  public async ping() {
+    await this.faber.ping()
   }
 
   public async message() {

--- a/packages/core/src/modules/oob/protocols/v1/OutOfBandService.ts
+++ b/packages/core/src/modules/oob/protocols/v1/OutOfBandService.ts
@@ -247,6 +247,13 @@ export class OutOfBandService {
     })
   }
 
+  public async findCreatedByRecipientDid(agentContext: AgentContext, recipientDid: string) {
+    return this.outOfBandRepository.findSingleByQuery(agentContext, {
+      recipientDid,
+      role: OutOfBandRole.Sender,
+    })
+  }
+
   public async getAll(agentContext: AgentContext) {
     return this.outOfBandRepository.getAll(agentContext)
   }

--- a/packages/core/src/modules/oob/repository/OutOfBandRecord.ts
+++ b/packages/core/src/modules/oob/repository/OutOfBandRecord.ts
@@ -27,6 +27,7 @@ type DefaultOutOfBandRecordTags = {
 
 interface CustomOutOfBandRecordTags extends TagsBase {
   recipientKeyFingerprints: string[]
+  recipientDid?: string
 }
 
 export interface OutOfBandRecordProps {
@@ -84,7 +85,7 @@ export class OutOfBandRecord extends BaseRecord<
       this.reusable = props.reusable ?? false
       this.mediatorId = props.mediatorId
       this.reuseConnectionId = props.reuseConnectionId
-      this._tags = props.tags ?? { recipientKeyFingerprints: [] }
+      this._tags = props.tags ?? { recipientKeyFingerprints: [], recipientDid: this.v2OutOfBandInvitation?.from }
     }
   }
 


### PR DESCRIPTION
When a connection is auto-created after receiving first DIDComm v2 message, the OOB record that generated the invitation is not associated to it. So it becomes difficult to find it it afterwards. 

This happened to Faber in the demo, and may happen to you as well!