### PR TITLE
feat: add sd-jwt credential status validation

### DIFF
--- a/packages/core/src/modules/sd-jwt-vc/SdJwtVcService.ts
+++ b/packages/core/src/modules/sd-jwt-vc/SdJwtVcService.ts
@@ -610,8 +610,13 @@ export class SdJwtVcService {
           } when fetching status list from ${uri}. ${await response.text()}`
         )
       }
-
-      return await response.text()
+      const responseText = await response.text()
+      const statusListJwt = Jwt.fromSerializedJwt(responseText)
+      // according to draft-ietf-oauth-status-list-13 status provider jwt 'sub' must match 'status_list.uri'
+      if (statusListJwt.payload.sub !== uri) {
+        throw new CredoError(`Status list provider JWT sub does not match the status_list.uri.`)
+      }
+      return responseText
     }
   }
   private getStatusVerifier(agentContext: AgentContext) {


### PR DESCRIPTION
Added credential status validation for SD-JWT VCs when a status attribute is present in the credential payload.
Now the flow checks both:
- The status provder’s signature on the status list JWT (via JWKS endpoint)
- And the actual status value (only valid when status = 0 according to ietf status list draft 13)

Not 100% sure if I’ve covered all edge cases, so any suggestions or improvements are super welcome!