### PR TITLE
feat: update dockerfile to node 18 and sample mediator to askar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ARG DEBIAN_FRONTEND noninteractive
 # Define packages to install
 ENV PACKAGES software-properties-common ca-certificates \
     curl build-essential git \
-    libzmq3-dev libsodium-dev pkg-config
+    libzmq3-dev libsodium-dev pkg-config gnupg
 
 # Combined update and install to ensure Docker caching works correctly
 RUN apt-get update -y \
@@ -24,7 +24,9 @@ RUN curl http://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1-1
 # Add APT sources
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CE7709D068DB5E88 \
     && add-apt-repository "deb https://repo.sovrin.org/sdk/deb bionic stable" \
-    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_18.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list  \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "next-version-bump": "ts-node ./scripts/get-next-bump.ts"
   },
   "devDependencies": {
+    "@hyperledger/aries-askar-nodejs": "^0.2.0-dev.1",
     "@types/cors": "^2.8.10",
     "@types/eslint": "^8.21.2",
     "@types/express": "^4.17.13",

--- a/samples/mediator.ts
+++ b/samples/mediator.ts
@@ -15,12 +15,13 @@
 import type { InitConfig } from '@aries-framework/core'
 import type { Socket } from 'net'
 
+import { ariesAskar } from '@hyperledger/aries-askar-nodejs'
 import express from 'express'
-import * as indySdk from 'indy-sdk'
 import { Server } from 'ws'
 
 import { TestLogger } from '../packages/core/tests/logger'
 
+import { AskarModule } from '@aries-framework/askar'
 import {
   ConnectionsModule,
   MediatorModule,
@@ -30,7 +31,6 @@ import {
   LogLevel,
   WsOutboundTransport,
 } from '@aries-framework/core'
-import { IndySdkModule } from '@aries-framework/indy-sdk'
 import { HttpInboundTransport, agentDependencies, WsInboundTransport } from '@aries-framework/node'
 
 const port = process.env.AGENT_PORT ? Number(process.env.AGENT_PORT) : 3001
@@ -60,7 +60,7 @@ const agent = new Agent({
   config: agentConfig,
   dependencies: agentDependencies,
   modules: {
-    indySdk: new IndySdkModule({ indySdk }),
+    askar: new AskarModule({ ariesAskar }),
     mediator: new MediatorModule({
       autoAcceptMediationRequests: true,
     }),


### PR DESCRIPTION
Intermediate solution until we finally remove `indy-sdk` dependency: current Dockerfile won't work because it install node 16 and we now require at least 18, so here we are updating it. Also upgraded sample mediator to use Aries Askar, which now works properly due to the patched `ref-napi` library.

Resolves #1621 