### PR TITLE
fix: directory import cheqd

### DIFF
--- a/packages/cheqd/src/dids/CheqdDidRegistrar.ts
+++ b/packages/cheqd/src/dids/CheqdDidRegistrar.ts
@@ -7,7 +7,7 @@ import {
   VerificationMethods,
 } from '@cheqd/sdk'
 import type { SignInfo } from '@cheqd/ts-proto/cheqd/did/v2'
-import { MsgCreateResourcePayload } from '@cheqd/ts-proto/cheqd/resource/v2'
+import { MsgCreateResourcePayload } from '@cheqd/ts-proto/cheqd/resource/v2/index.js'
 import {
   AgentContext,
   type AnyUint8Array,

--- a/packages/cheqd/src/dids/didCheqdUtil.ts
+++ b/packages/cheqd/src/dids/didCheqdUtil.ts
@@ -6,7 +6,7 @@ import {
   DIDModule,
   VerificationMethods,
 } from '@cheqd/sdk'
-import { MsgCreateDidDocPayload, MsgDeactivateDidDocPayload } from '@cheqd/ts-proto/cheqd/did/v2'
+import { MsgCreateDidDocPayload, MsgDeactivateDidDocPayload } from '@cheqd/ts-proto/cheqd/did/v2/index.js'
 import type { Metadata } from '@cheqd/ts-proto/cheqd/resource/v2'
 import { EnglishMnemonic as _EnglishMnemonic } from '@cosmjs/crypto'
 import { DirectSecp256k1HdWallet, DirectSecp256k1Wallet } from '@cosmjs/proto-signing'


### PR DESCRIPTION
At some point we should update all our imports to ESM imports in Credo, and not rely on the `bundler` to handle this. But that's a lot of work (I hope there's a migration tool) and so for now we just fix the issues when using the Credo ESM bundle