### PR TITLE
fix(oob): support oob with connection and messages

### DIFF
--- a/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
+++ b/packages/anoncreds/src/protocols/proofs/v1/V1ProofProtocol.ts
@@ -326,6 +326,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     })
     requestPresentationMessage.setThread({
       threadId: proofRecord.threadId,
+      parentThreadId: proofRecord.parentThreadId,
     })
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
@@ -523,7 +524,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
       comment,
       presentationProposal,
     })
-    message.setThread({ threadId: proofRecord.threadId })
+    message.setThread({ threadId: proofRecord.threadId, parentThreadId: proofRecord.parentThreadId })
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
@@ -600,7 +601,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
       comment,
       presentationAttachments: [attachment],
     })
-    message.setThread({ threadId: proofRecord.threadId })
+    message.setThread({ threadId: proofRecord.threadId, parentThreadId: proofRecord.parentThreadId })
 
     await didCommMessageRepository.saveAgentMessage(agentContext, {
       agentMessage: message,
@@ -745,11 +746,7 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     // only depends on the public api, rather than the internal API (this helps with breaking changes)
     const connectionService = agentContext.dependencyManager.resolve(ConnectionService)
 
-    const proofRecord = await this.getByThreadAndConnectionId(
-      agentContext,
-      presentationMessage.threadId,
-      connection?.id
-    )
+    const proofRecord = await this.getByThreadAndConnectionId(agentContext, presentationMessage.threadId)
 
     const proposalMessage = await didCommMessageRepository.findAgentMessage(agentContext, {
       associatedRecordId: proofRecord.id,
@@ -768,6 +765,15 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
       lastReceivedMessage: proposalMessage,
       lastSentMessage: requestMessage,
     })
+
+    // This makes sure that the sender of the incoming message is authorized to do so.
+    if (!proofRecord.connectionId) {
+      await connectionService.matchIncomingMessageToRequestMessageInOutOfBandExchange(messageContext, {
+        knownConnectionId: proofRecord.connectionId,
+      })
+
+      proofRecord.connectionId = connection?.id
+    }
 
     const presentationAttachment = presentationMessage.getPresentationAttachmentById(INDY_PROOF_ATTACHMENT_ID)
     if (!presentationAttachment) {
@@ -812,6 +818,11 @@ export class V1ProofProtocol extends BaseProofProtocol implements ProofProtocol<
     const ackMessage = new V1PresentationAckMessage({
       status: AckStatus.OK,
       threadId: proofRecord.threadId,
+    })
+
+    ackMessage.setThread({
+      threadId: proofRecord.threadId,
+      parentThreadId: proofRecord.parentThreadId,
     })
 
     // Update record

--- a/packages/core/src/agent/getOutboundMessageContext.ts
+++ b/packages/core/src/agent/getOutboundMessageContext.ts
@@ -297,8 +297,11 @@ async function addExchangeDataToMessage(
     associatedRecord: BaseRecordAny
   }
 ) {
+  const legacyInvitationMetadata = outOfBandRecord?.metadata.get(OutOfBandRecordMetadataKeys.LegacyInvitation)
+
   // Set the parentThreadId on the message from the oob invitation
-  if (outOfBandRecord) {
+  // If connectionless is used, we should not add the parentThreadId
+  if (outOfBandRecord && legacyInvitationMetadata?.legacyInvitationType !== 'connectionless') {
     if (!message.thread) {
       message.setThread({
         parentThreadId: outOfBandRecord.outOfBandInvitation.id,

--- a/packages/core/src/modules/credentials/CredentialsApi.ts
+++ b/packages/core/src/modules/credentials/CredentialsApi.ts
@@ -505,6 +505,7 @@ export class CredentialsApi<CPs extends CredentialProtocol[]> implements Credent
     })
     message.setThread({
       threadId: credentialRecord.threadId,
+      parentThreadId: credentialRecord.parentThreadId,
     })
     const outboundMessageContext = await getOutboundMessageContext(this.agentContext, {
       message,

--- a/packages/core/src/modules/credentials/protocol/v2/CredentialFormatCoordinator.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/CredentialFormatCoordinator.ts
@@ -70,7 +70,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       credentialPreview,
     })
 
-    message.setThread({ threadId: credentialRecord.threadId })
+    message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
@@ -182,7 +182,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       comment,
     })
 
-    message.setThread({ threadId: credentialRecord.threadId })
+    message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
@@ -254,7 +254,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       credentialPreview,
     })
 
-    message.setThread({ threadId: credentialRecord.threadId })
+    message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
@@ -345,7 +345,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       comment,
     })
 
