### PR TITLE
fix: duplicate service ids in connections protocol

### DIFF
--- a/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
+++ b/packages/core/src/modules/connections/__tests__/ConnectionService.test.ts
@@ -155,7 +155,7 @@ describe('ConnectionService', () => {
 
           service: [
             new IndyAgentService({
-              id: `XpwgBjsC2wh3eHcMW6ZRJT#IndyAgentService`,
+              id: `XpwgBjsC2wh3eHcMW6ZRJT#IndyAgentService-1`,
               serviceEndpoint: agentConfig.endpoints[0],
               recipientKeys: ['HoVPnpfUjrDECoMZy8vu4U6dwEcLhbzjNwyS3gwLDCG8'],
               routingKeys: [],
@@ -426,7 +426,7 @@ describe('ConnectionService', () => {
         authentication: [new ReferencedAuthentication(publicKey, authenticationTypes.Ed25519VerificationKey2018)],
         service: [
           new IndyAgentService({
-            id: `${did}#IndyAgentService`,
+            id: `${did}#IndyAgentService-1`,
             serviceEndpoint: 'http://example.com',
             recipientKeys: recipientKeys.map((did) => did.key.publicKeyBase58),
             routingKeys: [],

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -827,7 +827,7 @@ export class ConnectionService {
     const services = routing.endpoints.map(
       (endpoint, index) =>
         new IndyAgentService({
-          id: `${indyDid}#IndyAgentService`,
+          id: `${indyDid}#IndyAgentService-${index + 1}`,
           serviceEndpoint: endpoint,
           recipientKeys: [routing.recipientKey.publicKeyBase58],
           routingKeys: routing.routingKeys.map((key) => key.publicKeyBase58),
@@ -862,7 +862,7 @@ export class ConnectionService {
     const service = services.map(
       (service, index) =>
         new IndyAgentService({
-          id: `${did}#IndyAgentService`,
+          id: `${did}#IndyAgentService-${index + 1}`,
           serviceEndpoint: service.serviceEndpoint,
           recipientKeys: [recipientKey.publicKeyBase58],
           routingKeys: service.routingKeys?.map(didKeyToVerkey),


### PR DESCRIPTION
When creating the DID document, In `connections` protocol we are generating a DIDComm service per endpoint, but using the same `id` for all of them.