### PR TITLE
feat: sped up lookup for revocation registries

### DIFF
--- a/packages/anoncreds/src/utils/getRevocationRegistries.ts
+++ b/packages/anoncreds/src/utils/getRevocationRegistries.ts
@@ -45,6 +45,7 @@ export async function getRevocationRegistriesForRequest(
       })
     }
 
+    const revocationRegistryPromises = []
     for (const { referent, selectedCredential, nonRevoked, type } of referentCredentials) {
       if (!selectedCredential.credentialInfo) {
         throw new AriesFrameworkError(
@@ -76,28 +77,30 @@ export async function getRevocationRegistriesForRequest(
           .resolve(AnonCredsRegistryService)
           .getRegistryForIdentifier(agentContext, revocationRegistryId)
 
-        // Fetch revocation registry definition if not in revocation registries list yet
-        if (!revocationRegistries[revocationRegistryId]) {
-          const { revocationRegistryDefinition, resolutionMetadata } = await registry.getRevocationRegistryDefinition(
-            agentContext,
-            revocationRegistryId
-          )
-          if (!revocationRegistryDefinition) {
-            throw new AriesFrameworkError(
-              `Could not retrieve revocation registry definition for revocation registry ${revocationRegistryId}: ${resolutionMetadata.message}`
-            )
-          }
+        revocationRegistryPromises.push(
+          (async () => {
+            // Fetch revocation registry definition if not in revocation registries list yet
+            if (!revocationRegistries[revocationRegistryId]) {
+              const { revocationRegistryDefinition, resolutionMetadata } =
+                await registry.getRevocationRegistryDefinition(agentContext, revocationRegistryId)
+              if (!revocationRegistryDefinition) {
+                throw new AriesFrameworkError(
+                  `Could not retrieve revocation registry definition for revocation registry ${revocationRegistryId}: ${resolutionMetadata.message}`
+                )
+              }
 
-          const { tailsLocation, tailsHash } = revocationRegistryDefinition.value
-          const { tailsFilePath } = await downloadTailsFile(agentContext, tailsLocation, tailsHash)
+              const { tailsLocation, tailsHash } = revocationRegistryDefinition.value
+              const { tailsFilePath } = await downloadTailsFile(agentContext, tailsLocation, tailsHash)
 
-          // const tails = await this.indyUtilitiesService.downloadTails(tailsHash, tailsLocation)
-          revocationRegistries[revocationRegistryId] = {
-            definition: revocationRegistryDefinition,
-            tailsFilePath,
-            revocationStatusLists: {},
-          }
-        }
+              // const tails = await this.indyUtilitiesService.downloadTails(tailsHash, tailsLocation)
+              revocationRegistries[revocationRegistryId] = {
+                definition: revocationRegistryDefinition,
+                tailsFilePath,
+                revocationStatusLists: {},
+              }
+            }
+          })()
+        )
 
         // In most cases we will have a timestamp, but if it's not defined, we use the nonRevoked.to value
         const timestampToFetch = timestamp ?? nonRevoked.to
@@ -133,7 +136,8 @@ export async function getRevocationRegistriesForRequest(
         }
       }
     }
-
+    // await all revocation registry statuses asynchronously
+    await Promise.all(revocationRegistryPromises)
     agentContext.config.logger.debug(`Retrieved revocation registries for proof request`, {
       revocationRegistries,
     })
@@ -153,6 +157,7 @@ export async function getRevocationRegistriesForRequest(
 export async function getRevocationRegistriesForProof(agentContext: AgentContext, proof: AnonCredsProof) {
   const revocationRegistries: VerifyProofOptions['revocationRegistries'] = {}
 
+  const revocationRegistryPromises = []
   for (const identifier of proof.identifiers) {
     const revocationRegistryId = identifier.rev_reg_id
     const timestamp = identifier.timestamp
@@ -164,38 +169,42 @@ export async function getRevocationRegistriesForProof(agentContext: AgentContext
       .resolve(AnonCredsRegistryService)
       .getRegistryForIdentifier(agentContext, revocationRegistryId)
 
-    // Fetch revocation registry definition if not already fetched
-    if (!revocationRegistries[revocationRegistryId]) {
-      const { revocationRegistryDefinition, resolutionMetadata } = await registry.getRevocationRegistryDefinition(
-        agentContext,
-        revocationRegistryId
-      )
-      if (!revocationRegistryDefinition) {
-        throw new AriesFrameworkError(
-          `Could not retrieve revocation registry definition for revocation registry ${revocationRegistryId}: ${resolutionMetadata.message}`
-        )
-      }
+    revocationRegistryPromises.push(
+      (async () => {
+        // Fetch revocation registry definition if not already fetched
+        if (!revocationRegistries[revocationRegistryId]) {
+          const { revocationRegistryDefinition, resolutionMetadata } = await registry.getRevocationRegistryDefinition(
+            agentContext,
+            revocationRegistryId
+          )
+          if (!revocationRegistryDefinition) {
+            throw new AriesFrameworkError(
+              `Could not retrieve revocation registry definition for revocation registry ${revocationRegistryId}: ${resolutionMetadata.message}`
+            )
+          }
 
-      revocationRegistries[revocationRegistryId] = {
-        definition: revocationRegistryDefinition,
-        revocationStatusLists: {},
-      }
-    }
+          revocationRegistries[revocationRegistryId] = {
+            definition: revocationRegistryDefinition,
+            revocationStatusLists: {},
+          }
+        }
 
-    // Fetch revocation status list by timestamp if not already fetched
-    if (!revocationRegistries[revocationRegistryId].revocationStatusLists[timestamp]) {
-      const { revocationStatusList, resolutionMetadata: statusListResolutionMetadata } =
-        await registry.getRevocationStatusList(agentContext, revocationRegistryId, timestamp)
+        // Fetch revocation status list by timestamp if not already fetched
+        if (!revocationRegistries[revocationRegistryId].revocationStatusLists[timestamp]) {
+          const { revocationStatusList, resolutionMetadata: statusListResolutionMetadata } =
+            await registry.getRevocationStatusList(agentContext, revocationRegistryId, timestamp)
 
-      if (!revocationStatusList) {
-        throw new AriesFrameworkError(
-          `Could not retrieve revocation status list for revocation registry ${revocationRegistryId}: ${statusListResolutionMetadata.message}`
-        )
-      }
+          if (!revocationStatusList) {
+            throw new AriesFrameworkError(
+              `Could not retrieve revocation status list for revocation registry ${revocationRegistryId}: ${statusListResolutionMetadata.message}`
+            )
+          }
 
-      revocationRegistries[revocationRegistryId].revocationStatusLists[timestamp] = revocationStatusList
-    }
+          revocationRegistries[revocationRegistryId].revocationStatusLists[timestamp] = revocationStatusList
+        }
+      })()
+    )
   }
-
+  await Promise.all(revocationRegistryPromises)
   return revocationRegistries
 }


### PR DESCRIPTION
Previously when fetching multiple revocation registries, afj would wait for the response from the first request before sending off the second request. I added functionality to send off all requests at once and then wait for all responses. This makes the code more async and faster