-    message.setThread({ threadId: credentialRecord.threadId })
+    message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
@@ -399,7 +399,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       requestAttachments: requestAttachments,
     })
 
-    message.setThread({ threadId: credentialRecord.threadId })
+    message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
       agentMessage: message,
@@ -498,7 +498,7 @@ export class CredentialFormatCoordinator<CFs extends CredentialFormatService[]> 
       comment,
     })
 
-    message.setThread({ threadId: credentialRecord.threadId })
+    message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
     message.setPleaseAck()
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {

--- a/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
+++ b/packages/core/src/modules/credentials/protocol/v2/V2CredentialProtocol.ts
@@ -211,6 +211,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialRecord = new CredentialExchangeRecord({
         connectionId: connection?.id,
         threadId: proposalMessage.threadId,
+        parentThreadId: proposalMessage.thread?.parentThreadId,
         state: CredentialState.ProposalReceived,
         protocolVersion: 'v2',
       })
@@ -421,6 +422,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialRecord = new CredentialExchangeRecord({
         connectionId: connection?.id,
         threadId: offerMessage.threadId,
+        parentThreadId: offerMessage.thread?.parentThreadId,
         state: CredentialState.OfferReceived,
         protocolVersion: 'v2',
       })
@@ -586,11 +588,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
 
     agentContext.config.logger.debug(`Processing credential request with id ${requestMessage.id}`)
 
-    let credentialRecord = await this.findByThreadAndConnectionId(
-      messageContext.agentContext,
-      requestMessage.threadId,
-      connection?.id
-    )
+    let credentialRecord = await this.findByThreadAndConnectionId(messageContext.agentContext, requestMessage.threadId)
 
     const formatServices = this.getFormatServicesFromMessage(requestMessage.formats)
     if (formatServices.length === 0) {
@@ -617,6 +615,15 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
         lastSentMessage: offerMessage ?? undefined,
       })
 
+      // This makes sure that the sender of the incoming message is authorized to do so.
+      if (!credentialRecord.connectionId) {
+        await connectionService.matchIncomingMessageToRequestMessageInOutOfBandExchange(messageContext, {
+          knownConnectionId: credentialRecord.connectionId,
+        })
+
+        credentialRecord.connectionId = connection?.id
+      }
+
       await this.credentialFormatCoordinator.processRequest(messageContext.agentContext, {
         credentialRecord,
         formatServices,
@@ -634,6 +641,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       credentialRecord = new CredentialExchangeRecord({
         connectionId: connection?.id,
         threadId: requestMessage.threadId,
+        parentThreadId: requestMessage.thread?.parentThreadId,
         state: CredentialState.RequestReceived,
         protocolVersion: 'v2',
       })
@@ -778,6 +786,8 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       threadId: credentialRecord.threadId,
     })
 
+    ackMessage.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
+
     await this.updateState(agentContext, credentialRecord, CredentialState.Done)
 
     return { message: ackMessage, credentialRecord }
@@ -849,7 +859,7 @@ export class V2CredentialProtocol<CFs extends CredentialFormatService[] = Creden
       },
     })
 
-    message.setThread({ threadId: credentialRecord.threadId })
+    message.setThread({ threadId: credentialRecord.threadId, parentThreadId: credentialRecord.parentThreadId })
 
     return { credentialRecord, message }
   }

