### PR TITLE
build(deps): use node's built-in fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@types/eslint": "^8.21.2",
     "@types/express": "^4.17.13",
     "@types/jest": "^29.5.5",
-    "@types/node": "^16.11.7",
+    "@types/node": "^18.18.8",
     "@types/uuid": "^9.0.1",
     "@types/varint": "^6.0.0",
     "@types/ws": "^8.5.4",
@@ -61,7 +61,7 @@
     "ws": "^8.13.0"
   },
   "resolutions": {
-    "@types/node": "^16.11.7"
+    "@types/node": "18.18.8"
   },
   "engines": {
     "node": ">=18"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,7 +30,6 @@
     "@stablelib/ed25519": "^1.0.2",
     "@stablelib/random": "^1.0.1",
     "@stablelib/sha256": "^1.0.1",
-    "@types/node-fetch": "2.6.2",
     "@types/ws": "^8.5.4",
     "abort-controller": "^3.0.0",
     "big-integer": "^1.6.51",

--- a/packages/core/src/agent/AgentDependencies.ts
+++ b/packages/core/src/agent/AgentDependencies.ts
@@ -1,6 +1,5 @@
 import type { FileSystem } from '../storage/FileSystem'
 import type { EventEmitter } from 'events'
-import type fetch from 'node-fetch'
 import type WebSocket from 'ws'
 
 export interface AgentDependencies {

--- a/packages/core/src/transport/HttpOutboundTransport.ts
+++ b/packages/core/src/transport/HttpOutboundTransport.ts
@@ -3,7 +3,6 @@ import type { Agent } from '../agent/Agent'
 import type { AgentMessageReceivedEvent } from '../agent/Events'
 import type { Logger } from '../logger'
 import type { OutboundPackage } from '../types'
-import type fetch from 'node-fetch'
 
 import { AbortController } from 'abort-controller'
 
@@ -53,7 +52,7 @@ export class HttpOutboundTransport implements OutboundTransport {
           method: 'POST',
           body: JSON.stringify(payload),
           headers: { 'Content-Type': this.agent.config.didCommMimeType },
-          signal: abortController.signal,
+          signal: abortController.signal as NonNullable<RequestInit['signal']>,
         })
         clearTimeout(id)
         responseMessage = await response.text()

--- a/packages/core/src/utils/__tests__/shortenedUrl.test.ts
+++ b/packages/core/src/utils/__tests__/shortenedUrl.test.ts
@@ -1,7 +1,3 @@
-import type { Response } from 'node-fetch'
-
-import { Headers } from 'node-fetch'
-
 import { ConnectionInvitationMessage } from '../../modules/connections'
 import { InvitationType, OutOfBandInvitation } from '../../modules/oob'
 import { convertToNewInvitation } from '../../modules/oob/helpers'
@@ -51,7 +47,7 @@ const mockedResponseOobUrl = {
   url: 'https://wonderful-rabbit-5.tun2.indiciotech.io?oob=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9vdXQtb2YtYmFuZC8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiNzY0YWYyNTktOGJiNC00NTQ2LWI5MWEtOTI0YzkxMmQwYmI4IiwgImxhYmVsIjogIkFsaWNlIiwgImhhbmRzaGFrZV9wcm90b2NvbHMiOiBbImRpZDpzb3Y6QnpDYnNOWWhNcmpIaXFaRFRVQVNIZztzcGVjL2Nvbm5lY3Rpb25zLzEuMCJdLCAic2VydmljZXMiOiBbImRpZDpzb3Y6TXZUcVZYQ0VtSjg3dXNMOXVRVG83diJdfQ====',
 } as Response
 
-mockedResponseOobUrl.headers = dummyHeader
+dummyHeader.forEach(mockedResponseOobUrl.headers.append)
 
 const mockedResponseConnectionJson = {
   status: 200,
@@ -63,17 +59,15 @@ const mockedResponseConnectionJson = {
     serviceEndpoint: 'http://sour-cow-15.tun1.indiciotech.io',
     recipientKeys: ['5Gvpf9M4j7vWpHyeTyvBKbjYe7qWc72kGo6qZaLHkLrd'],
   }),
+  headers: header,
 } as Response
