### PR TITLE
fix(openid4vc): update session state to Error if failed to create response

### DIFF
--- a/.changeset/curly-pots-strive.md
+++ b/.changeset/curly-pots-strive.md
@@ -1,0 +1,5 @@
+---
+"@credo-ts/openid4vc": patch
+---
+
+The state of the issuance session is now correctly updated to 'Error' if an error happens while creating a credential response.

--- a/packages/openid4vc/src/openid4vc-issuer/router/credentialEndpoint.ts
+++ b/packages/openid4vc/src/openid4vc-issuer/router/credentialEndpoint.ts
@@ -320,6 +320,9 @@ export function configureCredentialEndpoint(router: Router, config: OpenId4VcIss
         credentialResponse.transaction_id ? 202 : 200
       )
     } catch (error) {
+      issuanceSession.errorMessage = 'Failed to create a credential response'
+      await openId4VcIssuerService.updateState(agentContext, issuanceSession, OpenId4VcIssuanceSessionState.Error)
+
       if (error instanceof Oauth2ServerErrorResponseError) {
         return sendOauth2ErrorResponse(response, next, agentContext.config.logger, error)
       }


### PR DESCRIPTION
Updates the session state to `Error` if an error occurred while creating a credential response. The session is, at this point, irrecoverable and can't be continued.