### PR TITLE
feat: bump indy-vdr version

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -14,7 +14,7 @@
     "refresh": "rm -rf ./node_modules ./yarn.lock && yarn"
   },
   "dependencies": {
-    "@hyperledger/indy-vdr-nodejs": "^0.2.0-dev.3",
+    "@hyperledger/indy-vdr-nodejs": "^0.2.0-dev.5",
     "@hyperledger/anoncreds-nodejs": "^0.2.0-dev.4",
     "@hyperledger/aries-askar-nodejs": "^0.2.0-dev.1",
     "inquirer": "^8.2.5"

--- a/packages/indy-vdr/package.json
+++ b/packages/indy-vdr/package.json
@@ -28,8 +28,8 @@
     "@aries-framework/core": "0.4.2"
   },
   "devDependencies": {
-    "@hyperledger/indy-vdr-nodejs": "^0.2.0-dev.3",
-    "@hyperledger/indy-vdr-shared": "^0.2.0-dev.3",
+    "@hyperledger/indy-vdr-nodejs": "^0.2.0-dev.5",
+    "@hyperledger/indy-vdr-shared": "^0.2.0-dev.5",
     "@stablelib/ed25519": "^1.0.2",
     "@types/ref-array-di": "^1.2.6",
     "@types/ref-struct-di": "^1.1.10",
@@ -38,6 +38,6 @@
     "typescript": "~4.9.5"
   },
   "peerDependencies": {
-    "@hyperledger/indy-vdr-shared": "^0.2.0-dev.3"
+    "@hyperledger/indy-vdr-shared": "^0.2.0-dev.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,22 +1242,22 @@
   dependencies:
     buffer "^6.0.3"
 
-"@hyperledger/indy-vdr-nodejs@^0.2.0-dev.3":
-  version "0.2.0-dev.3"
-  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-nodejs/-/indy-vdr-nodejs-0.2.0-dev.3.tgz#c7262df6545606c893994e236c635c287cd64fd0"
-  integrity sha512-W4z8AtrNGb4hbbdisz6HAFqyAoX9c4oT3qo/8mizKyuYCSiSwlmAllkIFjCt93xyYmecTivkY2V2BcWpaUW47A==
+"@hyperledger/indy-vdr-nodejs@^0.2.0-dev.5":
+  version "0.2.0-dev.5"
+  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-nodejs/-/indy-vdr-nodejs-0.2.0-dev.5.tgz#ea40095116e0abdd4c28214122f01669367f1db5"
+  integrity sha512-TeeapuZBRS7+Tbn8QQ3RoMpGaI/QHjeU7TlDU5UHNoEFuZcBdDcdH6V9QAoJ1RNxc6k7tiUYKFir8LMQ+hXrXQ==
   dependencies:
     "@2060.io/ffi-napi" "4.0.8"
     "@2060.io/ref-napi" "3.0.6"
-    "@hyperledger/indy-vdr-shared" "0.2.0-dev.3"
+    "@hyperledger/indy-vdr-shared" "0.2.0-dev.5"
     "@mapbox/node-pre-gyp" "^1.0.10"
     ref-array-di "^1.2.2"
     ref-struct-di "^1.1.1"
 
-"@hyperledger/indy-vdr-shared@0.2.0-dev.3", "@hyperledger/indy-vdr-shared@^0.2.0-dev.3":
-  version "0.2.0-dev.3"
-  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-shared/-/indy-vdr-shared-0.2.0-dev.3.tgz#14994a034691ffe08e14e5f7d60fd63237616d04"
-  integrity sha512-5/zgSxp4zZUuFLabWdpB6ttfD0aLIquR9qab+HAJFUYDiWGHKP7bztiu07p4Dvhtgah+ZFOFgQo7WC492DXBoQ==
+"@hyperledger/indy-vdr-shared@0.2.0-dev.5", "@hyperledger/indy-vdr-shared@^0.2.0-dev.5":
+  version "0.2.0-dev.5"
+  resolved "https://registry.yarnpkg.com/@hyperledger/indy-vdr-shared/-/indy-vdr-shared-0.2.0-dev.5.tgz#ab33feda90dcbf457f3ff59da266ab32968ab48c"
+  integrity sha512-oPvNG5ePvtuz3H+KxWdCdxWXeo3Jxs8AFAAuG8qLPSlicEHpWchbT1amun8ccp1lk7pIBx9J0aLf08yrM5H8iw==
 
 "@isaacs/string-locale-compare@^1.1.0":
   version "1.1.0"


### PR DESCRIPTION

It is already done in other open PRs, but just wanted to do this small one as it is getting a bit annoying to work on macOS these days 😞. This new release of `indy-vdr` wrapper takes the correct binary for this platform.