### PR TITLE
fix(core): remove node-fetch dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "@stablelib/ed25519": "^1.0.2",
     "@stablelib/random": "^1.0.1",
     "@stablelib/sha256": "^1.0.1",
+    "@types/node-fetch": "2.6.2",
     "@types/ws": "^8.5.4",
     "abort-controller": "^3.0.0",
     "big-integer": "^1.6.51",
@@ -41,7 +42,6 @@
     "lru_map": "^0.4.1",
     "luxon": "^3.3.0",
     "make-error": "^1.3.6",
-    "node-fetch": "^2.6.1",
     "object-inspect": "^1.10.3",
     "query-string": "^7.0.1",
     "reflect-metadata": "^0.1.13",
@@ -54,7 +54,6 @@
   "devDependencies": {
     "@types/events": "^3.0.0",
     "@types/luxon": "^3.2.0",
-    "@types/node-fetch": "2.6.2",
     "@types/object-inspect": "^1.8.0",
     "@types/uuid": "^9.0.1",
     "@types/varint": "^6.0.0",


### PR DESCRIPTION
Our good friend @dependabot with its #1565 made me remember we had this dependency on core that shouldn't be there. Didn't go further in order to not deal with breaking changes. I think we can move to node-fetch v3 (and see how to deal `AgentDependencies` types) in a next major release.

Fixes #1492