### PR TITLE
fix: version increment in changeset

### DIFF
--- a/.changeset/hip-toes-pick.md
+++ b/.changeset/hip-toes-pick.md
@@ -1,5 +1,5 @@
 ---
-"@credo-ts/openid4vc": minor
+"@credo-ts/openid4vc": patch
 ---
 
 Introduces a new callback in the issuer configuration (`getChainedAuthorizationRequestPayload`), which can be used


### PR DESCRIPTION
I hope this fixes it. For some reason I assumed changeset would count "minor" as patch if under v1