### PR TITLE
fix: abandon proof protocol if presentation fails

### DIFF
--- a/packages/core/src/modules/proofs/protocol/v2/ProofFormatCoordinator.ts
+++ b/packages/core/src/modules/proofs/protocol/v2/ProofFormatCoordinator.ts
@@ -463,7 +463,7 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       requestMessage: V2RequestPresentationMessage
       formatServices: ProofFormatService[]
     }
-  ) {
+  ): Promise<{ isValid: true; message: undefined } | { isValid: false; message: string }> {
     const didCommMessageRepository = agentContext.dependencyManager.resolve(DidCommMessageRepository)
 
     const formatVerificationResults: boolean[] = []
@@ -476,13 +476,21 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
         requestMessage.requestAttachments
       )
 
-      const isValid = await formatService.processPresentation(agentContext, {
-        attachment,
-        requestAttachment,
-        proofRecord,
-      })
+      try {
+        // TODO: this should return a more complex object explaining why it is invalid
+        const isValid = await formatService.processPresentation(agentContext, {
+          attachment,
+          requestAttachment,
+          proofRecord,
+        })
 
-      formatVerificationResults.push(isValid)
+        formatVerificationResults.push(isValid)
+      } catch (error) {
+        return {
+          message: error.message,
+          isValid: false,
+        }
+      }
     }
 
     await didCommMessageRepository.saveOrUpdateAgentMessage(agentContext, {
@@ -491,7 +499,19 @@ export class ProofFormatCoordinator<PFs extends ProofFormatService[]> {
       associatedRecordId: proofRecord.id,
     })
 
-    return formatVerificationResults.every((isValid) => isValid === true)
+    const isValid = formatVerificationResults.every((isValid) => isValid === true)
+
+    if (isValid) {
+      return {
+        isValid,
+        message: undefined,
+      }
+    } else {
+      return {
+        isValid,
+        message: 'Not all presentations are valid',
+      }
+    }
   }
 
   public getAttachmentForService(


### PR DESCRIPTION
Abandon the proof protocol if the presentation processing fails. It will send a problem report, and it will set the error message on the proof record.