### PR TITLE
fix(transport): Use connection in WebSocket ID

### DIFF
--- a/packages/core/src/transport/WsOutboundTransport.ts
+++ b/packages/core/src/transport/WsOutboundTransport.ts
@@ -47,8 +47,9 @@ export class WsOutboundTransport implements OutboundTransport {
       throw new AriesFrameworkError("Missing connection or endpoint. I don't know how and where to send the message.")
     }
 
-    const isNewSocket = !this.hasOpenSocket(endpoint)
-    const socket = await this.resolveSocket({ socketId: endpoint, endpoint, connectionId })
+    const socketId = `${endpoint}-${connectionId}`
+    const isNewSocket = !this.hasOpenSocket(socketId)
+    const socket = await this.resolveSocket({ socketId, endpoint, connectionId })
 
     socket.send(Buffer.from(JSON.stringify(payload)))
 


### PR DESCRIPTION
Updated `WsOutboundTransport` to use `connectionId` as part of WS connection identifier. In current implementation, only `endpoint` value is used.

This change fixes issue in use cases where tenant agent acts as a mediator:
- For instance, we have mediator and issuer agents hosted inside same multi-tenant AFJ instance and we also have a holder agent on mobile device. Holder on a mobile device has an active WS connection with a mediator.
- Currently, WS connection will be reused if it's already open for the same endpoint. This means that message sent from holder to issuer via WS transport will go through mediator WS connection
- On multi-tenant instance side, this message will be received with existing transport session of mediator WS connection
- This will cause transport session (along with mediator WS connection) to be closed as message addressed to issuer will not specify `return_route` (see [implementation](https://github.com/hyperledger/aries-framework-javascript/blob/main/packages/core/src/agent/MessageReceiver.ts#L148))
- Closed WS connection will trigger reconnection process

Above-metioned issue is causing unnecessary load in mediator interaction and may cause overlapping reconnection processes if there are a lot of messages being sent from holder to issuer in a short period of time (in our case, we were testing this with large amount of credential offers being accepted one by one).