### PR TITLE
fix(cheqd): make cosmos payer seed optional

### DIFF
--- a/packages/cheqd/src/CheqdModule.ts
+++ b/packages/cheqd/src/CheqdModule.ts
@@ -1,7 +1,7 @@
 import type { CheqdModuleConfigOptions } from './CheqdModuleConfig'
 import type { AgentContext, DependencyManager, Module } from '@aries-framework/core'
 
-import { AgentConfig } from '@aries-framework/core'
+import { AgentConfig, Buffer } from '@aries-framework/core'
 
 import { CheqdModuleConfig } from './CheqdModuleConfig'
 import { CheqdLedgerService } from './ledger'
@@ -25,6 +25,11 @@ export class CheqdModule implements Module {
     dependencyManager.registerInstance(CheqdModuleConfig, this.config)
 
     dependencyManager.registerSingleton(CheqdLedgerService)
+
+    // Cheqd module needs Buffer to be available globally
+    // If it is not available yet, we overwrite it with the
+    // Buffer implementation from AFJ
+    global.Buffer = global.Buffer || Buffer
   }
 
   public async initialize(agentContext: AgentContext): Promise<void> {

--- a/packages/cheqd/src/CheqdModuleConfig.ts
+++ b/packages/cheqd/src/CheqdModuleConfig.ts
@@ -7,7 +7,7 @@ export interface CheqdModuleConfigOptions {
 
 export interface NetworkConfig {
   rpcUrl?: string
-  cosmosPayerSeed: string
+  cosmosPayerSeed?: string
   network: string
 }
 

--- a/packages/cheqd/src/ledger/CheqdLedgerService.ts
+++ b/packages/cheqd/src/ledger/CheqdLedgerService.ts
@@ -3,7 +3,7 @@ import type { SignInfo } from '@cheqd/ts-proto/cheqd/did/v2'
 import type { MsgCreateResourcePayload } from '@cheqd/ts-proto/cheqd/resource/v2'
 import type { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing'
 
-import { injectable } from '@aries-framework/core'
+import { AriesFrameworkError, injectable } from '@aries-framework/core'
 import { createCheqdSDK, DIDModule, ResourceModule, CheqdNetwork } from '@cheqd/sdk'
 
 import { CheqdModuleConfig } from '../CheqdModuleConfig'
@@ -42,8 +42,8 @@ export class CheqdLedgerService {
       network.sdk = await createCheqdSDK({
         modules: [DIDModule as unknown as AbstractCheqdSDKModule, ResourceModule as unknown as AbstractCheqdSDKModule],
         rpcUrl: network.rpcUrl,
-        wallet: await network.cosmosPayerWallet.catch(() => {
-          throw new Error(`[did-provider-cheqd]: valid cosmosPayerSeed is required`)
+        wallet: await network.cosmosPayerWallet.catch((error) => {
+          throw new AriesFrameworkError(`Error initializing cosmos payer wallet: ${error.message}`, { cause: error })
         }),
       })
     }


### PR DESCRIPTION
Makes the cosmos payer seed optional, as you can also used it as a holder without payer seed.