### PR TITLE
fix: do not send package via outdated session

### DIFF
--- a/packages/core/src/agent/TransportService.ts
+++ b/packages/core/src/agent/TransportService.ts
@@ -13,8 +13,8 @@ export class TransportService {
   public transportSessionTable: TransportSessionTable = {}
 
   public saveSession(session: TransportSession) {
-    if (session.type === 'WebSocket' && session.connectionId) {
-      const oldSessions = this.getWebSocketSessionsForConnectionId(session.connectionId)
+    if (session.connectionId) {
+      const oldSessions = this.getExistingSessionsForConnectionIdAndType(session.connectionId, session.type)
       oldSessions.forEach((oldSession) => {
         if (oldSession) {
           this.removeSession(oldSession)
@@ -49,9 +49,9 @@ export class TransportService {
     delete this.transportSessionTable[session.id]
   }
 
-  private getWebSocketSessionsForConnectionId(connectionId: string) {
+  private getExistingSessionsForConnectionIdAndType(connectionId: string, type: string) {
     return Object.values(this.transportSessionTable).filter(
-      (session) => session?.connectionId === connectionId && session.type === 'WebSocket'
+      (session) => session?.connectionId === connectionId && session.type === type
     )
   }
 }

--- a/packages/core/src/agent/TransportService.ts
+++ b/packages/core/src/agent/TransportService.ts
@@ -13,6 +13,14 @@ export class TransportService {
   public transportSessionTable: TransportSessionTable = {}
 
   public saveSession(session: TransportSession) {
+    if (session.type === 'WebSocket' && session.connectionId) {
+      const oldSessions = this.getWebSocketSessionsForConnectionId(session.connectionId)
+      oldSessions.forEach((oldSession) => {
+        if (oldSession) {
+          this.removeSession(oldSession)
+        }
+      })
+    }
     this.transportSessionTable[session.id] = session
   }
 
@@ -39,6 +47,12 @@ export class TransportService {
 
   public removeSession(session: TransportSession) {
     delete this.transportSessionTable[session.id]
+  }
+
+  private getWebSocketSessionsForConnectionId(connectionId: string) {
+    return Object.values(this.transportSessionTable).filter(
+      (session) => session?.connectionId === connectionId && session.type === 'WebSocket'
+    )
   }
 }
 


### PR DESCRIPTION
We found an edge-case where a websocket transport session would be closed/unavailable on the client agent side, but mediator still thinks it is available (due to client being offline).
When client returns back online and initiates a flow via mediator, the mediator will attempt to send the package to the now outdated websocket, instead of the newest / current session.

This PR fixes the problem, but is there any reason why a single connection may need multiple open WebSocket transport sessions?