-
-mockedResponseConnectionJson['headers'] = header
 
 const mockedResponseConnectionUrl = {
   status: 200,
   ok: true,
   url: 'http://sour-cow-15.tun1.indiciotech.io?c_i=eyJAdHlwZSI6ICJkaWQ6c292OkJ6Q2JzTlloTXJqSGlxWkRUVUFTSGc7c3BlYy9jb25uZWN0aW9ucy8xLjAvaW52aXRhdGlvbiIsICJAaWQiOiAiMjA5NzFlZjAtMTAyOS00NmRiLWEyNWItYWY0YzQ2NWRkMTZiIiwgImxhYmVsIjogInRlc3QiLCAic2VydmljZUVuZHBvaW50IjogImh0dHA6Ly9zb3VyLWNvdy0xNS50dW4xLmluZGljaW90ZWNoLmlvIiwgInJlY2lwaWVudEtleXMiOiBbIjVHdnBmOU00ajd2V3BIeWVUeXZCS2JqWWU3cVdjNzJrR282cVphTEhrTHJkIl19',
+  headers: dummyHeader,
 } as Response
-
-mockedResponseConnectionUrl['headers'] = dummyHeader
 
 let outOfBandInvitationMock: OutOfBandInvitation
 let connectionInvitationMock: ConnectionInvitationMessage
