### PR TITLE
fix: authorization session expiry

### DIFF
--- a/packages/openid4vc/src/openid4vc-verifier/OpenId4VcVerifierModuleConfig.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/OpenId4VcVerifierModuleConfig.ts
@@ -73,7 +73,7 @@ export class OpenId4VcVerifierModuleConfig {
    *
    * @default 300
    */
-  public get authorizationRequestExpiresInSeconds() {
+  public get authorizationRequestExpirationInSeconds() {
     return this.options.authorizationRequestExpirationInSeconds ?? 300
   }
 }

--- a/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts
@@ -285,7 +285,7 @@ export class OpenId4VpVerifierService {
         ? {
             jwtSigner: jwtIssuer,
             requestUri: hostedAuthorizationRequestUri,
-            expiresInSeconds: this.config.authorizationRequestExpiresInSeconds,
+            expiresInSeconds: this.config.authorizationRequestExpirationInSeconds,
           }
         : undefined,
       authorizationRequestPayload:
@@ -319,7 +319,7 @@ export class OpenId4VpVerifierService {
       authorizationRequestId,
       state: OpenId4VcVerificationSessionState.RequestCreated,
       verifierId: options.verifier.verifierId,
-      expiresAt: utils.addSecondsToDate(new Date(), this.config.authorizationRequestExpiresInSeconds),
+      expiresAt: utils.addSecondsToDate(new Date(), this.config.authorizationRequestExpirationInSeconds),
       openId4VpVersion: version,
     })
     await this.openId4VcVerificationSessionRepository.save(agentContext, verificationSession)


### PR DESCRIPTION
The `authorizationRequestExpiresInSeconds` getter was returning the default value (300) even when `authorizationRequestExpirationInSeconds` was passed in the verifier config during agent initialization.

The [config](https://github.com/openwallet-foundation/credo-ts/blob/c5e2a218c10b64bd5288c5f54b454259d588c162/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts#L101) object inside the `OpenId4VpVerifierService` class contains another `OpenId4VcVerifierModuleConfig` instance instead of the raw option attributes, causing the getter in `OpenId4VcVerifierModuleConfig` to always fall back to its default.

This PR fixes the issue by ensuring the getter resolves the correct configuration value for authorization session expiry.  I'm not entirely sure whether this nested config behavior is intentional or a construction issue.

```
OpenId4VcVerifierModuleConfig {
  options: OpenId4VcVerifierModuleConfig {
    options: {
      baseUrl: 'https://ad3d603bfbeb.ngrok-free.app/oid4vp',
      router: [Function],
      authorizationRequestExpirationInSeconds: 3600
    },
    router: [Function: router] {
      caseSensitive: undefined,
      mergeParams: undefined,
      params: [Object],
      strict: undefined,
      stack: [Array]
    }
  },
  router: [Function: router] {
    caseSensitive: undefined,
    mergeParams: undefined,
    params: { verifierId: [Array] },
    strict: undefined,
    stack: [ [Layer], [Layer], [Layer], [Layer], [Layer] ]
  }
}
```