### PR TITLE
fix: implicit invitation to specific service

### DIFF
--- a/packages/core/src/modules/connections/ConnectionsModuleConfig.ts
+++ b/packages/core/src/modules/connections/ConnectionsModuleConfig.ts
@@ -7,6 +7,9 @@ export interface ConnectionsModuleConfigOptions {
    * Whether to automatically accept connection messages. Applies to both the connection protocol (RFC 0160)
    * and the DID exchange protocol (RFC 0023).
    *
+   * Note: this setting does not apply to implicit invitation flows, which always need to be manually accepted
+   * using ConnectionStateChangedEvent
+   *
    * @default false
    */
   autoAcceptConnections?: boolean

--- a/packages/core/src/modules/connections/services/ConnectionService.ts
+++ b/packages/core/src/modules/connections/services/ConnectionService.ts
@@ -32,6 +32,7 @@ import { DidRecordMetadataKeys } from '../../dids/repository/didRecordMetadataTy
 import { OutOfBandService } from '../../oob/OutOfBandService'
 import { OutOfBandRole } from '../../oob/domain/OutOfBandRole'
 import { OutOfBandState } from '../../oob/domain/OutOfBandState'
+import { InvitationType } from '../../oob/messages'
 import { OutOfBandRepository } from '../../oob/repository'
 import { OutOfBandRecordMetadataKeys } from '../../oob/repository/outOfBandRecordMetadataTypes'
 import { ConnectionEventTypes } from '../ConnectionEvents'
@@ -579,7 +580,7 @@ export class ConnectionService {
 
     // If the original invitation was a legacy connectionless invitation, it's okay if the message does not have a pthid.
     if (
-      legacyInvitationMetadata?.legacyInvitationType !== 'connectionless' &&
+      legacyInvitationMetadata?.legacyInvitationType !== InvitationType.Connectionless &&
       outOfBandRecord.outOfBandInvitation.id !== outOfBandInvitationId
     ) {
       throw new AriesFrameworkError(

--- a/packages/core/src/modules/didcomm/services/DidCommDocumentService.ts
+++ b/packages/core/src/modules/didcomm/services/DidCommDocumentService.ts
@@ -4,7 +4,7 @@ import type { ResolvedDidCommService } from '../types'
 import { KeyType } from '../../../crypto'
 import { injectable } from '../../../plugins'
 import { DidResolverService } from '../../dids'
-import { DidCommV1Service, IndyAgentService, keyReferenceToKey } from '../../dids/domain'
+import { DidCommV1Service, IndyAgentService, keyReferenceToKey, parseDid } from '../../dids/domain'
 import { verkeyToInstanceOfKey } from '../../dids/helpers'
 import { findMatchingEd25519Key } from '../util/matchingEd25519Key'
 
@@ -19,14 +19,19 @@ export class DidCommDocumentService {
   public async resolveServicesFromDid(agentContext: AgentContext, did: string): Promise<ResolvedDidCommService[]> {
     const didDocument = await this.didResolverService.resolveDidDocument(agentContext, did)
 
-    const didCommServices: ResolvedDidCommService[] = []
+    const resolvedServices: ResolvedDidCommService[] = []
+
+    // If did specifies a particular service, filter by its id (relative to did)
+    const didCommServices = parseDid(did).fragment
+      ? didDocument.didCommServices.filter((service) => service.id.split('#')[1] === parseDid(did).fragment)
+      : didDocument.didCommServices
 
     // FIXME: we currently retrieve did documents for all didcomm services in the did document, and we don't have caching
     // yet so this will re-trigger ledger resolves for each one. Should we only resolve the first service, then the second service, etc...?
-    for (const didCommService of didDocument.didCommServices) {
+    for (const didCommService of didCommServices) {
       if (didCommService instanceof IndyAgentService) {
         // IndyAgentService (DidComm v0) has keys encoded as raw publicKeyBase58 (verkeys)
-        didCommServices.push({
+        resolvedServices.push({
           id: didCommService.id,
           recipientKeys: didCommService.recipientKeys.map(verkeyToInstanceOfKey),
           routingKeys: didCommService.routingKeys?.map(verkeyToInstanceOfKey) || [],
@@ -54,7 +59,7 @@ export class DidCommDocumentService {
           return key
         })
 
-        didCommServices.push({
+        resolvedServices.push({
           id: didCommService.id,
           recipientKeys,
           routingKeys,
@@ -63,6 +68,6 @@ export class DidCommDocumentService {
       }
     }
 
-    return didCommServices
+    return resolvedServices
   }
 }

--- a/packages/core/src/modules/didcomm/services/DidCommDocumentService.ts
+++ b/packages/core/src/modules/didcomm/services/DidCommDocumentService.ts
@@ -21,9 +21,9 @@ export class DidCommDocumentService {
 
     const resolvedServices: ResolvedDidCommService[] = []
 
-    // If did specifies a particular service, filter by its id (relative to did)
+    // If did specifies a particular service, filter by its id
     const didCommServices = parseDid(did).fragment
-      ? didDocument.didCommServices.filter((service) => service.id.split('#')[1] === parseDid(did).fragment)
+      ? didDocument.didCommServices.filter((service) => service.id === did)
       : didDocument.didCommServices
 
     // FIXME: we currently retrieve did documents for all didcomm services in the did document, and we don't have caching

--- a/packages/core/src/modules/didcomm/services/__tests__/DidCommDocumentService.test.ts
+++ b/packages/core/src/modules/didcomm/services/__tests__/DidCommDocumentService.test.ts
@@ -117,5 +117,89 @@ describe('DidCommDocumentService', () => {
         routingKeys: [ed25519Key],
       })
     })
+
+    test('resolves specific DidCommV1Service', async () => {
+      const publicKeyBase58Ed25519 = 'GyYtYWU1vjwd5PFJM4VSX5aUiSV3TyZMuLBJBTQvfdF8'
+      const publicKeyBase58X25519 = 'S3AQEEKkGYrrszT9D55ozVVX2XixYp8uynqVm4okbud'
+
+      const Ed25519VerificationMethod: VerificationMethod = {
+        type: 'Ed25519VerificationKey2018',
+        controller: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
+        id: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h#key-1',
+        publicKeyBase58: publicKeyBase58Ed25519,
+      }
+      const X25519VerificationMethod: VerificationMethod = {
+        type: 'X25519KeyAgreementKey2019',
+        controller: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
+        id: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h#key-agreement-1',
+        publicKeyBase58: publicKeyBase58X25519,
+      }
+
+      mockFunction(didResolverService.resolveDidDocument).mockResolvedValue(
+        new DidDocument({
+          context: [
+            'https://w3id.org/did/v1',
+            'https://w3id.org/security/suites/ed25519-2018/v1',
+            'https://w3id.org/security/suites/x25519-2019/v1',
+          ],
+          id: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h',
+          verificationMethod: [Ed25519VerificationMethod, X25519VerificationMethod],
+          authentication: [Ed25519VerificationMethod.id],
+          keyAgreement: [X25519VerificationMethod.id],
+          service: [
+            new DidCommV1Service({
+              id: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h#test-id',
+              serviceEndpoint: 'https://test.com',
+              recipientKeys: [X25519VerificationMethod.id],
+              routingKeys: [Ed25519VerificationMethod.id],
+              priority: 5,
+            }),
+            new DidCommV1Service({
+              id: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h#test-id-2',
+              serviceEndpoint: 'wss://test.com',
+              recipientKeys: [X25519VerificationMethod.id],
+              routingKeys: [Ed25519VerificationMethod.id],
+              priority: 6,
+            }),
+          ],
+        })
+      )
+
+      let resolved = await didCommDocumentService.resolveServicesFromDid(
+        agentContext,
+        'did:sov:Q4zqM7aXqm7gDQkUVLng9h#test-id'
+      )
+      expect(didResolverService.resolveDidDocument).toHaveBeenCalledWith(
+        agentContext,
+        'did:sov:Q4zqM7aXqm7gDQkUVLng9h#test-id'
+      )
+
+      let ed25519Key = Key.fromPublicKeyBase58(publicKeyBase58Ed25519, KeyType.Ed25519)
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0]).toMatchObject({
+        id: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h#test-id',
+        serviceEndpoint: 'https://test.com',
+        recipientKeys: [ed25519Key],
+        routingKeys: [ed25519Key],
+      })
+
+      resolved = await didCommDocumentService.resolveServicesFromDid(
+        agentContext,
+        'did:sov:Q4zqM7aXqm7gDQkUVLng9h#test-id-2'
+      )
+      expect(didResolverService.resolveDidDocument).toHaveBeenCalledWith(
+        agentContext,
+        'did:sov:Q4zqM7aXqm7gDQkUVLng9h#test-id-2'
+      )
+
+      ed25519Key = Key.fromPublicKeyBase58(publicKeyBase58Ed25519, KeyType.Ed25519)
+      expect(resolved).toHaveLength(1)
+      expect(resolved[0]).toMatchObject({
+        id: 'did:sov:Q4zqM7aXqm7gDQkUVLng9h#test-id-2',
+        serviceEndpoint: 'wss://test.com',
+        recipientKeys: [ed25519Key],
+        routingKeys: [ed25519Key],
+      })
+    })
   })
 })

--- a/packages/core/src/modules/oob/OutOfBandApi.ts
+++ b/packages/core/src/modules/oob/OutOfBandApi.ts
@@ -461,7 +461,7 @@ export class OutOfBandApi {
     }
 
     // If the invitation was converted from another legacy format, we store this, as its needed for some flows
-    if (outOfBandInvitation.invitationType && outOfBandInvitation.invitationType !== 'out-of-band/1.x') {
+    if (outOfBandInvitation.invitationType && outOfBandInvitation.invitationType !== InvitationType.OutOfBand) {
       outOfBandRecord.metadata.set(OutOfBandRecordMetadataKeys.LegacyInvitation, {
         legacyInvitationType: outOfBandInvitation.invitationType,
       })
@@ -838,7 +838,7 @@ export class OutOfBandApi {
 
     // If the invitation is created from a legacy connectionless invitation, we don't need to set the pthid
     // as that's not expected, and it's generated on our side only
-    if (legacyInvitationMetadata?.legacyInvitationType === 'connectionless') {
+    if (legacyInvitationMetadata?.legacyInvitationType === InvitationType.Connectionless) {
       return
     }
 


### PR DESCRIPTION
It seems that  our implicit invitation implementation for DID Exchange does not conform exactly with what's written in [RFC 0023](https://github.com/hyperledger/aries-rfcs/blob/main/features/0023-did-exchange/README.md):

>An invitation is presented in one of two forms:

> An explicit [out-of-band invitation](https://github.com/hyperledger/aries-rfcs/blob/main/features/0434-outofband/README.md#messages) with its own @id.
> An implicit invitation contained in a DID document's [service](https://w3c-ccg.github.io/did-spec/#service-endpoints) attribute that conforms to the [DIDComm conventions](https://github.com/hyperledger/aries-rfcs/blob/main/features/0067-didcomm-diddoc-conventions/README.md#service-conventions).
> When a request responds to an explicit invitation, its ~thread.pthid MUST be equal to the @id property of the invitation [as described in the out-of-band RFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0434-outofband/README.md#correlating-responses-to-out-of-band-messages).
> 
> When a request responds to an implicit invitation, its ~thread.pthid MUST contain a [DID URL](https://w3c-ccg.github.io/did-spec/#dfn-did-url) that resolves to the specific service on a DID document that contains the invitation.

So it assumes that the implicit invitation should go to a specific service that contains a suitable DIDComm communication endpoint (e.g. `did:method:example#invitation`). However, in our implementation we are simply using the did and just selecting the highest priority DIDComm service.

Whilst I don't think it is bad for implicit invitations to work the way we are using it, here I'm adding the possibility of directing them to a specific service, so it will use it instead of resolving all DIDComm services the DID Document may have.