### PR TITLE
fix(hedera): Set build folder references in publishConfig

### DIFF
--- a/packages/hedera/package.json
+++ b/packages/hedera/package.json
@@ -6,6 +6,8 @@
   "files": ["build"],
   "license": "Apache-2.0",
   "publishConfig": {
+    "main": "build/index",
+    "types": "build/index",
     "access": "public"
   },
   "homepage": "https://github.com/openwallet-foundation/credo-ts/tree/main/packages/hedera",


### PR DESCRIPTION
This PR updates Hedera package `publishConfig` to properly change references from `src` to build folder in published `package.json`.