### PR TITLE
fix(openid4vc): throw proper validation error on dcql

### DIFF
--- a/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts
+++ b/packages/openid4vc/src/openid4vc-verifier/OpenId4VpVerifierService.ts
@@ -594,12 +594,22 @@ export class OpenId4VpVerifierService {
           )
         )
 
-        const presentationResult = await dcql.assertValidDcqlPresentation(agentContext, presentations, dcqlQuery)
+        try {
+          const presentationResult = await dcql.assertValidDcqlPresentation(agentContext, presentations, dcqlQuery)
 
-        dcqlResponse = {
-          presentations,
-          presentationResult,
-          query: dcqlQuery,
+          dcqlResponse = {
+            presentations,
+            presentationResult,
+            query: dcqlQuery,
+          }
+        } catch (error) {
+          throw new Oauth2ServerErrorResponseError(
+            {
+              error: Oauth2ErrorCodes.InvalidRequest,
+              error_description: 'Presentation submission does not satisfy presentation request.',
+            },
+            { cause: error }
+          )
         }
       }
 
@@ -671,7 +681,7 @@ export class OpenId4VpVerifierService {
           throw new Oauth2ServerErrorResponseError(
             {
               error: Oauth2ErrorCodes.InvalidRequest,
-              error_description: 'Presentation submission does not satisy presentation request.',
+              error_description: 'Presentation submission does not satisfy presentation request.',
             },
             { cause: error }
           )


### PR DESCRIPTION
Throw the correct invalid request error when failing to validate a DCQL presentation. This aligns with the PEX behavior.