@@ -126,7 +120,7 @@ describe('shortened urls resolving to connection invitations', () => {
       url: 'https://oob.lissi.io/ssi?oob=eyJAdHlwZSI6ImRpZDpzb3Y6QnpDYnNOWWhNcmpIaXFaRFRVQVNIZztzcGVjL2Nvbm5lY3Rpb25zLzEuMC9pbnZpdGF0aW9uIiwiQGlkIjoiMGU0NmEzYWEtMzUyOC00OTIxLWJmYjItN2JjYjk0NjVjNjZjIiwibGFiZWwiOiJTdGFkdCB8IExpc3NpLURlbW8iLCJzZXJ2aWNlRW5kcG9pbnQiOiJodHRwczovL2RlbW8tYWdlbnQuaW5zdGl0dXRpb25hbC1hZ2VudC5saXNzaS5pZC9kaWRjb21tLyIsImltYWdlVXJsIjoiaHR0cHM6Ly9yb3V0aW5nLmxpc3NpLmlvL2FwaS9JbWFnZS9kZW1vTXVzdGVyaGF1c2VuIiwicmVjaXBpZW50S2V5cyI6WyJEZlcxbzM2ekxuczlVdGlDUGQyalIyS2pvcnRvZkNhcFNTWTdWR2N2WEF6aCJdfQ',
     } as Response
 
-    mockedResponseConnectionInOobUrl.headers = dummyHeader
+    dummyHeader.forEach(mockedResponseConnectionInOobUrl.headers.append)
 
     const expectedOobMessage = convertToNewInvitation(
       JsonTransformer.fromJSON(

--- a/packages/core/src/utils/parseInvitation.ts
+++ b/packages/core/src/utils/parseInvitation.ts
@@ -1,5 +1,4 @@
 import type { AgentDependencies } from '../agent/AgentDependencies'
-import type { Response } from 'node-fetch'
 
 import { AbortController } from 'abort-controller'
 import { parseUrl } from 'query-string'
@@ -90,7 +89,7 @@ export const parseInvitationUrl = (invitationUrl: string): OutOfBandInvitation =
 export const oobInvitationFromShortUrl = async (response: Response): Promise<OutOfBandInvitation> => {
   if (response) {
     if (response.headers.get('Content-Type')?.startsWith('application/json') && response.ok) {
-      const invitationJson = await response.json()
+      const invitationJson = (await response.json()) as Record<string, unknown>
       return parseInvitationJson(invitationJson)
     } else if (response['url']) {
       // The following if else is for here for trinsic shorten urls

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -29,13 +29,10 @@
     "@aries-framework/core": "0.4.2",
     "@types/express": "^4.17.15",
     "express": "^4.17.1",
-    "node-fetch": "^2.6.1",
     "ws": "^8.13.0"
   },
   "devDependencies": {
-    "@types/node": "^16.11.7",
-    "@types/node-fetch": "2.6.2",
-    "@types/ref-napi": "^3.0.4",
+    "@types/node": "^18.18.8",
     "@types/ws": "^8.5.4",
     "nock": "^13.3.0",
     "rimraf": "^4.4.0",

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,7 +1,6 @@
 import type { AgentDependencies } from '@aries-framework/core'
 
 import { EventEmitter } from 'events'
-import fetch from 'node-fetch'
 import WebSocket from 'ws'
 
 import { NodeFileSystem } from './NodeFileSystem'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2889,18 +2889,12 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/node-fetch@2.6.2":
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.2.tgz#d1a9c5fd049d9415dce61571557104dec3ec81da"
-  integrity sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==
+"@types/node@*", "@types/node@18.18.8", "@types/node@>=13.7.0", "@types/node@^18.18.8":
+  version "18.18.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.18.8.tgz#2b285361f2357c8c8578ec86b5d097c7f464cfd6"
+  integrity sha512-OLGBaaK5V3VRBS1bAkMVP2/W9B+H8meUfl866OrMNQqt7wDgdpWPp5o6gmIc9pB+lIQHSq4ZL8ypeH1vPxcPaQ==
   dependencies:
-    "@types/node" "*"
-    form-data "^3.0.0"
-
-"@types/node@*", "@types/node@>=13.7.0", "@types/node@^16.11.7":
-  version "16.18.24"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.24.tgz#f21925dd56cd3467b4e1e0c5071d0f2af5e9a316"
-  integrity sha512-zvSN2Esek1aeLdKDYuntKAYjti9Z2oT4I8bfkLLhIxHlv3dwZ5vvATxOc31820iYm4hQRCwjUgDpwSMFjfTUnw==
+    undici-types "~5.26.4"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"
@@ -2938,13 +2932,6 @@
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/@types/ref-napi/-/ref-napi-3.0.7.tgz#20adc93a7a2f9f992dfb17409fd748e6f4bf403d"
   integrity sha512-CzPwr36VkezSpaJGdQX/UrczMSDsDgsWQQFEfQkS799Ft7n/s183a53lsql7RwVq+Ik4yLEgI84pRnLC0XXRlA==
-  dependencies:
-    "@types/node" "*"
-
-"@types/ref-napi@^3.0.4":
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/@types/ref-napi/-/ref-napi-3.0.8.tgz#7b4a131064f66d2decd6ddcb39d9b0b793e55e7f"
-  integrity sha512-L6yis+3lww27qQXLFS3eipTSivnYurvfMfttjF3kLUfIIhJ/ZUtcoF6JUcJ+AObdE4S6zK+h9ou5CmyLJJw/3w==
   dependencies:
     "@types/node" "*"
 
@@ -5909,15 +5896,6 @@ for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
   integrity sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==
-
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    mime-types "^2.1.12"
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -9170,7 +9148,7 @@ node-fetch@3.0.0-beta.9:
     data-uri-to-buffer "^3.0.1"
     fetch-blob "^2.1.1"
 
-node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.1, node-fetch@^2.6.7:
+node-fetch@^2.2.0, node-fetch@^2.6.0, node-fetch@^2.6.7:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.9.tgz#7c7f744b5cc6eb5fd404e0c7a9fec630a55657e6"
   integrity sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==
@@ -11993,6 +11971,11 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+undici-types@~5.26.4:
+  version "5.26.5"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
+  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
As now our minimal supported node version is 18, which has a built-in fetch API, this is an attempt to get rid of external `node-fetch` dependency on `@aries-framework/core`.

Credits to @dependabot, who give us the idea!