### PR TITLE
chore: expose integrity verifier

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -68,6 +68,7 @@ export {
   deepEquality,
   equalsIgnoreOrder,
   equalsWithOrder,
+  IntegrityVerifier,
   IsStringOrInstance,
   IsStringOrInstanceOrArrayOfInstances,
   IsStringOrStringArray,


### PR DESCRIPTION
IntegrityVerifier is a necessary utility to support `#integrity` claims verification, some extensions like TS12 require such validation.