### PR TITLE
chore: allow two storage versions

### DIFF
--- a/packages/core/src/storage/migration/StorageUpdateService.ts
+++ b/packages/core/src/storage/migration/StorageUpdateService.ts
@@ -7,7 +7,11 @@ import { isStorageUpToDate } from './isUpToDate'
 import { StorageVersionRecord } from './repository/StorageVersionRecord'
 import { StorageVersionRepository } from './repository/StorageVersionRepository'
 import type { UpdateToVersion } from './updates'
-import { CURRENT_FRAMEWORK_STORAGE_VERSION, INITIAL_STORAGE_VERSION } from './updates'
+import {
+  CURRENT_FRAMEWORK_STORAGE_VERSION,
+  INITIAL_STORAGE_VERSION,
+  PREVIOUS_FRAMEWORK_STORAGE_VERSION,
+} from './updates'
 
 @injectable()
 export class StorageUpdateService {
@@ -44,6 +48,10 @@ export class StorageUpdateService {
 
   public static get frameworkStorageVersion() {
     return CURRENT_FRAMEWORK_STORAGE_VERSION
+  }
+
+  public static get previousFrameworkStorageVersion() {
+    return PREVIOUS_FRAMEWORK_STORAGE_VERSION
   }
 
   public async setCurrentStorageVersion(agentContext: AgentContext, storageVersion: VersionString) {

--- a/packages/core/src/storage/migration/UpdateAssistant.ts
+++ b/packages/core/src/storage/migration/UpdateAssistant.ts
@@ -6,7 +6,12 @@ import { StorageUpdateError } from './error/StorageUpdateError'
 
 import { StorageUpdateService } from './StorageUpdateService'
 import type { Update, UpdateConfig, UpdateToVersion } from './updates'
-import { CURRENT_FRAMEWORK_STORAGE_VERSION, DEFAULT_UPDATE_CONFIG, supportedUpdates } from './updates'
+import {
+  CURRENT_FRAMEWORK_STORAGE_VERSION,
+  DEFAULT_UPDATE_CONFIG,
+  PREVIOUS_FRAMEWORK_STORAGE_VERSION,
+  supportedUpdates,
+} from './updates'
 
 export interface UpdateAssistantUpdateOptions {
   updateToVersion?: UpdateToVersion
@@ -41,6 +46,10 @@ export class UpdateAssistant<Agent extends BaseAgent<any> = BaseAgent> {
 
   public static get frameworkStorageVersion() {
     return CURRENT_FRAMEWORK_STORAGE_VERSION
+  }
+
+  public static get previousFrameworkStorageVersion() {
+    return PREVIOUS_FRAMEWORK_STORAGE_VERSION
   }
 
   public async getNeededUpdates(toVersion?: UpdateToVersion) {

--- a/packages/core/src/storage/migration/updates.ts
+++ b/packages/core/src/storage/migration/updates.ts
@@ -59,6 +59,11 @@ export const CURRENT_FRAMEWORK_STORAGE_VERSION = supportedUpdates[supportedUpdat
   typeof supportedUpdates
 >['toVersion']
 
+// Previous version is second-last toVersion from the supported updates
+export const PREVIOUS_FRAMEWORK_STORAGE_VERSION = supportedUpdates[supportedUpdates.length - 2].toVersion as LastItem<
+  typeof supportedUpdates
+>['toVersion']
+
 export const STORAGE_VERSION_RECORD_ID = 'STORAGE_VERSION_RECORD_ID'
 
 type LastItem<T extends readonly unknown[]> = T extends readonly [...infer _, infer U] ? U : T[0] | undefined


### PR DESCRIPTION
As discussed during the Credo WG call, this PR allows the last two storage versions to be used. This means you can already update to Credo 0.6, and then run the migration at a later stage. Not updating immediately may impact some behaviour (especially if you rely on new features), but we aim to support two storage versions.

Still draft as I need to update existing and add new tests. But I was surprised that the logic to support two versions was quite simple.
