### PR TITLE
fix: iss in authorization error response

### DIFF
--- a/demo-openid/src/Issuer.ts
+++ b/demo-openid/src/Issuer.ts
@@ -136,16 +136,7 @@ function getCredentialRequestToCredentialMapper({
     // Example of how to use the the access token information from the chained identity server.
     let authorizedUser = authorization.accessToken.payload.sub
 
-    const isOpenId = issuanceSession.chainedIdentity?.externalAccessTokenResponse?.scope?.split(' ').includes('openid')
-    if (isOpenId) {
-      if (
-        !issuanceSession.chainedIdentity?.externalAccessTokenResponse?.id_token ||
-        typeof issuanceSession.chainedIdentity?.externalAccessTokenResponse?.id_token !== 'string'
-      ) {
-        // This should never happen, as Credo already validated the id_token when there is an openid scope.
-        throw new Error('No id_token present in the external access token response')
-      }
-
+    if (typeof issuanceSession.chainedIdentity?.externalAccessTokenResponse?.id_token === 'string') {
       // This token has already been validated by Credo, so we can just decode it.
       const claims = decodeJwt(issuanceSession.chainedIdentity.externalAccessTokenResponse.id_token)
       if (typeof claims.email === 'string') {

--- a/packages/openid4vc/src/openid4vc-issuer/router/redirectEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/redirectEndpoint.ts
@@ -24,6 +24,7 @@ export function configureRedirectEndpoint(router: Router, config: OpenId4VcIssue
       const openId4VcIssuerService = agentContext.dependencyManager.resolve(OpenId4VcIssuerService)
       const issuerMetadata = await openId4VcIssuerService.getIssuerMetadata(agentContext, issuer)
       const oauth2Client = openId4VcIssuerService.getOauth2Client(agentContext, issuer)
+      const authorizationServerIssuer = issuerMetadata.authorizationServers[0].issuer
 
       let issuanceSession: OpenId4VcIssuanceSessionRecord | null = null
       try {
@@ -203,7 +204,7 @@ export function configureRedirectEndpoint(router: Router, config: OpenId4VcIssue
         const redirectUri = new URL(issuanceSession.chainedIdentity.redirectUri)
 
         // First authorization server is the internal authorization server (always used with chained authorization)
-        redirectUri.searchParams.set('iss', issuerMetadata.authorizationServers[0].issuer)
+        redirectUri.searchParams.set('iss', authorizationServerIssuer)
         redirectUri.searchParams.set('code', authorizationCode)
 
         if (issuanceSession.chainedIdentity.state) {
@@ -237,6 +238,7 @@ export function configureRedirectEndpoint(router: Router, config: OpenId4VcIssue
           if (issuanceSession?.chainedIdentity?.redirectUri) {
             const redirectUri = new URL(issuanceSession.chainedIdentity.redirectUri)
             redirectUri.searchParams.set('error', error.errorResponse.error)
+            redirectUri.searchParams.set('iss', authorizationServerIssuer)
             if (error.errorResponse.error_description) {
               redirectUri.searchParams.set('error_description', error.errorResponse.error_description)
             }


### PR DESCRIPTION
A small fix to include `iss` field also in error responses. Additionally, it simplifies the id token check in the demo, as the inclusion of the `scope` field is optional