### PR TITLE
chore: remove ffi libraries

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -32,8 +32,6 @@
     "prepublishOnly": "pnpm run build"
   },
   "dependencies": {
-    "@2060.io/ffi-napi": "^4.0.9",
-    "@2060.io/ref-napi": "^3.0.6",
     "@credo-ts/core": "workspace:*",
     "@credo-ts/didcomm": "workspace:*",
     "@types/express": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -862,12 +862,6 @@ importers:
 
   packages/node:
     dependencies:
-      '@2060.io/ffi-napi':
-        specifier: ^4.0.9
-        version: 4.0.9
-      '@2060.io/ref-napi':
-        specifier: ^3.0.6
-        version: 3.0.6
       '@credo-ts/core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
These were needed before, but there's no FFI in the node package anymore