--- a/packages/core/src/modules/credentials/repository/CredentialExchangeRecord.ts
+++ b/packages/core/src/modules/credentials/repository/CredentialExchangeRecord.ts
@@ -17,6 +17,7 @@ export interface CredentialExchangeRecordProps {
   state: CredentialState
   connectionId?: string
   threadId: string
+  parentThreadId?: string
   protocolVersion: string
 
   tags?: CustomCredentialTags
@@ -31,6 +32,7 @@ export interface CredentialExchangeRecordProps {
 export type CustomCredentialTags = TagsBase
 export type DefaultCredentialTags = {
   threadId: string
+  parentThreadId?: string
   connectionId?: string
   state: CredentialState
   credentialIds: string[]
@@ -44,6 +46,7 @@ export interface CredentialRecordBinding {
 export class CredentialExchangeRecord extends BaseRecord<DefaultCredentialTags, CustomCredentialTags> {
   public connectionId?: string
   public threadId!: string
+  public parentThreadId?: string
   public state!: CredentialState
   public autoAcceptCredential?: AutoAcceptCredential
   public revocationNotification?: RevocationNotification
@@ -69,6 +72,7 @@ export class CredentialExchangeRecord extends BaseRecord<DefaultCredentialTags, 
       this.state = props.state
       this.connectionId = props.connectionId
       this.threadId = props.threadId
+      this.parentThreadId = props.parentThreadId
       this.protocolVersion = props.protocolVersion
       this._tags = props.tags ?? {}
 
@@ -87,6 +91,7 @@ export class CredentialExchangeRecord extends BaseRecord<DefaultCredentialTags, 
     return {
       ...this._tags,
       threadId: this.threadId,
+      parentThreadId: this.parentThreadId,
       connectionId: this.connectionId,
       state: this.state,
       credentialIds: ids,

--- a/packages/core/src/modules/oob/helpers.ts
+++ b/packages/core/src/modules/oob/helpers.ts
@@ -32,7 +32,9 @@ export function convertToNewInvitation(oldInvitation: ConnectionInvitationMessag
     handshakeProtocols: [HandshakeProtocol.Connections],
   }
 
-  return new OutOfBandInvitation(options)
+  const outOfBandInvitation = new OutOfBandInvitation(options)
+  outOfBandInvitation.invitationType = 'connections/1.x'
+  return outOfBandInvitation
 }
 
 export function convertToOldInvitation(newInvitation: OutOfBandInvitation) {

--- a/packages/core/src/modules/oob/messages/OutOfBandInvitation.ts
+++ b/packages/core/src/modules/oob/messages/OutOfBandInvitation.ts
@@ -1,7 +1,7 @@
 import type { PlaintextMessage } from '../../../types'
 import type { HandshakeProtocol } from '../../connections'
 
-import { Expose, Transform, TransformationType, Type } from 'class-transformer'
+import { Exclude, Expose, Transform, TransformationType, Type } from 'class-transformer'
 import { ArrayNotEmpty, IsArray, IsInstance, IsOptional, IsUrl, ValidateNested } from 'class-validator'
 import { parseUrl } from 'query-string'
 
@@ -43,6 +43,13 @@ export class OutOfBandInvitation extends AgentMessage {
       this.appendedAttachments = options.appendedAttachments
     }
   }
+
+  /**
+   * The original type of the invitation. This is not part of the RFC, but allows to identify
+   * from what the oob invitation was originally created (e.g. legacy connectionless invitation).
+   */
+  @Exclude()
+  public invitationType?: InvitationType
 
   public addRequest(message: AgentMessage) {
     if (!this.requests) this.requests = []
@@ -179,3 +186,8 @@ function OutOfBandServiceTransformer() {
     return value
   })
 }
+
+/**
+ * The original invitation an out of band invitation was derived from.
+ */
+export type InvitationType = 'out-of-band/1.x' | 'connections/1.x' | 'connectionless'

--- a/packages/core/src/modules/oob/repository/outOfBandRecordMetadataTypes.ts
+++ b/packages/core/src/modules/oob/repository/outOfBandRecordMetadataTypes.ts
@@ -1,5 +1,8 @@
+import type { InvitationType } from '../messages'
+
 export enum OutOfBandRecordMetadataKeys {
   RecipientRouting = '_internal/recipientRouting',
+  LegacyInvitation = '_internal/legacyInvitation',
 }
 
 export type OutOfBandRecordMetadata = {
@@ -8,5 +11,11 @@ export type OutOfBandRecordMetadata = {
     routingKeyFingerprints: string[]
     endpoints: string[]
     mediatorId?: string
+  }
+  [OutOfBandRecordMetadataKeys.LegacyInvitation]: {
+    /**
+     * Indicates the type of the legacy invitation that was used for this out of band exchange.
+     */
+    legacyInvitationType?: Exclude<InvitationType, 'out-of-band/1.x'>
   }
 }

--- a/packages/core/src/modules/proofs/protocol/v2/ProofFormatCoordinator.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/ProofFormatCoordinator.ts
@@ -328,7 +328,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       goalCode,
     })
 
-    message.setThread({ threadId: proofRecord.threadId })
+    message.setThread({ threadId: proofRecord.threadId, parentThreadId: proofRecord.parentThreadId })
     message.setPleaseAck()
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -90,6 +90,7 @@ export interface PlaintextMessage {
   '@id': string
   '~thread'?: {
     thid?: string
+    pthid?: string
   }
   [key: string]: unknown
 }

--- a/packages/core/tests/oob.test.ts
+++ b/packages/core/tests/oob.test.ts
@@ -721,6 +721,94 @@ describe('out of band', () => {
     })
   })
 
