### PR TITLE
feat: dynamic callback for chained authorization request

### DIFF
--- a/.changeset/hip-toes-pick.md
+++ b/.changeset/hip-toes-pick.md
@@ -1,0 +1,11 @@
+---
+"@credo-ts/openid4vc": minor
+---
+
+Introduces a new callback in the issuer configuration (`getChainedAuthorizationRequestPayload`), which can be used
+to dynamically provide the request scopes and additional payload to the chained authorization server that is being used with the request.
+
+This means that the `scopesMapping` configuration is now optional. Either `scopesMapping` ot the new callback must be defined in order to fullfil
+a chained authorization request.
+
+The option `getVerificationSessionForIssuanceSessionAuthorization` has been deprecated and replaced with `getVerificationSession`. Please update your usage.

--- a/demo-openid/src/Issuer.ts
+++ b/demo-openid/src/Issuer.ts
@@ -266,7 +266,7 @@ export class Issuer extends BaseAgent<{
             baseUrl: `${url}/oid4vci`,
             credentialRequestToCredentialMapper: (...args) =>
               getCredentialRequestToCredentialMapper({ issuerDidKey: this.didKey })(...args),
-            getVerificationSessionForIssuanceSessionAuthorization: async ({ agentContext, scopes }) => {
+            getVerificationSession: async ({ agentContext, scopes }) => {
               const verifierApi = agentContext.dependencyManager.resolve(OpenId4VcVerifierApi)
               const authorizationRequest = await verifierApi.createAuthorizationRequest({
                 verifierId: this.verifierRecord.verifierId,

--- a/packages/openid4vc/src/openid4vc-issuer/router/authorizationChallengeEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/authorizationChallengeEndpoint.ts
@@ -190,13 +190,13 @@ async function handleAuthorizationChallengeNoAuthSession(options: {
     )
   }
 
-  if (!config.getVerificationSessionForIssuanceSessionAuthorization) {
+  if (!config.getVerificationSession) {
     throw new Oauth2ServerErrorResponseError(
       {
         error: Oauth2ErrorCodes.ServerError,
       },
       {
-        internalMessage: `Missing required 'getVerificationSessionForIssuanceSessionAuthorization' callback in openid4vc issuer module config. This callback is required for presentation during issuance flows.`,
+        internalMessage: `Missing required 'getVerificationSession' callback in openid4vc issuer module config. This callback is required for presentation during issuance flows.`,
       }
     )
   }
@@ -259,7 +259,7 @@ async function handleAuthorizationChallengeNoAuthSession(options: {
     authorizationRequest,
     verificationSession,
     scopes: presentationScopes,
-  } = await config.getVerificationSessionForIssuanceSessionAuthorization({
+  } = await config.getVerificationSession({
     agentContext,
     issuanceSession,
     requestedCredentialConfigurations,

--- a/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/pushedAuthorizationRequestEndpoint.ts
@@ -184,20 +184,46 @@ export async function handlePushedAuthorizationRequest(
   const redirectUri = joinUriParts(config.baseUrl, [issuer.issuerId, 'redirect'])
   const chainedIdentityState = utils.uuid()
 
-  const scopes = requestedScopes.flatMap((scope) => {
-    if (scope in authorizationServerConfig.scopesMapping) {
-      return authorizationServerConfig.scopesMapping[scope]
-    }
+  let scopes: string[] = []
+  let additionalRequestPayload: Record<string, unknown> | undefined
 
-    throw new Oauth2ServerErrorResponseError(
-      {
-        error: Oauth2ErrorCodes.ServerError,
-      },
-      {
-        internalMessage: `Issuer '${issuer.issuerId}' does not have a scope mapping for scope '${scope}' for external authorization server '${authorizationServerConfig.issuer}'`,
+  if (config.getChainedAuthorizationRequestPayload) {
+    const dynamicConfiguration = await config.getChainedAuthorizationRequestPayload({
+      agentContext,
+      issuanceSession,
+      chainedAuthorizationServerConfig: authorizationServerConfig,
+      requestedCredentialConfigurations,
+    })
+
+    scopes = dynamicConfiguration.scopes
+    additionalRequestPayload = dynamicConfiguration.additionalPayload
+  } else {
+    for (const scope of requestedScopes) {
+      if (!authorizationServerConfig.scopesMapping) {
+        throw new Oauth2ServerErrorResponseError(
+          {
+            error: Oauth2ErrorCodes.ServerError,
+          },
+          {
+            internalMessage: `Issuer '${issuer.issuerId}' does not have a scope mapping for scope '${scope}' for external authorization server '${authorizationServerConfig.issuer}'`,
+          }
+        )
       }
-    )
-  })
+
+      if (scope in authorizationServerConfig.scopesMapping) {
+        scopes.push(...authorizationServerConfig.scopesMapping[scope])
+      } else {
+        throw new Oauth2ServerErrorResponseError(
+          {
+            error: Oauth2ErrorCodes.ServerError,
+          },
+          {
+            internalMessage: `Issuer '${issuer.issuerId}' does not have a scope mapping for scope '${scope}' for external authorization server '${authorizationServerConfig.issuer}'`,
+          }
+        )
+      }
+    }
+  }
 
   // TODO: add support for DPoP
   const { authorizationRequestUrl, pkce } = await oauth2Client.initiateAuthorization({
@@ -206,6 +232,7 @@ export async function handlePushedAuthorizationRequest(
     redirectUri,
     state: chainedIdentityState,
     scope: scopes.join(' '),
+    additionalRequestPayload,
   })
 
   issuanceSession.chainedIdentity = {

--- a/packages/openid4vc/src/shared/models/OpenId4VciAuthorizationServerConfig.ts
+++ b/packages/openid4vc/src/shared/models/OpenId4VciAuthorizationServerConfig.ts
@@ -70,8 +70,10 @@ export interface OpenId4VciChainedAuthorizationServerConfig {
   /**
    * Mapping between credential scopes and authorization server scopes.
    *
-   * This is mandatory. If a scope is missing, an error will be thrown when making
-   * a credential offer. If no additional scope is needed, use an empty array.
+   * If a scope is missing, an error will be thrown when making a credential offer.
+   * If no additional scope is needed, use an empty array.
+   *
+   * Required if the callback `getChainedAuthorizationRequestPayload` is not provided.
    */
-  scopesMapping: Record<string, string[]>
+  scopesMapping?: Record<string, string[]>
 }

--- a/packages/openid4vc/tests/openid4vc-presentation-during-issuance.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-presentation-during-issuance.e2e.test.ts
@@ -8,7 +8,7 @@ import {
   getScopesFromCredentialConfigurationsSupported,
   OpenId4VcIssuanceSessionState,
   type OpenId4VcIssuerModuleConfigOptions,
-  type OpenId4VciGetVerificationSessionForIssuanceSessionAuthorization,
+  type OpenId4VciGetVerificationSession,
   type OpenId4VciSignSdJwtCredentials,
   OpenId4VcModule,
   type OpenId4VcVerifierModuleConfigOptions,
@@ -85,8 +85,8 @@ describe('OpenId4Vc Presentation During Issuance', () => {
     openid4vc: OpenId4VcModule<OpenId4VcIssuerModuleConfigOptions, OpenId4VcVerifierModuleConfigOptions>
   }>
 
-  const getVerificationSessionForIssuanceSessionAuthorization =
-    (queryMethod: 'dcql' | 'presentationDefinition'): OpenId4VciGetVerificationSessionForIssuanceSessionAuthorization =>
+  const getVerificationSession =
+    (queryMethod: 'dcql' | 'presentationDefinition'): OpenId4VciGetVerificationSession =>
     async ({ issuanceSession, scopes }) => {
       if (scopes.includes(universityDegreeCredentialConfigurationSupported.scope)) {
         const createRequestReturn = await issuer.agent.openid4vc.verifier.createAuthorizationRequest({
@@ -136,8 +136,7 @@ describe('OpenId4Vc Presentation During Issuance', () => {
           },
           issuer: {
             baseUrl: issuerBaseUrl,
-            getVerificationSessionForIssuanceSessionAuthorization:
-              getVerificationSessionForIssuanceSessionAuthorization('presentationDefinition'),
+            getVerificationSession: getVerificationSession('presentationDefinition'),
             credentialRequestToCredentialMapper: async ({ holderBinding, verification, credentialConfiguration }) => {
               if (!verification) {
                 throw new Error('Expected verification in credential request mapper')
@@ -340,8 +339,7 @@ describe('OpenId4Vc Presentation During Issuance', () => {
   })
 
   it('e2e flow with requesting presentation of credentials before issuance succeeds with dcql query', async () => {
-    issuer.agent.openid4vc.issuer.config.getVerificationSessionForIssuanceSessionAuthorization =
-      getVerificationSessionForIssuanceSessionAuthorization('dcql')
+    issuer.agent.openid4vc.issuer.config.getVerificationSession = getVerificationSession('dcql')
 
     const issuerRecord = await issuer.agent.openid4vc.issuer.createIssuer({
       issuerId: '2f9c0385-7191-4c50-aa22-40cf5839d52b',

--- a/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vc-wallet-key-attestation.e2e.test.ts
@@ -72,7 +72,7 @@ describe('OpenId4Vc Wallet and Key Attestations', () => {
           app: expressApp,
           issuer: {
             baseUrl: issuerBaseUrl,
-            getVerificationSessionForIssuanceSessionAuthorization: async ({ issuanceSession, scopes }) => {
+            getVerificationSession: async ({ issuanceSession, scopes }) => {
               if (scopes.includes(universityDegreeCredentialConfigurationSupportedMdoc.scope)) {
                 const createRequestReturn = await issuer.agent.openid4vc.verifier.createAuthorizationRequest({
                   verifierId: issuanceSession.issuerId,

--- a/packages/openid4vc/tests/openid4vci-chained.e2e.test.ts
+++ b/packages/openid4vc/tests/openid4vci-chained.e2e.test.ts
@@ -8,7 +8,7 @@ import express, { type Express } from 'express'
 import { InMemoryWalletModule } from '../../../tests/InMemoryWalletModule'
 import { setupNockToExpress } from '../../../tests/nockToExpress'
 import { TenantsModule } from '../../tenants/src'
-import type { OpenId4VcIssuerModuleConfigOptions } from '../src'
+import type { OpenId4VcIssuerModuleConfigOptions, OpenId4VciCredentialRequestToCredentialMapper } from '../src'
 import { OpenId4VcIssuanceSessionState, OpenId4VcModule } from '../src'
 import type { OpenId4VciCredentialBindingResolver } from '../src/openid4vc-holder'
 import { getOid4vcCallbacks } from '../src/shared/callbacks'
@@ -36,69 +36,54 @@ describe('OpenId4Vc (Chained Authorization)', () => {
   }>
   let holder1: TenantType
 
+  const credentialRequestToCredentialMapper: OpenId4VciCredentialRequestToCredentialMapper = async ({
+    agentContext,
+    credentialConfiguration,
+    issuanceSession,
+    holderBinding,
+    authorization,
+  }) => {
+    // We sign the request with the first did:key did we have
+    const didsApi = agentContext.dependencyManager.resolve(DidsApi)
+    const [firstDidKeyDid] = await didsApi.getCreatedDids({ method: 'key' })
+    const didDocument = await didsApi.resolveDidDocument(firstDidKeyDid.did)
+    const verificationMethod = didDocument.verificationMethod?.[0]
+    if (!verificationMethod) {
+      throw new Error('No verification method found')
+    }
+
+    let name = authorization.accessToken.payload.sub
+    if (typeof issuanceSession.chainedIdentity?.externalAccessTokenResponse?.id_token === 'string') {
+      // This token has already been validated by Credo, so we can just decode it.
+      const { payload } = decodeJwt({
+        jwt: issuanceSession.chainedIdentity.externalAccessTokenResponse.id_token,
+      })
+      if (typeof payload.name === 'string') {
+        name = payload.name
+      }
+    }
+
+    if (credentialConfiguration.format === 'vc+sd-jwt' && credentialConfiguration.vct) {
+      return {
+        type: 'credentials',
+        format: 'dc+sd-jwt',
+        credentials: holderBinding.keys.map((holderBinding) => ({
+          payload: { vct: credentialConfiguration.vct, university: 'innsbruck', degree: 'bachelor', name },
+          holder: holderBinding,
+          issuer: {
+            method: 'did',
+            didUrl: verificationMethod.id,
+          },
+          disclosureFrame: { _sd: ['university', 'degree'] },
+        })),
+      }
+    }
+
+    throw new Error('Invalid request')
+  }
+
   beforeEach(async () => {
     expressApp = express()
-
-    issuer = (await createAgentFromModules(
-      {
-        inMemory: new InMemoryWalletModule(),
-        openid4vc: new OpenId4VcModule({
-          app: expressApp,
-          issuer: {
-            baseUrl: issuanceBaseUrl,
-            credentialRequestToCredentialMapper: async ({
-              agentContext,
-              credentialConfiguration,
-              issuanceSession,
-              holderBinding,
-              authorization,
-            }) => {
-              // We sign the request with the first did:key did we have
-              const didsApi = agentContext.dependencyManager.resolve(DidsApi)
-              const [firstDidKeyDid] = await didsApi.getCreatedDids({ method: 'key' })
-              const didDocument = await didsApi.resolveDidDocument(firstDidKeyDid.did)
-              const verificationMethod = didDocument.verificationMethod?.[0]
-              if (!verificationMethod) {
-                throw new Error('No verification method found')
-              }
-
-              let name = authorization.accessToken.payload.sub
-              if (typeof issuanceSession.chainedIdentity?.externalAccessTokenResponse?.id_token === 'string') {
-                // This token has already been validated by Credo, so we can just decode it.
-                const { payload } = decodeJwt({
-                  jwt: issuanceSession.chainedIdentity.externalAccessTokenResponse.id_token,
-                })
-                if (typeof payload.name === 'string') {
-                  name = payload.name
-                }
-              }
-
-              if (credentialConfiguration.format === 'vc+sd-jwt' && credentialConfiguration.vct) {
-                return {
-                  type: 'credentials',
-                  format: 'dc+sd-jwt',
-                  credentials: holderBinding.keys.map((holderBinding) => ({
-                    payload: { vct: credentialConfiguration.vct, university: 'innsbruck', degree: 'bachelor', name },
-                    holder: holderBinding,
-                    issuer: {
-                      method: 'did',
-                      didUrl: verificationMethod.id,
-                    },
-                    disclosureFrame: { _sd: ['university', 'degree'] },
-                  })),
-                }
-              }
-
-              throw new Error('Invalid request')
-            },
-          },
-        }),
-        tenants: new TenantsModule(),
-      },
-      '96213c3d7fc8d4d6754c7a0fd969598g',
-      global.fetch
-    )) as unknown as typeof issuer
-    issuer1 = await createTenantForAgent(issuer.agent, 'iTenant1')
 
     holder = (await createAgentFromModules(
       {
@@ -146,6 +131,23 @@ describe('OpenId4Vc (Chained Authorization)', () => {
   }
 
   it('e2e flow with tenants, issuer endpoints requesting a sd-jwt-vc using authorization code flow, openid, id tokens', async () => {
+    issuer = (await createAgentFromModules(
+      {
+        inMemory: new InMemoryWalletModule(),
+        openid4vc: new OpenId4VcModule({
+          app: expressApp,
+          issuer: {
+            baseUrl: issuanceBaseUrl,
+            credentialRequestToCredentialMapper,
+          },
+        }),
+        tenants: new TenantsModule(),
+      },
+      '96213c3d7fc8d4d6754c7a0fd969598g',
+      global.fetch
+    )) as unknown as typeof issuer
+    issuer1 = await createTenantForAgent(issuer.agent, 'iTenant1')
+
     const walletClientId = 'wallet'
     const idpClientId = 'foo'
     const idpClientSecret = 'bar'
@@ -366,6 +368,272 @@ describe('OpenId4Vc (Chained Authorization)', () => {
       resolvedCredentialOffer,
       ...tokenResponseTenant,
       credentialBindingResolver,
+      clientId: walletClientId,
+    })
+
+    await waitForCredentialIssuanceSessionRecordSubject(issuer.replaySubject, {
+      state: OpenId4VcIssuanceSessionState.Completed,
+      issuanceSessionId,
+      contextCorrelationId: issuerTenant.context.contextCorrelationId,
+    })
+
+    expect(credentialResponse.credentials).toHaveLength(1)
+    const firstSdJwtVcTenant1 = (credentialResponse.credentials[0].record as SdJwtVcRecord).firstCredential
+    expect(firstSdJwtVcTenant1.payload.vct).toEqual('UniversityDegreeCredential')
+    expect(firstSdJwtVcTenant1.payload.name).toEqual('John Doe')
+
+    await holderTenant.endSession()
+
+    clearIdpNock()
+    clearHolderNock()
+  })
+
+  it('e2e flow with tenants, issuer endpoints requesting a sd-jwt-vc using authorization code flow, openid, additional parameter, id tokens (callback)', async () => {
+    issuer = (await createAgentFromModules(
+      {
+        inMemory: new InMemoryWalletModule(),
+        openid4vc: new OpenId4VcModule({
+          app: expressApp,
+          issuer: {
+            baseUrl: issuanceBaseUrl,
+            credentialRequestToCredentialMapper,
+            getChainedAuthorizationRequestPayload: async () => {
+              return {
+                scopes: ['ScopeFoo', 'ScopeBar'],
+                additionalPayload: {
+                  foo: 'bar',
+                },
+              }
+            },
+          },
+        }),
+        tenants: new TenantsModule(),
+      },
+      '96213c3d7fc8d4d6754c7a0fd969598g',
+      global.fetch
+    )) as unknown as typeof issuer
+    issuer1 = await createTenantForAgent(issuer.agent, 'iTenant1')
+
+    const walletClientId = 'wallet'
+    const idpClientId = 'foo'
+    const idpClientSecret = 'bar'
+
+    // Setup External IDP Authorization Server
+    const idpServerKey = await issuer.agent.kms.createKey({
+      type: {
+        kty: 'EC',
+        crv: 'P-256',
+      },
+    })
+    const idpServerJwk = Kms.PublicJwk.fromPublicJwk(idpServerKey.publicJwk)
+    const idpSignJwt: SignJwtCallback = async (_signer, { header, payload }) => {
+      const jwsService = issuer.agent.dependencyManager.resolve(JwsService)
+      const compact = await jwsService.createJwsCompact(issuer.agent.context, {
+        keyId: idpServerKey.keyId,
+        payload: JwtPayload.fromJson(payload),
+        protectedHeaderOptions: {
+          ...header,
+          jwk: undefined,
+          alg: 'ES256',
+          kid: 'first',
+        },
+      })
+
+      return {
+        jwt: compact,
+        signerJwk: idpServerKey.publicJwk as Jwk,
+      }
+    }
+    const idpServer = new Oauth2AuthorizationServer({
+      callbacks: {
+        ...getOid4vcCallbacks(issuer.agent.context),
+        signJwt: idpSignJwt,
+      },
+    })
+
+    const idpApp = express()
+    idpApp.get('/.well-known/oauth-authorization-server', (_req, res) =>
+      res.json({
+        jwks_uri: 'http://localhost:4747/jwks.json',
+        issuer: 'http://localhost:4747',
+        token_endpoint: 'http://localhost:4747/token',
+        authorization_endpoint: 'http://localhost:4747/authorize',
+      } satisfies AuthorizationServerMetadata)
+    )
+    idpApp.get('/jwks.json', (_req, res) =>
+      res.setHeader('Content-Type', 'application/jwk-set+json').send(
+        JSON.stringify({
+          keys: [{ ...idpServerJwk.toJson(), kid: 'first' }],
+        })
+      )
+    )
+    idpApp.get('/authorize', (req, res) => {
+      // Check params
+      expect(req.query.client_id).toBe(idpClientId)
+      expect(req.query.redirect_uri).toBeDefined()
+      expect(req.query.state).toBeDefined()
+      expect(req.query.foo).toBe('bar')
+
+      const scope = (req.query.scope as string).split(' ')
+      expect(scope).toContain('ScopeFoo')
+      expect(scope).toContain('ScopeBar')
+
+      const redirect = new URL(req.query.redirect_uri as string)
+      const searchParams = redirect.searchParams
+      searchParams.set('state', req.query.state as string)
+      searchParams.set('code', randomUUID())
+      redirect.search = searchParams.toString()
+
+      return res.redirect(redirect.toString())
+    })
+    idpApp.post('/token', async (req, res) => {
+      const authorizationHeader = req.headers.authorization?.split(' ')
+      if (!authorizationHeader || authorizationHeader[0] !== 'Basic' || authorizationHeader.length !== 2) {
+        return res.status(401).json({
+          error: 'invalid_client',
+          error_description: 'Invalid authorization header',
+        })
+      }
+
+      if (TypedArrayEncoder.fromBase64(authorizationHeader[1]).toString() !== `${idpClientId}:${idpClientSecret}`) {
+        return res.status(401).json({
+          error: 'invalid_client',
+          error_description: 'Unauthorized user',
+        })
+      }
+
+      // Create id_token
+      const signer = {
+        method: 'jwk',
+        publicJwk: idpServerJwk.toJson() as Jwk,
+        alg: 'ES256',
+      } satisfies JwtSigner
+
+      const header = {
+        ...jwtHeaderFromJwtSigner(signer),
+        alg: 'ES256',
+        typ: 'JWT',
+      }
+
+      const payload = {
+        iss: 'http://localhost:4747',
+        aud: [idpClientId],
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        iat: Math.floor(Date.now() / 1000),
+        sub: 'user-123',
+        name: 'John Doe',
+        nickname: 'marmite',
+        website: 'https://example.com',
+      }
+
+      const { jwt } = await idpSignJwt(signer, {
+        header,
+        payload,
+      })
+
+      return res.json(
+        await idpServer.createAccessTokenResponse({
+          authorizationServer: 'http://localhost:4747',
+          clientId: idpClientId,
+          audience: idpClientId,
+          expiresInSeconds: 5000,
+          subject: 'externalIdpSubject',
+          scope: 'MappedUniversityDegreeCredential openid',
+          signer: {
+            method: 'jwk',
+            publicJwk: idpServerJwk.toJson() as Jwk,
+            alg: 'ES256',
+          },
+          additionalAccessTokenResponsePayload: {
+            id_token: jwt,
+          },
+        })
+      )
+    })
+    const clearIdpNock = setupNockToExpress('http://localhost:4747', idpApp)
+
+    // Setup Holder Redirect
+    const holderApp = express()
+    holderApp.get('/redirect', (req, res) => {
+      // For testing, we just return the code directly. On a real use case, the user
+      // will see this page, and therefore should be provided with some HTML.
+      res.json({
+        code: req.query.code,
+      })
+    })
+    const clearHolderNock = setupNockToExpress('http://localhost:5757', holderApp)
+
+    // Setup issuer and holder
+    const issuerTenant = await issuer.agent.modules.tenants.getTenantAgent({ tenantId: issuer1.tenantId })
+    const holderTenant = await holder.agent.modules.tenants.getTenantAgent({ tenantId: holder1.tenantId })
+
+    const openIdIssuerTenant = await issuerTenant.openid4vc.issuer.createIssuer({
+      issuerId: '8bc91672-6a32-466c-96ec-6efca8760068',
+      credentialConfigurationsSupported: {
+        universityDegree: universityDegreeCredentialConfigurationSupported,
+      },
+      authorizationServerConfigs: [
+        {
+          type: 'chained',
+          issuer: 'http://localhost:4747',
+          clientAuthentication: {
+            type: 'clientSecret',
+            clientId: idpClientId,
+            clientSecret: idpClientSecret,
+          },
+        },
+      ],
+    })
+
+    const {
+      issuanceSession: { id: issuanceSessionId },
+      credentialOffer,
+    } = await issuerTenant.openid4vc.issuer.createCredentialOffer({
+      issuerId: openIdIssuerTenant.issuerId,
+      credentialConfigurationIds: ['universityDegree'],
+      authorizationCodeFlowConfig: {
+        authorizationServerUrl: 'http://localhost:4747',
+        issuerState: utils.uuid(),
+      },
+    })
+
+    await issuerTenant.endSession()
+
+    const resolvedCredentialOffer = await holderTenant.openid4vc.holder.resolveCredentialOffer(credentialOffer)
+    const resolvedAuthorization = await holderTenant.openid4vc.holder.resolveOpenId4VciAuthorizationRequest(
+      resolvedCredentialOffer,
+      {
+        clientId: walletClientId,
+        redirectUri: 'http://localhost:5757/redirect',
+        scope: ['UniversityDegreeCredential'],
+      }
+    )
+
+    if (resolvedAuthorization.authorizationFlow !== AuthorizationFlow.Oauth2Redirect) {
+      throw new Error(`Expected Oauth2Redirect flow, got ${resolvedAuthorization.authorizationFlow}`)
+    }
+
+    const authorizationResponse = await fetch(resolvedAuthorization.authorizationRequestUrl, {
+      redirect: 'follow',
+    })
+    expect(authorizationResponse.ok).toBe(true)
+    const code = ((await authorizationResponse.json()) as Record<string, string>)?.code
+
+    expect(code).toBeDefined()
+
+    const tokenResponseTenant = await holderTenant.openid4vc.holder.requestToken({
+      resolvedCredentialOffer,
+      clientId: walletClientId,
+      codeVerifier: resolvedAuthorization.codeVerifier,
+      code,
+      redirectUri: 'http://localhost:5757/redirect',
+    })
+
+    const credentialResponse = await holderTenant.openid4vc.holder.requestCredentials({
+      resolvedCredentialOffer,
+      ...tokenResponseTenant,
+      credentialBindingResolver,
+
       clientId: walletClientId,
     })
 


### PR DESCRIPTION
Introduces a new callback in the issuer configuration, which can be used to dynamically provide the request scopes and additional payload to the chained authorization server that is being used with the request.

This means that the `scopesMapping` configuration is now optional. Either `scopesMapping` ot the new callback must be defined in order to fullfil a chained authorization request.