### PR TITLE
ci: update deprecated actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name != 'pull_request_review' ||  github.event.pull_request.head.ref == 'changeset-release/main'
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
 
       - name: Setup NodeJS
         uses: actions/setup-node@v6
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
 
       - name: Setup NodeJS
         id: setup-node
@@ -129,7 +129,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
 
       # See https://github.com/actions/setup-node/issues/641#issuecomment-1358859686
       - name: pnpm cache path
@@ -189,7 +189,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
 
       # See https://github.com/actions/setup-node/issues/641#issuecomment-1358859686
       - name: pnpm cache path

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
     if: github.event_name != 'pull_request_review' ||  github.event.pull_request.head.ref == 'changeset-release/main'
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Setup NodeJS
         uses: actions/setup-node@v6
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Setup NodeJS
         id: setup-node
@@ -129,7 +129,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       # See https://github.com/actions/setup-node/issues/641#issuecomment-1358859686
       - name: pnpm cache path
@@ -189,7 +189,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       # See https://github.com/actions/setup-node/issues/641#issuecomment-1358859686
       - name: pnpm cache path

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create Github Release
         if: "startsWith(github.event.head_commit.message, 'chore(release): new version')"
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.CURRENT_PACKAGE_VERSION }}
 
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/checkout@v6.0.2
         if: steps.should-run.outputs.run == 'true'
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         if: steps.should-run.outputs.run == 'true'
 
       - name: Setup Node.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6.0.2
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/checkout@v6.0.2
         if: steps.should-run.outputs.run == 'true'
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@v5
         if: steps.should-run.outputs.run == 'true'
 
       - name: Setup Node.js

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: 'Checkout code'
-        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.1.1
+        uses: actions/checkout@v6.0.2
         with:
           persist-credentials: false
 
@@ -37,7 +37,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: 'Upload artifact'
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v3.pre.node20
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: SARIF file
           path: results.sarif
@@ -46,6 +46,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: 'Upload to code-scanning'
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v3.29.5
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Upgrade all GitHub CI/CD workflows to use node 22+ actions.