+  describe('messages and connection exchange', () => {
+    test('oob exchange with handshake where response is received to invitation', async () => {
+      const { message } = await faberAgent.credentials.createOffer(credentialTemplate)
+      const outOfBandRecord = await faberAgent.oob.createInvitation({
+        handshake: true,
+        messages: [message],
+      })
+      const { outOfBandInvitation } = outOfBandRecord
+
+      await aliceAgent.oob.receiveInvitation(outOfBandInvitation)
+
+      const aliceCredentialRecordPromise = waitForCredentialRecord(aliceAgent, {
+        state: CredentialState.OfferReceived,
+        threadId: message.threadId,
+        timeoutMs: 10000,
+      })
+
+      const aliceCredentialRecord = await aliceCredentialRecordPromise
+      expect(aliceCredentialRecord.state).toBe(CredentialState.OfferReceived)
+
+      // If we receive the event, we know the processing went well
+      const faberCredentialRecordPromise = waitForCredentialRecord(faberAgent, {
+        state: CredentialState.RequestReceived,
+        threadId: message.threadId,
+        timeoutMs: 10000,
+      })
+
+      await aliceAgent.credentials.acceptOffer({
+        credentialRecordId: aliceCredentialRecord.id,
+      })
+
+      await faberCredentialRecordPromise
+    })
+
+    test('oob exchange with reuse where response is received to invitation', async () => {
+      const { message } = await faberAgent.credentials.createOffer(credentialTemplate)
+
+      const routing = await faberAgent.mediationRecipient.getRouting({})
+      const connectionOutOfBandRecord = await faberAgent.oob.createInvitation({
+        routing,
+      })
+
+      // Create connection
+      const { connectionRecord } = await aliceAgent.oob.receiveInvitation(connectionOutOfBandRecord.outOfBandInvitation)
+      if (!connectionRecord) throw new Error('Connection record is undefined')
+      await aliceAgent.connections.returnWhenIsConnected(connectionRecord.id)
+
+      // Create offer and reuse
+      const outOfBandRecord = await faberAgent.oob.createInvitation({
+        routing,
+        messages: [message],
+      })
+      // Create connection
+      const { connectionRecord: offerConnectionRecord } = await aliceAgent.oob.receiveInvitation(
+        outOfBandRecord.outOfBandInvitation,
+        {
+          reuseConnection: true,
+        }
+      )
+      if (!offerConnectionRecord) throw new Error('Connection record is undefined')
+
+      // Should be the same, as connection is reused.
+      expect(offerConnectionRecord.id).toEqual(connectionRecord.id)
+
+      const aliceCredentialRecordPromise = waitForCredentialRecord(aliceAgent, {
+        state: CredentialState.OfferReceived,
+        threadId: message.threadId,
+        timeoutMs: 10000,
+      })
+
+      const aliceCredentialRecord = await aliceCredentialRecordPromise
+      expect(aliceCredentialRecord.state).toBe(CredentialState.OfferReceived)
+
+      // If we receive the event, we know the processing went well
+      const faberCredentialRecordPromise = waitForCredentialRecord(faberAgent, {
+        state: CredentialState.RequestReceived,
+        threadId: message.threadId,
+        timeoutMs: 10000,
+      })
+
+      await aliceAgent.credentials.acceptOffer({
+        credentialRecordId: aliceCredentialRecord.id,
+      })
+
+      await faberCredentialRecordPromise
+    })
+  })
+
   describe('connection-less exchange', () => {
     test('oob exchange without handshake where response is received to invitation', async () => {
       const { message } = await faberAgent.credentials.createOffer(credentialTemplate)


### PR DESCRIPTION
Fixes #1129

We now correctly check whether an oob exchange is associated with an exchange if there's no connectionId, and assign the connection if this is the case. 

I think we now really support al flows and combinations of messages / handhsake / connectionless from the oob protocol.

