### PR TITLE
fix: save AnonCredsCredentialRecord createdAt

### DIFF
--- a/packages/anoncreds/src/repository/AnonCredsCredentialRecord.ts
+++ b/packages/anoncreds/src/repository/AnonCredsCredentialRecord.ts
@@ -5,6 +5,7 @@ import { BaseRecord, utils } from '@aries-framework/core'
 
 export interface AnonCredsCredentialRecordProps {
   id?: string
+  createdAt?: Date
   credential: AnonCredsCredential
   credentialId: string
   credentialRevocationId?: string
@@ -60,6 +61,7 @@ export class AnonCredsCredentialRecord extends BaseRecord<
 
     if (props) {
       this.id = props.id ?? utils.uuid()
+      this.createdAt = props.createdAt ?? new Date()
       this.credentialId = props.credentialId
       this.credential = props.credential
       this.credentialRevocationId = props.credentialRevocationId


### PR DESCRIPTION
For some unfortunate reason, we are not saving `createdAt` at AnonCredsCredentialRecord creation. This is useful to do things like sorting credentials by their issuance date (something available with W3C Credential Reacords)