### PR TITLE
fix(hedera): Set build folder references in publishConfig (backport of #2442)

### DIFF
--- a/packages/hedera/package.json
+++ b/packages/hedera/package.json
@@ -8,6 +8,8 @@
   ],
   "license": "Apache-2.0",
   "publishConfig": {
+    "main": "build/index",
+    "types": "build/index",
     "access": "public"
   },
   "homepage": "https://github.com/openwallet-foundation/credo-ts/tree/main/packages/hedera",


### PR DESCRIPTION
This PR updates Hedera package `publishConfig` to properly change references from `src` to build folder in published `package.json`.

Backport of #2442 for Credo 0.5.x.

