### PR TITLE
fix: service validation in OOB invitation objects

### DIFF
--- a/packages/core/src/modules/oob/__tests__/OutOfBandInvitation.test.ts
+++ b/packages/core/src/modules/oob/__tests__/OutOfBandInvitation.test.ts
@@ -1,8 +1,11 @@
 import type { ClassValidationError } from '../../../error/ClassValidationError'
 
 import { Attachment } from '../../../decorators/attachment/Attachment'
+import { MessageValidator } from '../../../utils'
 import { JsonEncoder } from '../../../utils/JsonEncoder'
 import { JsonTransformer } from '../../../utils/JsonTransformer'
+import { HandshakeProtocol } from '../../connections'
+import { OutOfBandDidCommService } from '../domain'
 import { OutOfBandInvitation } from '../messages/OutOfBandInvitation'
 
 describe('toUrl', () => {
@@ -23,6 +26,54 @@ describe('toUrl', () => {
     })
 
     expect(invitationUrl).toBe(`${domain}?oob=${JsonEncoder.toBase64URL(json)}`)
+  })
+})
+
+describe('validation', () => {
+  test('Out-of-Band Invitation instance with did as service', async () => {
+    const invitation = new OutOfBandInvitation({
+      id: '69212a3a-d068-4f9d-a2dd-4741bca89af3',
+      label: 'Faber College',
+      services: ['did:sov:LjgpST2rjsoxYegQDRm7EL'],
+      handshakeProtocols: [HandshakeProtocol.DidExchange],
+    })
+
+    expect(() => MessageValidator.validateSync(invitation)).not.toThrow()
+  })
+
+  test('Out-of-Band Invitation instance with object as service', async () => {
+    const invitation = new OutOfBandInvitation({
+      id: '69212a3a-d068-4f9d-a2dd-4741bca89af3',
+      label: 'Faber College',
+      services: [
+        new OutOfBandDidCommService({
+          id: 'didcomm',
+          serviceEndpoint: 'http://endpoint',
+          recipientKeys: ['did:key:z6MkqgkLrRyLg6bqk27djwbbaQWgaSYgFVCKq9YKxZbNkpVv'],
+        }),
+      ],
+      handshakeProtocols: [HandshakeProtocol.DidExchange],
+    })
+
+    expect(() => MessageValidator.validateSync(invitation)).not.toThrow()
+  })
+
+  test('Out-of-Band Invitation instance with string and object as services', async () => {
+    const invitation = new OutOfBandInvitation({
+      id: '69212a3a-d068-4f9d-a2dd-4741bca89af3',
+      label: 'Faber College',
+      services: [
+        'did:sov:LjgpST2rjsoxYegQDRm7EL',
+        new OutOfBandDidCommService({
+          id: 'didcomm',
+          serviceEndpoint: 'http://endpoint',
+          recipientKeys: ['did:key:z6MkqgkLrRyLg6bqk27djwbbaQWgaSYgFVCKq9YKxZbNkpVv'],
+        }),
+      ],
+      handshakeProtocols: [HandshakeProtocol.DidExchange],
+    })
+
+    expect(() => MessageValidator.validateSync(invitation)).not.toThrow()
   })
 })
 

--- a/packages/core/src/modules/oob/messages/OutOfBandInvitation.ts
+++ b/packages/core/src/modules/oob/messages/OutOfBandInvitation.ts
@@ -143,7 +143,6 @@ export class OutOfBandInvitation extends AgentMessage {
   @ArrayNotEmpty()
   @OutOfBandServiceTransformer()
   @IsStringOrInstance(OutOfBandDidCommService, { each: true })
-  @ValidateNested({ each: true })
   // eslint-disable-next-line @typescript-eslint/ban-types
   private services!: Array<OutOfBandDidCommService | string | String>
 


### PR DESCRIPTION
I'm not an expert (neither a fan 😝) of `class-validator` but I recently found an issue when creating an `OutOfBandInvitation` instance whose `service` field contains a plain string. It works and allows to do a `toUrl()` and so on, but when it passes through the MessageValidator it threw an error saying:

```
OutOfBandInvitation: Failed to validate class.
    An instance of OutOfBandInvitation has failed the validation:
     - property services[0] has failed the following constraints: each value in nested property services must be either object or array·
```

I found that services field has both `@IsStringOrInstance` and `@ValidateNested` decorators. The first one seems to be doing the correct check on every element of the array, while the latter (which is the one  throwing the error) seems to me redundant in this case. If I remove it, class validation passes (as expected). 

So here I'm removing `@ValidateNested` decorator. Not sure if it's the best approach, but of course happy to change it if there is a more appropriate way.