### PR TITLE
fix: make redirect_uri required

### DIFF
--- a/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
@@ -48,6 +48,13 @@ export async function handlePushedAuthorizationRequest(
     })
   }
 
+  if (!parsedAuthorizationRequest.authorizationRequest.redirect_uri) {
+    throw new Oauth2ServerErrorResponseError({
+      error: Oauth2ErrorCodes.InvalidScope,
+      error_description: `Missing required 'redirect_uri' parameter.`,
+    })
+  }
+
   const allowedStates = [OpenId4VcIssuanceSessionState.OfferCreated, OpenId4VcIssuanceSessionState.OfferUriRetrieved]
   if (!allowedStates.includes(issuanceSession.state)) {
     throw new Oauth2ServerErrorResponseError(


### PR DESCRIPTION
@hacdias I think redirect_uri is required for us at the moment, as we don't have a way to inject the redirect_uri on the server side.

I think adding some functionality to limit the redirect_uris would be good, but for now failing early makes sense I think