### PR TITLE
fix(webvh): adjust publicKeyMultibase decoding in EddsaJcs2022Cryptosuite

### DIFF
--- a/packages/webvh/src/cryptosuites/eddsa-jcs-2022.ts
+++ b/packages/webvh/src/cryptosuites/eddsa-jcs-2022.ts
@@ -1,7 +1,7 @@
 import type { ProofOptions } from './types'
 import type { WebVhResource } from '../anoncreds/utils/transform'
 
-import { type AgentContext, CredoError } from '@credo-ts/core'
+import { type AgentContext, CredoError, Key } from '@credo-ts/core'
 import { DidsApi, Hasher, MultiBaseEncoder, TypedArrayEncoder } from '@credo-ts/core'
 import { canonicalize } from 'json-canonicalize'
 
@@ -24,7 +24,7 @@ export class EddsaJcs2022Cryptosuite {
     const didDocument = await this.didApi.resolveDidDocument(verificationMethodId)
     const verificationMethod = didDocument.dereferenceVerificationMethod(verificationMethodId)
     if ('publicKeyMultibase' in verificationMethod && verificationMethod.publicKeyMultibase) {
-      return MultiBaseEncoder.decode(verificationMethod.publicKeyMultibase).data
+      return Key.fromFingerprint(verificationMethod.publicKeyMultibase).publicKey
     }
     return null
   }


### PR DESCRIPTION
Looks like this function was trying to use the multibase headers in the public key (this is only a bug on the v0.5.x branch)